### PR TITLE
fix: 无开始唤醒任务时资源加载使用正确的服务器类型

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/TaskChainState.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/TaskChainState.kt
@@ -47,6 +47,7 @@ class TaskChainState(
         private val CHAIN_KEY = stringPreferencesKey("chain")
         private val PROFILES_KEY = stringPreferencesKey("profiles")
         private val ACTIVE_PROFILE_KEY = stringPreferencesKey("active_profile_id")
+        private val LAST_USED_CLIENT_TYPE_KEY = stringPreferencesKey("last_used_client_type")
 
         private const val PROFILE_NAME_PREFIX = "配置-"
         private const val MAX_PROFILES = 10
@@ -98,6 +99,7 @@ class TaskChainState(
                 persistProfiles(listOf(profile), profile.id)
             }
             _isLoaded.value = true
+            _lastUsedClientType.value = prefs[LAST_USED_CLIENT_TYPE_KEY]
         }
     }
 
@@ -220,7 +222,6 @@ class TaskChainState(
 
     fun getClientTypeOrNull(): String? {
         return findFirstEnabledConfig<WakeUpConfig>()?.clientType
-            ?: findFirstConfig<WakeUpConfig>()?.clientType
             ?: _lastUsedClientType.value
     }
 
@@ -228,6 +229,11 @@ class TaskChainState(
 
     fun saveLastUsedClientType(clientType: String) {
         _lastUsedClientType.value = clientType
+        scope.launch {
+            context.store.edit { prefs ->
+                prefs[LAST_USED_CLIENT_TYPE_KEY] = clientType
+            }
+        }
     }
 
     inline fun <reified T : TaskParamProvider> findFirstEnabledConfig(): T? {

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/TaskChainState.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/TaskChainState.kt
@@ -220,6 +220,7 @@ class TaskChainState(
 
     fun getClientTypeOrNull(): String? {
         return findFirstEnabledConfig<WakeUpConfig>()?.clientType
+            ?: findFirstConfig<WakeUpConfig>()?.clientType
             ?: _lastUsedClientType.value
     }
 

--- a/app/src/main/java/com/aliothmoon/maameow/domain/service/MaaCompositionService.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/service/MaaCompositionService.kt
@@ -211,8 +211,8 @@ class MaaCompositionService(
         return result
     }
 
-    private suspend fun checkPreconditions(mode: RunMode, clientType: String): StartResult? {
-        activityManager.runIfDirty { resourceLoader.load(clientType) }
+    private suspend fun checkPreconditions(mode: RunMode): StartResult? {
+        activityManager.runIfDirty { resourceLoader.load() }
         val loaded = resourceLoader.ensureLoaded()
         if (loaded.isFailure) {
             return failStart(
@@ -339,7 +339,7 @@ class MaaCompositionService(
 
         val mode = appSettings.runMode.value
         return withContext(Dispatchers.IO) {
-            checkPreconditions(mode, clientType)?.let { return@withContext it }
+            checkPreconditions(mode)?.let { return@withContext it }
 
             useRemoteService { service ->
                 val maa = service.maaCoreService

--- a/app/src/main/java/com/aliothmoon/maameow/domain/service/MaaCompositionService.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/service/MaaCompositionService.kt
@@ -211,8 +211,8 @@ class MaaCompositionService(
         return result
     }
 
-    private suspend fun checkPreconditions(mode: RunMode): StartResult? {
-        activityManager.runIfDirty { resourceLoader.load() }
+    private suspend fun checkPreconditions(mode: RunMode, clientType: String): StartResult? {
+        activityManager.runIfDirty { resourceLoader.load(clientType) }
         val loaded = resourceLoader.ensureLoaded()
         if (loaded.isFailure) {
             return failStart(
@@ -339,7 +339,7 @@ class MaaCompositionService(
 
         val mode = appSettings.runMode.value
         return withContext(Dispatchers.IO) {
-            checkPreconditions(mode)?.let { return@withContext it }
+            checkPreconditions(mode, clientType)?.let { return@withContext it }
 
             useRemoteService { service ->
                 val maa = service.maaCoreService

--- a/app/src/main/java/com/aliothmoon/maameow/domain/service/UnifiedStateDispatcher.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/service/UnifiedStateDispatcher.kt
@@ -107,7 +107,7 @@ class UnifiedStateDispatcher(
         // 切换客户端时就要重新加载资源
         scope.launch {
             chainState.firstEnabledConfigFlow<WakeUpConfig>()
-                .map { (it ?: WakeUpConfig()).clientType }
+                .map { it?.clientType ?: chainState.getClientType() }
                 .distinctUntilChanged()
                 .drop(1)
                 .collect { newClientType ->


### PR DESCRIPTION
修复三个导致非国服环境下资源错误加载为官服的问题：

1. checkPreconditions 未将已解析的 clientType 传递给 resourceLoader， 导致 resourceLoader.load() 使用默认参数 chainState.getClientType()， 该值在冷启动且无启用 WakeUp 时回退为 "Official"。

2. UnifiedStateDispatcher 监听客户端类型变化时，当 WakeUp 被禁用后 flow 返回 null，直接创建默认 WakeUpConfig() 导致 clientType 变为 "Official"，触发资源重新加载为国服资源。

3. getClientTypeOrNull 仅查找已启用的 WakeUp 配置， 未考虑用户已配置但禁用的 WakeUp 节点，现增加对禁用配置的回退。