### PR TITLE
chore: 添加使用Android Studio的说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,19 @@
 
 ## 构建
 
-```bash
-# 下载 MAA Core 预编译产物（so 库 + 资源文件）
-python scripts/setup_maa_core.py
+- 安装 [Eclipse Temurin JDK 21](https://adoptium.net/zh-CN/temurin/releases?version=21)
 
-# 构建
-./gradlew assembleDebug
-```
+- 安装 [Android Studio](https://developer.android.com/studio)
+
+- 下载 MAA Core 预编译产物（so 库 + 资源文件）
+
+  ```bash
+  python scripts/setup_maa_core.py
+  ```
+
+- 使用 Android Studio 打开此文件夹，在 Settings - Build, Execution, Deployment - Build Tools - Gradle - Gradle Projects - Gradle JDK 选择此前安装的 temurin-21
+
+- 运行 Sync Project with Gradle Files，Android Studio 将自行安装其他依赖，完成后运行 Assemble app Run Configuration 即可构建apk。
 
 ## 第三方代码
 


### PR DESCRIPTION
实测可以使用Android Studio进行构建，简化操作难度
必须在Android Studio内选择使用Adoptium JDK，使用默认的jbrsdk 21会报错
不太确定Adoptium的官网是不是这个，我是从tuna镜像站下载的
我也不太确定zulu等等的其他JDK分支能不能用，因为我也不怎么懂这些

↑来自抛弃了java导致现在被java和kotlin抛弃的屑（悲）