### PR TITLE
feat: 公告弹窗交互优化与设置页新增查看公告入口

### DIFF
--- a/app/src/main/assets/announcement/announcement_en.md
+++ b/app/src/main/assets/announcement/announcement_en.md
@@ -11,7 +11,7 @@ Do not participate in spreading insider information. It is strictly prohibited t
 Please download MaaMeow exclusively from **official channels**:
 
 - **GitHub Release**: [github.com/Aliothmoon/MAA-Meow](https://github.com/Aliothmoon/MAA-Meow/releases)
-- **QQ Group**: announcements and files within the official group
+- **Official QQ Group**: announcements and files within the group (join via Settings → About → Feedback QQ Group)
 - **MirrorChyan**: the officially supported mirror download service
 
 **Avoid downloading from network drives, forum posts, or any unofficial sources.**

--- a/app/src/main/assets/announcement/announcement_zh.md
+++ b/app/src/main/assets/announcement/announcement_zh.md
@@ -11,7 +11,7 @@
 请优先通过以下 **官方渠道** 获取 MaaMeow：
 
 - **GitHub Release**：[github.com/Aliothmoon/MAA-Meow](https://github.com/Aliothmoon/MAA-Meow/releases)
-- **QQ 交流群**：群内公告/文件
+- **QQ 官方群**：群内公告/文件（可通过「设置 → 关于 → 问题反馈 QQ 群」加群）
 - **Mirror 酱**：官方支持的镜像加速渠道
 
 **请避免从网盘、论坛帖子、不明链接等非官方途径下载。**

--- a/app/src/main/java/com/aliothmoon/maameow/announcement/AnnouncementConfig.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/announcement/AnnouncementConfig.kt
@@ -7,7 +7,7 @@ import java.util.Locale
 
 object AnnouncementConfig {
 
-    const val CURRENT_VERSION = "v1"
+    const val CURRENT_VERSION = "v2"
 
     private const val ASSET_DIR = "announcement"
 

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.runtime.snapshotFlow
 import com.aliothmoon.maameow.R
+import kotlinx.coroutines.flow.distinctUntilChanged
 import dev.jeziellago.compose.markdowntext.MarkdownText
 import kotlinx.coroutines.delay
 

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
@@ -20,12 +20,14 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Campaign
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -37,35 +39,55 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.runtime.snapshotFlow
 import com.aliothmoon.maameow.R
 import dev.jeziellago.compose.markdowntext.MarkdownText
 import kotlinx.coroutines.delay
 
-private const val CONFIRM_COUNTDOWN = 5
+/** 勾选"不再显示"前需停留的秒数 */
+private const val STAY_SECONDS_REQUIRED = 5
 
 @Composable
 fun AnnouncementDialog(
     imageAssetPath: String?,
     markdown: String,
-    onConfirmed: () -> Unit,
+    onDismiss: (dontShowAgain: Boolean) -> Unit,
 ) {
-    var confirmed by remember { mutableStateOf(false) }
-    var countdown by remember { mutableIntStateOf(0) }
+    // 是否已滚动至底部
+    var scrolledToBottom by remember { mutableStateOf(false) }
+    // 已停留秒数
+    var elapsedSeconds by remember { mutableIntStateOf(0) }
+    // "不再显示"勾选状态
+    var dontShowAgain by remember { mutableStateOf(false) }
 
-    LaunchedEffect(confirmed) {
-        if (confirmed) {
-            countdown = CONFIRM_COUNTDOWN
-            while (countdown > 0) {
-                delay(1000)
-                countdown--
+    val scrollState = rememberScrollState()
+
+    // 检测是否滚动到底部
+    LaunchedEffect(scrollState.maxValue) {
+        snapshotFlow { scrollState.value }
+            .collect { value ->
+                if (scrollState.maxValue > 0 && value >= scrollState.maxValue) {
+                    scrolledToBottom = true
+                }
             }
+    }
+
+    // 停留计时器
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(1000)
+            elapsedSeconds++
         }
+    }
+
+    // 勾选框是否可启用
+    val canCheck by remember {
+        derivedStateOf { scrolledToBottom && elapsedSeconds >= STAY_SECONDS_REQUIRED }
     }
 
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
@@ -97,6 +119,7 @@ fun AnnouncementDialog(
             shadowElevation = 8.dp,
         ) {
             Column(modifier = Modifier.padding(20.dp)) {
+                // 标题栏
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -128,11 +151,12 @@ fun AnnouncementDialog(
 
                 Spacer(modifier = Modifier.height(16.dp))
 
+                // 公告内容（可滚动）
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(screenHeight * 0.55f)
-                        .verticalScroll(rememberScrollState()),
+                        .verticalScroll(scrollState),
                 ) {
                     if (imageBitmap != null) {
                         Image(
@@ -153,27 +177,52 @@ fun AnnouncementDialog(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(16.dp))
 
-                val canConfirm = confirmed && countdown == 0
+                // "不再显示"勾选框
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Checkbox(
+                        checked = dontShowAgain,
+                        onCheckedChange = { dontShowAgain = it },
+                        enabled = canCheck,
+                    )
+                    Text(
+                        text = stringResource(R.string.announcement_dont_show_again),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (canCheck) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        },
+                    )
+                }
+
+                // 未满足条件时显示提示
+                if (!canCheck) {
+                    val remaining = maxOf(0, STAY_SECONDS_REQUIRED - elapsedSeconds)
+                    Text(
+                        text = stringResource(
+                            R.string.announcement_dont_show_again_hint,
+                            remaining,
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 48.dp),
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 确认按钮（无限制，始终可点击）
                 Button(
-                    onClick = {
-                        when {
-                            !confirmed -> confirmed = true
-                            canConfirm -> onConfirmed()
-                        }
-                    },
-                    enabled = !confirmed || canConfirm,
+                    onClick = { onDismiss(dontShowAgain) },
                     modifier = Modifier.fillMaxWidth(),
                     shape = MaterialTheme.shapes.large,
                 ) {
-                    Text(
-                        when {
-                            !confirmed -> stringResource(R.string.announcement_read_button)
-                            countdown > 0 -> stringResource(R.string.announcement_confirm_ok) + " ($countdown)"
-                            else -> stringResource(R.string.announcement_confirm_ok)
-                        }
-                    )
+                    Text(stringResource(R.string.announcement_confirm))
                 }
             }
         }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
@@ -3,6 +3,7 @@ package com.aliothmoon.maameow.presentation.components
 import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -40,6 +41,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -182,13 +184,20 @@ fun AnnouncementDialog(
 
                 // "不再显示"勾选框
                 Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .toggleable(
+                            value = dontShowAgain,
+                            enabled = canCheck,
+                            role = Role.Checkbox,
+                            onValueChange = { dontShowAgain = it },
+                        ),
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     Checkbox(
                         checked = dontShowAgain,
-                        onCheckedChange = { dontShowAgain = it },
-                        enabled = canCheck,
+                        onCheckedChange = null,
                     )
                     Text(
                         text = stringResource(R.string.announcement_dont_show_again),

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
@@ -75,14 +75,16 @@ fun AnnouncementDialog(
         snapshotFlow { scrollState.value >= scrollState.maxValue }
             .distinctUntilChanged()
             .collect { atBottom ->
-                if (atBottom && scrollState.maxValue >= 0) {
+                if (atBottom) {
                     scrolledToBottom = true
                 }
             }
     }
 
-    // 停留计时器
-    LaunchedEffect(Unit) {
+    // 停留计时器：滚动到底部后才开始计时，使倒计时提示得以显示
+    LaunchedEffect(scrolledToBottom) {
+        if (!scrolledToBottom) return@LaunchedEffect
+        elapsedSeconds = 0
         repeat(STAY_SECONDS_REQUIRED) {
             delay(1000)
             elapsedSeconds++

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
@@ -67,11 +67,12 @@ fun AnnouncementDialog(
 
     val scrollState = rememberScrollState()
 
-    // 检测是否滚动到底部
-    LaunchedEffect(scrollState.maxValue) {
-        snapshotFlow { scrollState.value }
-            .collect { value ->
-                if (scrollState.maxValue > 0 && value >= scrollState.maxValue) {
+    // 检测是否滚动到底部（内容不足一屏时 maxValue==0 视为已到底）
+    LaunchedEffect(scrollState) {
+        snapshotFlow { scrollState.value >= scrollState.maxValue }
+            .distinctUntilChanged()
+            .collect { atBottom ->
+                if (atBottom && scrollState.maxValue >= 0) {
                     scrolledToBottom = true
                 }
             }
@@ -79,7 +80,7 @@ fun AnnouncementDialog(
 
     // 停留计时器
     LaunchedEffect(Unit) {
-        while (true) {
+        repeat(STAY_SECONDS_REQUIRED) {
             delay(1000)
             elapsedSeconds++
         }
@@ -202,16 +203,27 @@ fun AnnouncementDialog(
 
                 // 未满足条件时显示提示
                 if (!canCheck) {
-                    val remaining = maxOf(0, STAY_SECONDS_REQUIRED - elapsedSeconds)
-                    Text(
-                        text = stringResource(
-                            R.string.announcement_dont_show_again_hint,
-                            remaining,
-                        ),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(start = 48.dp),
-                    )
+                    if (!scrolledToBottom) {
+                        // 尚未滚动到底部（无论 elapsedSeconds 是多少）
+                        Text(
+                            text = stringResource(R.string.announcement_scroll_to_bottom_hint),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(start = 48.dp),
+                        )
+                    } else {
+                        // 已滚动到底部，但时间未到
+                        val remaining = maxOf(0, STAY_SECONDS_REQUIRED - elapsedSeconds)
+                        Text(
+                            text = stringResource(
+                                R.string.announcement_dont_show_again_hint,
+                                remaining,
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(start = 48.dp),
+                        )
+                    }
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -314,9 +314,11 @@ fun AppNavigation(
             AnnouncementDialog(
                 imageAssetPath = remember(language) { AnnouncementConfig.imageAssetPath(language) },
                 markdown = announcementMarkdown,
-                onConfirmed = {
-                    coroutineScope.launch {
-                        appSettings.setAnnouncementReadVersion(AnnouncementConfig.CURRENT_VERSION)
+                onDismiss = { dontShowAgain ->
+                    if (dontShowAgain) {
+                        coroutineScope.launch {
+                            appSettings.setAnnouncementReadVersion(AnnouncementConfig.CURRENT_VERSION)
+                        }
                     }
                 },
             )

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -324,7 +324,6 @@ fun AppNavigation(
                 onDismiss = { dontShowAgain ->
                     forceShowAnnouncement = false
                     if (dontShowAgain) {
-                        announcementDismissedOnce = false
                         coroutineScope.launch {
                             appSettings.setAnnouncementReadVersion(AnnouncementConfig.CURRENT_VERSION)
                         }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -63,6 +63,7 @@ fun AppNavigation(
     val context = LocalContext.current
 
     var isFullscreen by remember { mutableStateOf(false) }
+    var forceShowAnnouncement by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
 
     // 执行模式状态 - 用于底部导航拦截
@@ -210,7 +211,10 @@ fun AppNavigation(
                             slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
                         }
                     ) {
-                        SettingsView(navController = navController)
+                        SettingsView(
+                            navController = navController,
+                            onViewAnnouncement = { forceShowAnnouncement = true },
+                        )
                     }
 
                     composable(
@@ -302,9 +306,11 @@ fun AppNavigation(
             )
         }
 
-        // 长期公告弹窗：每次公告版本变更后首次启动自动弹出
-        val announcementMarkdown = remember(announcementReadVersion, language) {
-            if (announcementReadVersion != AnnouncementConfig.CURRENT_VERSION) {
+        // 长期公告弹窗：每次公告版本变更后首次启动自动弹出，或从设置中手动打开
+        val showAnnouncement = forceShowAnnouncement ||
+            announcementReadVersion != AnnouncementConfig.CURRENT_VERSION
+        val announcementMarkdown = remember(showAnnouncement, language) {
+            if (showAnnouncement) {
                 AnnouncementConfig.loadContent(context, language)
             } else {
                 null
@@ -315,6 +321,7 @@ fun AppNavigation(
                 imageAssetPath = remember(language) { AnnouncementConfig.imageAssetPath(language) },
                 markdown = announcementMarkdown,
                 onDismiss = { dontShowAgain ->
+                    forceShowAnnouncement = false
                     if (dontShowAgain) {
                         coroutineScope.launch {
                             appSettings.setAnnouncementReadVersion(AnnouncementConfig.CURRENT_VERSION)

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -64,6 +64,7 @@ fun AppNavigation(
 
     var isFullscreen by remember { mutableStateOf(false) }
     var forceShowAnnouncement by remember { mutableStateOf(false) }
+    var announcementDismissedOnce by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
 
     // 执行模式状态 - 用于底部导航拦截
@@ -307,8 +308,8 @@ fun AppNavigation(
         }
 
         // 长期公告弹窗：每次公告版本变更后首次启动自动弹出，或从设置中手动打开
-        val showAnnouncement = forceShowAnnouncement ||
-            announcementReadVersion != AnnouncementConfig.CURRENT_VERSION
+        val needsToShow = announcementReadVersion != AnnouncementConfig.CURRENT_VERSION
+        val showAnnouncement = forceShowAnnouncement || (needsToShow && !announcementDismissedOnce)
         val announcementMarkdown = remember(showAnnouncement, language) {
             if (showAnnouncement) {
                 AnnouncementConfig.loadContent(context, language)
@@ -323,9 +324,12 @@ fun AppNavigation(
                 onDismiss = { dontShowAgain ->
                     forceShowAnnouncement = false
                     if (dontShowAgain) {
+                        announcementDismissedOnce = false
                         coroutineScope.launch {
                             appSettings.setAnnouncementReadVersion(AnnouncementConfig.CURRENT_VERSION)
                         }
+                    } else {
+                        announcementDismissedOnce = true
                     }
                 },
             )

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -71,6 +71,7 @@ import org.koin.compose.koinInject
 @Composable
 fun SettingsView(
     navController: NavController,
+    onViewAnnouncement: () -> Unit = {},
     viewModel: SettingsViewModel = koinViewModel(),
     resourceInitService: ResourceInitService = koinInject(),
     logExportService: LogExportService = koinInject()
@@ -405,6 +406,13 @@ fun SettingsView(
                         Misc.openUriSafely(context, "https://qm.qq.com/q/j4CFbeDQXu")
                     }
                     SettingsDivider(contentColor)
+                    SettingClickItem(
+                        title = stringResource(R.string.settings_about_announcement),
+                        contentColor = contentColor
+                    ) {
+                        onViewAnnouncement()
+                    }
+                    SettingsDivider(contentColor)
                     Text(
                         text = stringResource(R.string.settings_about_star),
                         style = MaterialTheme.typography.bodyMedium,
@@ -485,7 +493,7 @@ private fun SettingThemeModeItem(
 @Composable
 private fun SettingClickItem(
     title: String,
-    description: String,
+    description: String = "",
     contentColor: Color,
     onClick: () -> Unit
 ) {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1263,4 +1263,7 @@
     <string name="announcement_confirm_message">This notice won\'t appear again after confirmation. Please make sure you have read it fully.</string>
     <string name="announcement_confirm_ok">Got it, don\'t show again</string>
     <string name="announcement_confirm_back">Back to read again</string>
+    <string name="announcement_dont_show_again">Don\'t show again until next update</string>
+    <string name="announcement_dont_show_again_hint">Scroll to the bottom and stay for %1$d seconds to enable</string>
+    <string name="announcement_confirm">Confirm</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1265,6 +1265,7 @@
     <string name="announcement_confirm_ok">Got it, don\'t show again</string>
     <string name="announcement_confirm_back">Back to read again</string>
     <string name="announcement_dont_show_again">Don\'t show again until next update</string>
-    <string name="announcement_dont_show_again_hint">Scroll to the bottom and stay for %1$d seconds to enable</string>
+    <string name="announcement_dont_show_again_hint">Please read the full announcement and stay for %1$d seconds to enable</string>
+    <string name="announcement_scroll_to_bottom_hint">Please read the full announcement first</string>
     <string name="announcement_confirm">Confirm</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1259,11 +1259,6 @@
 
     <!-- i18n: announcement -->
     <string name="announcement_title">Important Notice</string>
-    <string name="announcement_read_button">I\'ve Read It</string>
-    <string name="announcement_confirm_title">Confirm</string>
-    <string name="announcement_confirm_message">This notice won\'t appear again after confirmation. Please make sure you have read it fully.</string>
-    <string name="announcement_confirm_ok">Got it, don\'t show again</string>
-    <string name="announcement_confirm_back">Back to read again</string>
     <string name="announcement_dont_show_again">Don\'t show again until next update</string>
     <string name="announcement_dont_show_again_hint">Please read the full announcement and stay for %1$d seconds to enable</string>
     <string name="announcement_scroll_to_bottom_hint">Please read the full announcement first</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -333,6 +333,7 @@
     <string name="settings_about_developer">Developer</string>
     <string name="settings_about_qq_group_title">Feedback QQ Group</string>
     <string name="settings_about_qq_group_desc">Got issues or suggestions? Join the QQ group to discuss</string>
+    <string name="settings_about_announcement">View Announcement</string>
     <string name="settings_about_star">⭐ Star us if you like it</string>
 
     <!-- ============================================================

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -530,6 +530,7 @@
     <string name="settings_about_developer">开发者</string>
     <string name="settings_about_qq_group_title">问题反馈 QQ 群</string>
     <string name="settings_about_qq_group_desc">遇到问题或有建议？欢迎加群交流反馈</string>
+    <string name="settings_about_announcement">查看公告</string>
     <string name="settings_about_star">⭐ 喜欢就给个 Star 吧</string>
 
     <!-- common: additional -->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1312,4 +1312,7 @@
     <string name="announcement_confirm_message">确认后本公告不再弹出，请确保已完整阅读全部内容。</string>
     <string name="announcement_confirm_ok">确认，不再提示</string>
     <string name="announcement_confirm_back">返回继续阅读</string>
+    <string name="announcement_dont_show_again">下次公告更新前不再显示</string>
+    <string name="announcement_dont_show_again_hint">需滑动至底部并停留 %1$d 秒后可勾选</string>
+    <string name="announcement_confirm">确认</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1314,6 +1314,7 @@
     <string name="announcement_confirm_ok">确认，不再提示</string>
     <string name="announcement_confirm_back">返回继续阅读</string>
     <string name="announcement_dont_show_again">下次公告更新前不再显示</string>
-    <string name="announcement_dont_show_again_hint">需滑动至底部并停留 %1$d 秒后可勾选</string>
+    <string name="announcement_dont_show_again_hint">请阅读完公告并停留 %1$d 秒后可勾选</string>
+    <string name="announcement_scroll_to_bottom_hint">请阅读完公告内容</string>
     <string name="announcement_confirm">确认</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1308,11 +1308,6 @@
 
     <!-- i18n: announcement -->
     <string name="announcement_title">重要公告</string>
-    <string name="announcement_read_button">我已阅读</string>
-    <string name="announcement_confirm_title">确认已阅读</string>
-    <string name="announcement_confirm_message">确认后本公告不再弹出，请确保已完整阅读全部内容。</string>
-    <string name="announcement_confirm_ok">确认，不再提示</string>
-    <string name="announcement_confirm_back">返回继续阅读</string>
     <string name="announcement_dont_show_again">下次公告更新前不再显示</string>
     <string name="announcement_dont_show_again_hint">请阅读完公告并停留 %1$d 秒后可勾选</string>
     <string name="announcement_scroll_to_bottom_hint">请阅读完公告内容</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1317,6 +1317,7 @@
     <string name="announcement_confirm_ok">确认，不再提示</string>
     <string name="announcement_confirm_back">返回继续阅读</string>
     <string name="announcement_dont_show_again">下次公告更新前不再显示</string>
-    <string name="announcement_dont_show_again_hint">需滑动至底部并停留 %1$d 秒后可勾选</string>
+    <string name="announcement_dont_show_again_hint">请阅读完公告并停留 %1$d 秒后可勾选</string>
+    <string name="announcement_scroll_to_bottom_hint">请阅读完公告内容</string>
     <string name="announcement_confirm">确认</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -533,6 +533,7 @@
     <string name="settings_about_developer">开发者</string>
     <string name="settings_about_qq_group_title">问题反馈 QQ 群</string>
     <string name="settings_about_qq_group_desc">遇到问题或有建议？欢迎加群交流反馈</string>
+    <string name="settings_about_announcement">查看公告</string>
     <string name="settings_about_star">⭐ 喜欢就给个 Star 吧</string>
 
     <!-- common: additional -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1315,4 +1315,7 @@
     <string name="announcement_confirm_message">确认后本公告不再弹出，请确保已完整阅读全部内容。</string>
     <string name="announcement_confirm_ok">确认，不再提示</string>
     <string name="announcement_confirm_back">返回继续阅读</string>
+    <string name="announcement_dont_show_again">下次公告更新前不再显示</string>
+    <string name="announcement_dont_show_again_hint">需滑动至底部并停留 %1$d 秒后可勾选</string>
+    <string name="announcement_confirm">确认</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1311,11 +1311,6 @@
 
     <!-- i18n: announcement -->
     <string name="announcement_title">重要公告</string>
-    <string name="announcement_read_button">我已阅读</string>
-    <string name="announcement_confirm_title">确认已阅读</string>
-    <string name="announcement_confirm_message">确认后本公告不再弹出，请确保已完整阅读全部内容。</string>
-    <string name="announcement_confirm_ok">确认，不再提示</string>
-    <string name="announcement_confirm_back">返回继续阅读</string>
     <string name="announcement_dont_show_again">下次公告更新前不再显示</string>
     <string name="announcement_dont_show_again_hint">请阅读完公告并停留 %1$d 秒后可勾选</string>
     <string name="announcement_scroll_to_bottom_hint">请阅读完公告内容</string>


### PR DESCRIPTION
## Summary by Sourcery

优化长期公告对话框的行为，并在“设置-关于”页面中提供手动入口。

New Features:
- 在“设置-关于”中新增菜单项，允许用户手动打开长期公告对话框。

Enhancements:
- 修改公告对话框的行为，使用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能勾选“不要再显示”，并提供相应的上下文提示。
- 支持长期公告在版本变更时自动弹出，或由用户通过设置页手动打开，并将单次关闭改为非永久性，除非用户明确选择不再显示。
- 更新公告内容与版本信息，以体现从设置页进入 QQ 群的新路径，并确保对话框文案与新的交互模式保持一致。

Documentation:
- 调整英文和中文公告的 Markdown 文案以及本地化字符串，以适配新的 QQ 群路径、对话框标签和提示内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the long-term announcement dialog behavior and expose a manual entry point from the Settings About page.

New Features:
- Add a Settings About menu item that allows users to manually open the long-term announcement dialog.

Enhancements:
- Change the announcement dialog so users can only mark it as "don’t show again" after scrolling to the bottom and staying on the dialog for a minimum time, with contextual hints.
- Allow the long-term announcement to be shown either automatically on version change or manually from Settings, and make single dismissals non-permanent unless explicitly opted out.
- Update the announcement content and version to reflect the new QQ group access path from Settings and ensure the dialog text aligns with the new interaction model.

Documentation:
- Adjust English and Chinese announcement markdown and localized strings for the new QQ group path, dialog labels, and hints.

</details>

新特性：
- 允许用户从设置页的“关于”部分手动打开长期公告对话框。

改进：
- 调整公告对话框逻辑，用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能选择将公告标记为“不要再显示”，并配有相应的提示说明。
- 调整公告的展示逻辑，使其既可以在版本变更时自动触发，也可以从设置页手动触发，并且可被关闭一次而不会被永久屏蔽。
- 更新英文和中文公告的 Markdown 内容，以通过设置页指向官方 QQ 群的正确入口路径。

文档：
- 为新的公告交互文案和设置入口标签新增本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化长期公告对话框的行为，并在“设置-关于”页面中提供手动入口。

New Features:
- 在“设置-关于”中新增菜单项，允许用户手动打开长期公告对话框。

Enhancements:
- 修改公告对话框的行为，使用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能勾选“不要再显示”，并提供相应的上下文提示。
- 支持长期公告在版本变更时自动弹出，或由用户通过设置页手动打开，并将单次关闭改为非永久性，除非用户明确选择不再显示。
- 更新公告内容与版本信息，以体现从设置页进入 QQ 群的新路径，并确保对话框文案与新的交互模式保持一致。

Documentation:
- 调整英文和中文公告的 Markdown 文案以及本地化字符串，以适配新的 QQ 群路径、对话框标签和提示内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the long-term announcement dialog behavior and expose a manual entry point from the Settings About page.

New Features:
- Add a Settings About menu item that allows users to manually open the long-term announcement dialog.

Enhancements:
- Change the announcement dialog so users can only mark it as "don’t show again" after scrolling to the bottom and staying on the dialog for a minimum time, with contextual hints.
- Allow the long-term announcement to be shown either automatically on version change or manually from Settings, and make single dismissals non-permanent unless explicitly opted out.
- Update the announcement content and version to reflect the new QQ group access path from Settings and ensure the dialog text aligns with the new interaction model.

Documentation:
- Adjust English and Chinese announcement markdown and localized strings for the new QQ group path, dialog labels, and hints.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化长期公告对话框的行为，并在“设置-关于”页面中提供手动入口。

New Features:
- 在“设置-关于”中新增菜单项，允许用户手动打开长期公告对话框。

Enhancements:
- 修改公告对话框的行为，使用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能勾选“不要再显示”，并提供相应的上下文提示。
- 支持长期公告在版本变更时自动弹出，或由用户通过设置页手动打开，并将单次关闭改为非永久性，除非用户明确选择不再显示。
- 更新公告内容与版本信息，以体现从设置页进入 QQ 群的新路径，并确保对话框文案与新的交互模式保持一致。

Documentation:
- 调整英文和中文公告的 Markdown 文案以及本地化字符串，以适配新的 QQ 群路径、对话框标签和提示内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the long-term announcement dialog behavior and expose a manual entry point from the Settings About page.

New Features:
- Add a Settings About menu item that allows users to manually open the long-term announcement dialog.

Enhancements:
- Change the announcement dialog so users can only mark it as "don’t show again" after scrolling to the bottom and staying on the dialog for a minimum time, with contextual hints.
- Allow the long-term announcement to be shown either automatically on version change or manually from Settings, and make single dismissals non-permanent unless explicitly opted out.
- Update the announcement content and version to reflect the new QQ group access path from Settings and ensure the dialog text aligns with the new interaction model.

Documentation:
- Adjust English and Chinese announcement markdown and localized strings for the new QQ group path, dialog labels, and hints.

</details>

新特性：
- 允许用户从设置页的“关于”部分手动打开长期公告对话框。

改进：
- 调整公告对话框逻辑，用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能选择将公告标记为“不要再显示”，并配有相应的提示说明。
- 调整公告的展示逻辑，使其既可以在版本变更时自动触发，也可以从设置页手动触发，并且可被关闭一次而不会被永久屏蔽。
- 更新英文和中文公告的 Markdown 内容，以通过设置页指向官方 QQ 群的正确入口路径。

文档：
- 为新的公告交互文案和设置入口标签新增本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化长期公告对话框的行为，并在“设置-关于”页面中提供手动入口。

New Features:
- 在“设置-关于”中新增菜单项，允许用户手动打开长期公告对话框。

Enhancements:
- 修改公告对话框的行为，使用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能勾选“不要再显示”，并提供相应的上下文提示。
- 支持长期公告在版本变更时自动弹出，或由用户通过设置页手动打开，并将单次关闭改为非永久性，除非用户明确选择不再显示。
- 更新公告内容与版本信息，以体现从设置页进入 QQ 群的新路径，并确保对话框文案与新的交互模式保持一致。

Documentation:
- 调整英文和中文公告的 Markdown 文案以及本地化字符串，以适配新的 QQ 群路径、对话框标签和提示内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the long-term announcement dialog behavior and expose a manual entry point from the Settings About page.

New Features:
- Add a Settings About menu item that allows users to manually open the long-term announcement dialog.

Enhancements:
- Change the announcement dialog so users can only mark it as "don’t show again" after scrolling to the bottom and staying on the dialog for a minimum time, with contextual hints.
- Allow the long-term announcement to be shown either automatically on version change or manually from Settings, and make single dismissals non-permanent unless explicitly opted out.
- Update the announcement content and version to reflect the new QQ group access path from Settings and ensure the dialog text aligns with the new interaction model.

Documentation:
- Adjust English and Chinese announcement markdown and localized strings for the new QQ group path, dialog labels, and hints.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化长期公告对话框的行为，并在“设置-关于”页面中提供手动入口。

New Features:
- 在“设置-关于”中新增菜单项，允许用户手动打开长期公告对话框。

Enhancements:
- 修改公告对话框的行为，使用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能勾选“不要再显示”，并提供相应的上下文提示。
- 支持长期公告在版本变更时自动弹出，或由用户通过设置页手动打开，并将单次关闭改为非永久性，除非用户明确选择不再显示。
- 更新公告内容与版本信息，以体现从设置页进入 QQ 群的新路径，并确保对话框文案与新的交互模式保持一致。

Documentation:
- 调整英文和中文公告的 Markdown 文案以及本地化字符串，以适配新的 QQ 群路径、对话框标签和提示内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the long-term announcement dialog behavior and expose a manual entry point from the Settings About page.

New Features:
- Add a Settings About menu item that allows users to manually open the long-term announcement dialog.

Enhancements:
- Change the announcement dialog so users can only mark it as "don’t show again" after scrolling to the bottom and staying on the dialog for a minimum time, with contextual hints.
- Allow the long-term announcement to be shown either automatically on version change or manually from Settings, and make single dismissals non-permanent unless explicitly opted out.
- Update the announcement content and version to reflect the new QQ group access path from Settings and ensure the dialog text aligns with the new interaction model.

Documentation:
- Adjust English and Chinese announcement markdown and localized strings for the new QQ group path, dialog labels, and hints.

</details>

新特性：
- 允许用户从设置页的“关于”部分手动打开长期公告对话框。

改进：
- 调整公告对话框逻辑，用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能选择将公告标记为“不要再显示”，并配有相应的提示说明。
- 调整公告的展示逻辑，使其既可以在版本变更时自动触发，也可以从设置页手动触发，并且可被关闭一次而不会被永久屏蔽。
- 更新英文和中文公告的 Markdown 内容，以通过设置页指向官方 QQ 群的正确入口路径。

文档：
- 为新的公告交互文案和设置入口标签新增本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化长期公告对话框的行为，并在“设置-关于”页面中提供手动入口。

New Features:
- 在“设置-关于”中新增菜单项，允许用户手动打开长期公告对话框。

Enhancements:
- 修改公告对话框的行为，使用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能勾选“不要再显示”，并提供相应的上下文提示。
- 支持长期公告在版本变更时自动弹出，或由用户通过设置页手动打开，并将单次关闭改为非永久性，除非用户明确选择不再显示。
- 更新公告内容与版本信息，以体现从设置页进入 QQ 群的新路径，并确保对话框文案与新的交互模式保持一致。

Documentation:
- 调整英文和中文公告的 Markdown 文案以及本地化字符串，以适配新的 QQ 群路径、对话框标签和提示内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the long-term announcement dialog behavior and expose a manual entry point from the Settings About page.

New Features:
- Add a Settings About menu item that allows users to manually open the long-term announcement dialog.

Enhancements:
- Change the announcement dialog so users can only mark it as "don’t show again" after scrolling to the bottom and staying on the dialog for a minimum time, with contextual hints.
- Allow the long-term announcement to be shown either automatically on version change or manually from Settings, and make single dismissals non-permanent unless explicitly opted out.
- Update the announcement content and version to reflect the new QQ group access path from Settings and ensure the dialog text aligns with the new interaction model.

Documentation:
- Adjust English and Chinese announcement markdown and localized strings for the new QQ group path, dialog labels, and hints.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化长期公告对话框的行为，并在“设置-关于”页面中提供手动入口。

New Features:
- 在“设置-关于”中新增菜单项，允许用户手动打开长期公告对话框。

Enhancements:
- 修改公告对话框的行为，使用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能勾选“不要再显示”，并提供相应的上下文提示。
- 支持长期公告在版本变更时自动弹出，或由用户通过设置页手动打开，并将单次关闭改为非永久性，除非用户明确选择不再显示。
- 更新公告内容与版本信息，以体现从设置页进入 QQ 群的新路径，并确保对话框文案与新的交互模式保持一致。

Documentation:
- 调整英文和中文公告的 Markdown 文案以及本地化字符串，以适配新的 QQ 群路径、对话框标签和提示内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the long-term announcement dialog behavior and expose a manual entry point from the Settings About page.

New Features:
- Add a Settings About menu item that allows users to manually open the long-term announcement dialog.

Enhancements:
- Change the announcement dialog so users can only mark it as "don’t show again" after scrolling to the bottom and staying on the dialog for a minimum time, with contextual hints.
- Allow the long-term announcement to be shown either automatically on version change or manually from Settings, and make single dismissals non-permanent unless explicitly opted out.
- Update the announcement content and version to reflect the new QQ group access path from Settings and ensure the dialog text aligns with the new interaction model.

Documentation:
- Adjust English and Chinese announcement markdown and localized strings for the new QQ group path, dialog labels, and hints.

</details>

新特性：
- 允许用户从设置页的“关于”部分手动打开长期公告对话框。

改进：
- 调整公告对话框逻辑，用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能选择将公告标记为“不要再显示”，并配有相应的提示说明。
- 调整公告的展示逻辑，使其既可以在版本变更时自动触发，也可以从设置页手动触发，并且可被关闭一次而不会被永久屏蔽。
- 更新英文和中文公告的 Markdown 内容，以通过设置页指向官方 QQ 群的正确入口路径。

文档：
- 为新的公告交互文案和设置入口标签新增本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化长期公告对话框的行为，并在“设置-关于”页面中提供手动入口。

New Features:
- 在“设置-关于”中新增菜单项，允许用户手动打开长期公告对话框。

Enhancements:
- 修改公告对话框的行为，使用户只有在滚动到最底部并在对话框上停留达到最短时间后，才能勾选“不要再显示”，并提供相应的上下文提示。
- 支持长期公告在版本变更时自动弹出，或由用户通过设置页手动打开，并将单次关闭改为非永久性，除非用户明确选择不再显示。
- 更新公告内容与版本信息，以体现从设置页进入 QQ 群的新路径，并确保对话框文案与新的交互模式保持一致。

Documentation:
- 调整英文和中文公告的 Markdown 文案以及本地化字符串，以适配新的 QQ 群路径、对话框标签和提示内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the long-term announcement dialog behavior and expose a manual entry point from the Settings About page.

New Features:
- Add a Settings About menu item that allows users to manually open the long-term announcement dialog.

Enhancements:
- Change the announcement dialog so users can only mark it as "don’t show again" after scrolling to the bottom and staying on the dialog for a minimum time, with contextual hints.
- Allow the long-term announcement to be shown either automatically on version change or manually from Settings, and make single dismissals non-permanent unless explicitly opted out.
- Update the announcement content and version to reflect the new QQ group access path from Settings and ensure the dialog text aligns with the new interaction model.

Documentation:
- Adjust English and Chinese announcement markdown and localized strings for the new QQ group path, dialog labels, and hints.

</details>

</details>

</details>

</details>