### PR TITLE
chore: 完善gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,39 @@
 *.iml
-.gradle
 /local.properties
 .DS_Store
-build
 /captures
 .externalNativeBuild
-.cxx
 local.properties
-.idea
 *.jks
 *.b64
 AGENTS.md
+/.vscode/
+
+# Generated files
+bin/
+gen/
+out/
+
+# Gradle files
+.gradle/
+**/build/
+
+# Gradle/Android Studio
+versionname.txt
+versioncode.txt
+android/.cxx
+
+# Log Files
+*.log
+
+# IntelliJ
+*.iml
+.idea/
+
 # MaaResource
 /app/src/main/assets/MaaSync
+/app/src/main/jniLibs/*/*.so
+!/app/src/main/jniLibs/*/libjnidispatch.so
+
 # MAA Core download cache
 .maa-cache/


### PR DESCRIPTION
屏蔽了jniLibs目录下来自Maa的so文件
参考[LibChecker](https://github.com/LibChecker/LibChecker)的对应文件对gitignore进行了简单的归类
添加了对vscode，Android Studio的一些文件的屏蔽