### PR TITLE
build(gradle): 优化资源目录配置和构建设置

### DIFF
--- a/app/asset-manifest.gradle.kts
+++ b/app/asset-manifest.gradle.kts
@@ -52,6 +52,16 @@ val generateAssetManifest by tasks.registering(GenerateAssetManifestTask::class)
 
     val assetsDir = layout.projectDirectory.dir("src/main/assets")
     val assetSourceDirName = "MaaSync/MaaResource"
+    //检查 MaaSync/MaaResource 目录
+    doFirst {
+        val targetDir = File(assetsDir.asFile, assetSourceDirName)
+        if (!targetDir.exists()) {
+            logger.lifecycle("Creating directory: ${targetDir.absolutePath}")
+            targetDir.mkdirs()
+        } else {
+            logger.lifecycle("Directory already exists: ${targetDir.absolutePath}")
+        }
+    }
 
     assetSourceDir.set(assetSourceDirName)
     sourceDir.set(assetsDir.dir(assetSourceDirName))

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,6 @@ org.gradle.configureondemand=true
 # -- Kotlin --
 kotlin.code.style=official
 kotlin.incremental=true
-kotlin.incremental.useClasspathSnapshot=true
 kotlin.build.report.output=file
 
 # -- Android --


### PR DESCRIPTION
- 在 asset-manifest.gradle.kts 中添加 MaaSync/MaaResource 目录检查逻辑, 确保目标目录存在，不存在时自动创建并输出日志
- 从 gradle.properties 中移除过时的 kotlin.incremental.useClasspathSnapshot 配置项