### PR TITLE
feat(schedule): 实现前台模式定时任务执行逻辑与悬浮球联动

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ android/.cxx
 # App Build
 /app/release
 /app/debug
+/gradle/gradle-daemon-jvm.properties

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -473,4 +473,19 @@ class AppSettingsManager(private val context: Context) {
         }
     }
 
+    // 允许在前台模式执行定时任务
+    val allowForegroundScheduledTask: StateFlow<Boolean> = settings
+        .map { it.allowForegroundScheduledTask.toBooleanStrictOrNull() ?: false }
+        .distinctUntilChanged()
+        .stateIn(
+            scope, SharingStarted.Eagerly,
+            initialSettings.allowForegroundScheduledTask.toBooleanStrictOrNull() ?: false
+        )
+
+    suspend fun setAllowForegroundScheduledTask(enabled: Boolean) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[allowForegroundScheduledTask] = enabled.toString() }
+        }
+    }
+
 }

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -68,4 +68,6 @@ data class AppSettings(
      * 注意：受游戏自身 FLAG_ACTIVITY_MULTIPLE_TASK 影响，实际效果有限，默认 false。
      */
     @PrefKey(default = "false") val excludeFromRecentsOnBackground: String = "false",
+
+    @PrefKey(default = "false") val allowForegroundScheduledTask: String = "false",
 )

--- a/app/src/main/java/com/aliothmoon/maameow/domain/service/MaaCompositionService.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/service/MaaCompositionService.kt
@@ -187,10 +187,12 @@ class MaaCompositionService(
     suspend fun start(
         tasks: List<MaaTaskParams>,
         clientType: String,
+        isScheduled: Boolean = false,
         onSessionStarted: (suspend () -> Unit)? = null
     ): StartResult = executeStart(
         tasks = tasks,
         clientType = clientType,
+        isScheduled = isScheduled,
         startMessage = "开始执行任务，共 ${tasks.size} 项",
         successMessage = "任务开始运行",
         onSessionStarted = onSessionStarted,
@@ -225,7 +227,7 @@ class MaaCompositionService(
         return result
     }
 
-    private suspend fun checkPreconditions(mode: RunMode): StartResult? {
+    private suspend fun checkPreconditions(mode: RunMode, isScheduled: Boolean = false): StartResult? {
         // 服务连接中时直接拒绝，避免与后台自动 load() 并发触发 LoadResource
         val serviceState = RemoteServiceManager.state.value
         if (serviceState is RemoteServiceManager.ServiceState.Connecting) {
@@ -244,7 +246,7 @@ class MaaCompositionService(
                 StartResult.ResourceError(loaded.exceptionOrNull())
             )
         }
-        if (mode == RunMode.FOREGROUND) {
+        if (mode == RunMode.FOREGROUND && !isScheduled) {
             val (width, height) = Misc.getScreenSize(context)
             if (height > width) {
                 return failStart(
@@ -359,6 +361,7 @@ class MaaCompositionService(
         clientType: String,
         startMessage: String,
         successMessage: String,
+        isScheduled: Boolean = false,
         onSessionStarted: (suspend () -> Unit)? = null,
     ): StartResult {
         setRunState(MaaExecutionState.STARTING)
@@ -369,7 +372,7 @@ class MaaCompositionService(
 
         val mode = appSettings.runMode.value
         return withContext(Dispatchers.IO) {
-            checkPreconditions(mode)?.let { return@withContext it }
+            checkPreconditions(mode, isScheduled)?.let { return@withContext it }
 
             useRemoteService { service ->
                 val maa = service.maaCoreService

--- a/app/src/main/java/com/aliothmoon/maameow/koin/AppModule.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/koin/AppModule.kt
@@ -19,7 +19,7 @@ import com.aliothmoon.maameow.data.preferences.ConfigBackupManager
 import com.aliothmoon.maameow.data.preferences.TaskChainState
 import com.aliothmoon.maameow.schedule.service.ScheduleAlarmManager
 import com.aliothmoon.maameow.schedule.service.ScheduleTriggerLogger
-import com.aliothmoon.maameow.schedule.service.ForegroundScheduleStarter;
+import com.aliothmoon.maameow.schedule.service.ForegroundScheduleStarter
 import com.aliothmoon.maameow.schedule.data.ScheduleStrategyRepository
 import com.aliothmoon.maameow.data.repository.CopilotRepository
 import com.aliothmoon.maameow.data.resource.ActivityManager

--- a/app/src/main/java/com/aliothmoon/maameow/koin/AppModule.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/koin/AppModule.kt
@@ -19,6 +19,7 @@ import com.aliothmoon.maameow.data.preferences.ConfigBackupManager
 import com.aliothmoon.maameow.data.preferences.TaskChainState
 import com.aliothmoon.maameow.schedule.service.ScheduleAlarmManager
 import com.aliothmoon.maameow.schedule.service.ScheduleTriggerLogger
+import com.aliothmoon.maameow.schedule.service.ForegroundScheduleStarter;
 import com.aliothmoon.maameow.schedule.data.ScheduleStrategyRepository
 import com.aliothmoon.maameow.data.repository.CopilotRepository
 import com.aliothmoon.maameow.data.resource.ActivityManager
@@ -167,4 +168,7 @@ val appModule = module {
     singleOf(::CopilotManager)
     singleOf(::ApplicationLogWriter)
     singleOf(::LogTreeHolder)
+
+    // 前台模式自动任务
+    singleOf(::ForegroundScheduleStarter)
 }

--- a/app/src/main/java/com/aliothmoon/maameow/overlay/FloatBall.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/overlay/FloatBall.kt
@@ -19,13 +19,16 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.aliothmoon.maameow.domain.state.MaaExecutionState
 
 
@@ -33,12 +36,15 @@ import com.aliothmoon.maameow.domain.state.MaaExecutionState
 fun FloatBall(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    runningState: MaaExecutionState = MaaExecutionState.IDLE
+    runningState: MaaExecutionState = MaaExecutionState.IDLE,
+    countdownSeconds: Int? = null,
 ) {
-    val targetColor = when (runningState) {
-        MaaExecutionState.RUNNING -> Color(0xFF4CAF50) // 绿色 - 运行中
-        MaaExecutionState.STOPPING -> Color(0xFFFFA726) // 橙色 - 停止中
-        MaaExecutionState.ERROR -> Color(0xFFE53935) // 红色 - 错误
+    val isCountdown = countdownSeconds != null
+    val targetColor = when {
+        isCountdown -> Color(0xFFFFA726)
+        runningState == MaaExecutionState.RUNNING -> Color(0xFF4CAF50) // 绿色 - 运行中
+        runningState == MaaExecutionState.STOPPING -> Color(0xFFFFA726) // 橙色 - 停止中
+        runningState == MaaExecutionState.ERROR -> Color(0xFFE53935) // 红色 - 错误
         else -> MaterialTheme.colorScheme.primary // IDLE, STARTING 等使用默认主题色
     }
 
@@ -59,7 +65,7 @@ fun FloatBall(
         ),
     )
 
-    val alphaModifier = if (runningState == MaaExecutionState.RUNNING) {
+    val alphaModifier = if (runningState == MaaExecutionState.RUNNING || isCountdown) {
         Modifier.alpha(breathingAlpha)
     } else {
         Modifier
@@ -80,16 +86,25 @@ fun FloatBall(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
-            Icon(
-                imageVector = when (runningState) {
-                    MaaExecutionState.RUNNING -> Icons.Filled.PlayArrow
-                    MaaExecutionState.ERROR -> Icons.Filled.Warning
-                    else -> Icons.Filled.Check
-                },
-                contentDescription = runningState.name,
-                tint = textColor,
-                modifier = Modifier.size(16.dp)
-            )
+            if (isCountdown) {
+                Text(
+                    text = "$countdownSeconds",
+                    color = textColor,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+            } else {
+                Icon(
+                    imageVector = when (runningState) {
+                        MaaExecutionState.RUNNING -> Icons.Filled.PlayArrow
+                        MaaExecutionState.ERROR -> Icons.Filled.Warning
+                        else -> Icons.Filled.Check
+                    },
+                    contentDescription = runningState.name,
+                    tint = textColor,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/overlay/FloatBall.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/overlay/FloatBall.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
+import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.domain.state.MaaExecutionState
 
 
@@ -76,17 +78,28 @@ fun FloatBall(
         Modifier
     }
 
+    val stateDescription = stringResource(
+        when (runningState) {
+            MaaExecutionState.IDLE -> R.string.overlay_floatball_state_idle
+            MaaExecutionState.STARTING -> R.string.overlay_floatball_state_starting
+            MaaExecutionState.RUNNING -> R.string.overlay_floatball_state_running
+            MaaExecutionState.STOPPING -> R.string.overlay_floatball_state_stopping
+            MaaExecutionState.ERROR -> R.string.overlay_floatball_state_error
+        }
+    )
+    val semanticsDescription = if (isCountdown) {
+        stringResource(R.string.overlay_floatball_countdown_desc, countdownText)
+    } else {
+        stateDescription
+    }
+
     Surface(
         modifier = modifier
             .size(32.dp)
             .border(1.dp, textColor.copy(alpha = 0.15f), CircleShape)
             .then(alphaModifier)
             .semantics {
-                if (isCountdown) {
-                    contentDescription = "正在倒计时，剩余 $countdownText 秒"
-                } else {
-                    contentDescription = runningState.name
-                }
+                contentDescription = semanticsDescription
             },
         shape = CircleShape,
         color = baseColor,
@@ -112,7 +125,7 @@ fun FloatBall(
                         MaaExecutionState.ERROR -> Icons.Filled.Warning
                         else -> Icons.Filled.Check
                     },
-                    contentDescription = runningState.name,
+                    contentDescription = stateDescription,
                     tint = textColor,
                     modifier = Modifier.size(16.dp)
                 )

--- a/app/src/main/java/com/aliothmoon/maameow/overlay/FloatBall.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/overlay/FloatBall.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,7 +41,10 @@ fun FloatBall(
     runningState: MaaExecutionState = MaaExecutionState.IDLE,
     countdownSeconds: Int? = null,
 ) {
-    val isCountdown = countdownSeconds != null
+    val safeCountdownSeconds = countdownSeconds?.takeIf { it > 0 }
+    val isCountdown = safeCountdownSeconds != null
+    val countdownText = safeCountdownSeconds?.toString().orEmpty()
+
     val targetColor = when {
         isCountdown -> Color(0xFFFFA726)
         runningState == MaaExecutionState.RUNNING -> Color(0xFF4CAF50) // 绿色 - 运行中
@@ -75,7 +80,14 @@ fun FloatBall(
         modifier = modifier
             .size(32.dp)
             .border(1.dp, textColor.copy(alpha = 0.15f), CircleShape)
-            .then(alphaModifier),
+            .then(alphaModifier)
+            .semantics {
+                if (isCountdown) {
+                    contentDescription = "正在倒计时，剩余 $countdownText 秒"
+                } else {
+                    contentDescription = runningState.name
+                }
+            },
         shape = CircleShape,
         color = baseColor,
         shadowElevation = 8.dp,
@@ -88,7 +100,7 @@ fun FloatBall(
         ) {
             if (isCountdown) {
                 Text(
-                    text = "$countdownSeconds",
+                    text = countdownText,
                     color = textColor,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Bold,

--- a/app/src/main/java/com/aliothmoon/maameow/overlay/OverlayController.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/overlay/OverlayController.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
@@ -19,6 +20,7 @@ import com.aliothmoon.maameow.domain.service.MaaCompositionService
 import com.aliothmoon.maameow.domain.state.MaaExecutionState
 import com.aliothmoon.maameow.overlay.border.BorderOverlayManager
 import com.aliothmoon.maameow.presentation.LocalFloatingWindowContext
+import com.aliothmoon.maameow.schedule.model.CountdownState
 import com.aliothmoon.maameow.presentation.view.panel.ExpandedControlPanel
 import com.aliothmoon.maameow.service.AccessibilityHelperService
 import com.aliothmoon.maameow.theme.MaaMeowTheme
@@ -68,6 +70,15 @@ class OverlayController(
 
     private var currentMode: OverlayControlMode = OverlayControlMode.ACCESSIBILITY
     private var maaStateJob: Job? = null
+
+    private val _countdownState = MutableStateFlow<CountdownState>(CountdownState.Idle)
+    val countdownState: StateFlow<CountdownState> = _countdownState.asStateFlow()
+
+    var onCountdownClick: (() -> Unit)? = null
+
+    fun updateCountdownState(state: CountdownState) {
+        _countdownState.value = state
+    }
 
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
@@ -293,10 +304,12 @@ class OverlayController(
                             setViewTreeSavedStateRegistryOwner(it)
                         }
                         setContent {
-                            val runningState by compositionService.state.collectAsStateWithLifecycle()
+                            val runningState by compositionService.state.collectAsState()
+                            val countdown by _countdownState.collectAsState()
                             FloatBall(
                                 onClick = ::onFloatBallClick,
-                                runningState = runningState
+                                runningState = runningState,
+                                countdownSeconds = (countdown as? CountdownState.Counting)?.remainingSeconds,
                             )
                         }
                     }
@@ -316,6 +329,10 @@ class OverlayController(
     }
 
     fun onFloatBallClick() {
+        if (_countdownState.value is CountdownState.Counting) {
+            onCountdownClick?.invoke()
+            return
+        }
         hideFloatBall()
         if (compositionService.state.value == MaaExecutionState.RUNNING) {
             scope.launch {

--- a/app/src/main/java/com/aliothmoon/maameow/overlay/OverlayController.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/overlay/OverlayController.kt
@@ -75,6 +75,20 @@ class OverlayController(
     val countdownState: StateFlow<CountdownState> = _countdownState.asStateFlow()
 
     var onCountdownClick: (() -> Unit)? = null
+    private var tempCountdownListener: (() -> Unit)? = null
+
+    fun setTemporaryCountdownListener(listener: (() -> Unit)?) {
+        this.tempCountdownListener = listener
+    }
+
+    fun handleCountdownClick() {
+        val temp = tempCountdownListener
+        if (temp != null) {
+            temp.invoke()
+        } else {
+            onCountdownClick?.invoke()
+        }
+    }
 
     fun updateCountdownState(state: CountdownState) {
         _countdownState.value = state
@@ -304,10 +318,17 @@ class OverlayController(
                             setViewTreeSavedStateRegistryOwner(it)
                         }
                         setContent {
+                            // 悬浮窗需要在后台强行保持监听，不使用 collectAsStateWithLifecycle
                             val runningState by compositionService.state.collectAsState()
-                            val countdown by _countdownState.collectAsState()
+                            val countdown by countdownState.collectAsState()
                             FloatBall(
-                                onClick = ::onFloatBallClick,
+                                onClick = {
+                                    if (countdown is CountdownState.Counting) {
+                                        handleCountdownClick()
+                                    } else {
+                                        onFloatBallClick()
+                                    }
+                                },
                                 runningState = runningState,
                                 countdownSeconds = (countdown as? CountdownState.Counting)?.remainingSeconds,
                             )
@@ -330,7 +351,7 @@ class OverlayController(
 
     fun onFloatBallClick() {
         if (_countdownState.value is CountdownState.Counting) {
-            onCountdownClick?.invoke()
+            handleCountdownClick()
             return
         }
         hideFloatBall()

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -31,7 +31,6 @@ import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.announcement.AnnouncementConfig
 import com.aliothmoon.maameow.constant.Routes
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
-import com.aliothmoon.maameow.domain.models.OverlayControlMode
 import com.aliothmoon.maameow.domain.models.RunMode
 import com.aliothmoon.maameow.domain.service.ExternalNotificationService
 import com.aliothmoon.maameow.overlay.OverlayController
@@ -332,11 +331,10 @@ fun AppNavigation(
 
         ResourceLoadingOverlay()
 
-        // 全局定时任务倒计时弹窗（前台+FLOAT_BALL模式通过悬浮球显示倒计时，不弹出对话框）
+        // 全局定时任务倒计时弹窗（前台所有控制模式均不弹出对话框，静默处理）
         val countdown = scheduledCountdownState
-        val useFloatBallCountdown = runMode == RunMode.FOREGROUND
-                && overlayControlMode == OverlayControlMode.FLOAT_BALL
-        if (countdown is CountdownState.Counting && !useFloatBallCountdown) {
+        val hideCountdownDialog = runMode == RunMode.FOREGROUND
+        if (countdown is CountdownState.Counting && !hideCountdownDialog) {
             CountdownDialog(
                 state = countdown,
                 onCancel = { backgroundTaskViewModel.onScheduledCountdownCancel() },

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -31,8 +31,10 @@ import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.announcement.AnnouncementConfig
 import com.aliothmoon.maameow.constant.Routes
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
+import com.aliothmoon.maameow.domain.models.OverlayControlMode
 import com.aliothmoon.maameow.domain.models.RunMode
 import com.aliothmoon.maameow.domain.service.ExternalNotificationService
+import com.aliothmoon.maameow.overlay.OverlayController
 import com.aliothmoon.maameow.presentation.components.AnnouncementDialog
 import com.aliothmoon.maameow.presentation.components.ResourceLoadingOverlay
 import com.aliothmoon.maameow.presentation.view.background.BackgroundTaskView
@@ -56,6 +58,7 @@ fun AppNavigation(
     backgroundTaskViewModel: BackgroundTaskViewModel,
     appSettings: AppSettingsManager = koinInject(),
     notificationService: ExternalNotificationService = koinInject(),
+    overlayController: OverlayController = koinInject(),
 ) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -72,6 +75,7 @@ fun AppNavigation(
     val runMode by appSettings.runMode.collectAsStateWithLifecycle()
     val announcementReadVersion by appSettings.announcementReadVersion.collectAsStateWithLifecycle()
     val language by appSettings.language.collectAsStateWithLifecycle()
+    val overlayControlMode by appSettings.overlayControlMode.collectAsStateWithLifecycle()
     val pendingScheduledExecution by backgroundTaskViewModel.coordinator.pendingExecution.collectAsStateWithLifecycle()
     val scheduledCountdownState by backgroundTaskViewModel.coordinator.countdownState.collectAsStateWithLifecycle()
 
@@ -100,6 +104,18 @@ fun AppNavigation(
     LaunchedEffect(backgroundTaskViewModel) {
         backgroundTaskViewModel.coordinator.feedbackMessages.collect { message ->
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    LaunchedEffect(backgroundTaskViewModel) {
+        backgroundTaskViewModel.coordinator.countdownState.collect { state ->
+            overlayController.updateCountdownState(state)
+        }
+    }
+
+    LaunchedEffect(backgroundTaskViewModel) {
+        overlayController.onCountdownClick = {
+            backgroundTaskViewModel.onScheduledStartNow()
         }
     }
 
@@ -316,9 +332,11 @@ fun AppNavigation(
 
         ResourceLoadingOverlay()
 
-        // 全局定时任务倒计时弹窗
+        // 全局定时任务倒计时弹窗（前台+FLOAT_BALL模式通过悬浮球显示倒计时，不弹出对话框）
         val countdown = scheduledCountdownState
-        if (countdown is CountdownState.Counting) {
+        val useFloatBallCountdown = runMode == RunMode.FOREGROUND
+                && overlayControlMode == OverlayControlMode.FLOAT_BALL
+        if (countdown is CountdownState.Counting && !useFloatBallCountdown) {
             CountdownDialog(
                 state = countdown,
                 onCancel = { backgroundTaskViewModel.onScheduledCountdownCancel() },

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -358,7 +358,6 @@ fun SettingsView(
                     SettingsDivider(contentColor)
                     SettingSwitchItem(
                         title = stringResource(R.string.settings_allow_foreground_scheduled_task),
-                        description = stringResource(R.string.settings_allow_foreground_scheduled_task_desc),
                         contentColor = contentColor,
                         checked = allowForegroundScheduledTask,
                         onCheckedChange = { viewModel.setAllowForegroundScheduledTask(it) }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -89,6 +89,7 @@ fun SettingsView(
     val deploymentWithPause by viewModel.deploymentWithPause.collectAsStateWithLifecycle()
     val forceFullscreenOnVirtualDisplay by viewModel.forceFullscreenOnVirtualDisplay.collectAsStateWithLifecycle()
     val excludeFromRecentsOnBackground by viewModel.excludeFromRecentsOnBackground.collectAsStateWithLifecycle()
+    val allowForegroundScheduledTask by viewModel.allowForegroundScheduledTask.collectAsStateWithLifecycle()
     val tasksOverrideEnabled by viewModel.tasksOverrideEnabled.collectAsStateWithLifecycle()
     val updateChannel by viewModel.updateChannel.collectAsStateWithLifecycle()
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
@@ -353,6 +354,14 @@ fun SettingsView(
                         contentColor = contentColor,
                         checked = excludeFromRecentsOnBackground,
                         onCheckedChange = { viewModel.setExcludeFromRecentsOnBackground(it) }
+                    )
+                    SettingsDivider(contentColor)
+                    SettingSwitchItem(
+                        title = stringResource(R.string.settings_allow_foreground_scheduled_task),
+                        description = stringResource(R.string.settings_allow_foreground_scheduled_task_desc),
+                        contentColor = contentColor,
+                        checked = allowForegroundScheduledTask,
+                        onCheckedChange = { viewModel.setAllowForegroundScheduledTask(it) }
                     )
                     SettingsDivider(contentColor)
                     SettingSwitchItem(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/BackgroundTaskViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/BackgroundTaskViewModel.kt
@@ -437,6 +437,7 @@ class BackgroundTaskViewModel(
         val result = compositionService.start(
             tasks = plan.params,
             clientType = plan.clientType,
+            isScheduled = context.mode == TaskStartMode.SCHEDULED,
         ) {
             if (request != null) {
                 sessionLogger.appendAndWait(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -171,6 +171,15 @@ class SettingsViewModel(
         }
     }
 
+    val allowForegroundScheduledTask: StateFlow<Boolean> = appSettingsManager.allowForegroundScheduledTask
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    fun setAllowForegroundScheduledTask(enabled: Boolean) {
+        viewModelScope.launch {
+            appSettingsManager.setAllowForegroundScheduledTask(enabled)
+        }
+    }
+
     val updateChannel: StateFlow<UpdateChannel> = appSettingsManager.updateChannel
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), UpdateChannel.STABLE)
 

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -172,7 +172,6 @@ class SettingsViewModel(
     }
 
     val allowForegroundScheduledTask: StateFlow<Boolean> = appSettingsManager.allowForegroundScheduledTask
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     fun setAllowForegroundScheduledTask(enabled: Boolean) {
         viewModelScope.launch {

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ForegroundScheduleStarter.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ForegroundScheduleStarter.kt
@@ -19,9 +19,7 @@ import kotlinx.coroutines.flow.first
 import timber.log.Timber
 import java.util.concurrent.atomic.AtomicBoolean
 
-/**
- * 专供前台悬浮球模式使用的静默启动器。
- */
+
 class ForegroundScheduleStarter(
     private val overlayController: OverlayController,
     private val prepareTaskStartUseCase: PrepareTaskStartUseCase,
@@ -40,7 +38,7 @@ class ForegroundScheduleStarter(
             return
         }
         try {
-            Timber.i("SilentStarter: 接管前台悬浮球定时请求 ${request.requestId}")
+            Timber.i("接管前台定时请求 ${request.requestId}")
 
             if (compositionService.state.value == MaaExecutionState.RUNNING ||
                 compositionService.state.value == MaaExecutionState.STARTING) {
@@ -101,9 +99,7 @@ class ForegroundScheduleStarter(
 
             try {
                 val startContext = TaskStartContext(mode = TaskStartMode.SCHEDULED)
-                val decision = prepareTaskStartUseCase.invoke(chain, startContext)
-
-                when (decision) {
+                when (val decision = prepareTaskStartUseCase.invoke(chain, startContext)) {
                     is TaskStartDecision.Ready -> {
                         triggerLogger.append("前置条件通过，启用任务 ${chain.size} 项，正在启动 MAA 核心服务...")
 

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ForegroundScheduleStarter.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ForegroundScheduleStarter.kt
@@ -1,6 +1,7 @@
 package com.aliothmoon.maameow.schedule.service
 
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
+import com.aliothmoon.maameow.domain.models.OverlayControlMode
 import com.aliothmoon.maameow.data.preferences.TaskChainState
 import com.aliothmoon.maameow.domain.service.MaaCompositionService
 import com.aliothmoon.maameow.domain.state.MaaExecutionState
@@ -28,7 +29,8 @@ class ForegroundScheduleStarter(
     private val chainState: TaskChainState,
     private val compositionService: MaaCompositionService,
     private val triggerLogger: ScheduleTriggerLogger,
-    private val scheduleRepository: ScheduleStrategyRepository
+    private val scheduleRepository: ScheduleStrategyRepository,
+    private val appSettingsManager: AppSettingsManager,
 ) {
     private val mutex = Mutex()
 
@@ -55,30 +57,36 @@ class ForegroundScheduleStarter(
                 chainState.switchProfile(request.profileId)
             }
 
-            // 倒计时并同步到悬浮球
+            // 无论哪种模式，都执行倒计时等待到整点
             var isStartingNow = false
+            val isFloatBall = appSettingsManager.overlayControlMode.value == OverlayControlMode.FLOAT_BALL
 
-            triggerLogger.append("开始倒计时 (${ScheduledExecutionRequest.COUNTDOWN_SECONDS}s)")
+            if (isFloatBall) {
+                triggerLogger.append("开始倒计时 (${ScheduledExecutionRequest.COUNTDOWN_SECONDS}s)")
+                try {
+                    overlayController.setTemporaryCountdownListener {
+                        isStartingNow = true
+                        triggerLogger.append("用户点击立即执行")
+                    }
 
-            try {
-                overlayController.setTemporaryCountdownListener {
-                    isStartingNow = true
-                    triggerLogger.append("用户点击立即执行")
+                    for (remaining in ScheduledExecutionRequest.COUNTDOWN_SECONDS downTo 1) {
+                        if (isStartingNow) break
+                        overlayController.updateCountdownState(
+                            CountdownState.Counting(request.strategyName, remaining)
+                        )
+                        delay(1000)
+                    }
+                } finally {
+                    overlayController.updateCountdownState(CountdownState.Idle)
+                    overlayController.setTemporaryCountdownListener(null)
                 }
-
-                for (remaining in ScheduledExecutionRequest.COUNTDOWN_SECONDS downTo 1) {
-                    if (isStartingNow) break
-                    overlayController.updateCountdownState(
-                        CountdownState.Counting(request.strategyName, remaining)
-                    )
-                    delay(1000)
-                }
-            } finally {
-                overlayController.updateCountdownState(CountdownState.Idle)
-                overlayController.setTemporaryCountdownListener(null)
+            } else {
+                // 非悬浮球模式：静默等待，不更新 UI（但仍保证任务在整点开始）
+                triggerLogger.append("非悬浮球模式，静默倒计时")
+                delay(ScheduledExecutionRequest.COUNTDOWN_SECONDS * 1000L)
             }
-
             triggerLogger.append("倒计时结束，开始准备执行")
+
             val chain = chainState.chain.value.filter { it.enabled }
             if (chain.isEmpty()) {
                 val emptyMsg = "关联的任务配置中没有启用任务"

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ForegroundScheduleStarter.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ForegroundScheduleStarter.kt
@@ -15,6 +15,8 @@ import com.aliothmoon.maameow.schedule.model.ExecutionResult
 import com.aliothmoon.maameow.schedule.model.ScheduledExecutionRequest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
 
 /**
@@ -28,96 +30,102 @@ class ForegroundScheduleStarter(
     private val triggerLogger: ScheduleTriggerLogger,
     private val scheduleRepository: ScheduleStrategyRepository
 ) {
-    suspend fun executeSilentStart(request: ScheduledExecutionRequest) {
-        Timber.i("SilentStarter: 接管前台悬浮球定时请求 ${request.requestId}")
+    private val mutex = Mutex()
 
-        if (compositionService.state.value == MaaExecutionState.RUNNING ||
-            compositionService.state.value == MaaExecutionState.STARTING) {
-            if (request.forceStart) {
-                triggerLogger.append("强制启动: 停止当前运行任务")
-                compositionService.stop()
-            } else {
-                val busyMsg = "有任务正在运行，跳过定时执行"
-                triggerLogger.append(busyMsg)
-                recordResult(request, ExecutionResult.SKIPPED_BUSY, busyMsg)
+    suspend fun executeSilentStart(request: ScheduledExecutionRequest) {
+        mutex.withLock {
+            Timber.i("SilentStarter: 接管前台悬浮球定时请求 ${request.requestId}")
+
+            if (compositionService.state.value == MaaExecutionState.RUNNING ||
+                compositionService.state.value == MaaExecutionState.STARTING) {
+                if (request.forceStart) {
+                    triggerLogger.append("强制启动: 停止当前运行任务")
+                    compositionService.stop()
+                } else {
+                    val busyMsg = "有任务正在运行，跳过定时执行"
+                    triggerLogger.append(busyMsg)
+                    recordResult(request, ExecutionResult.SKIPPED_BUSY, busyMsg)
+                    return
+                }
+            }
+
+            chainState.isLoaded.first { it }
+            if (chainState.activeProfileId.value != request.profileId) {
+                triggerLogger.append("切换任务配置: ${request.profileId}")
+                chainState.switchProfile(request.profileId)
+            }
+
+            // 倒计时并同步到悬浮球
+            var isStartingNow = false
+
+            triggerLogger.append("开始倒计时 (${ScheduledExecutionRequest.COUNTDOWN_SECONDS}s)")
+
+            try {
+                overlayController.setTemporaryCountdownListener {
+                    isStartingNow = true
+                    triggerLogger.append("用户点击立即执行")
+                }
+
+                for (remaining in ScheduledExecutionRequest.COUNTDOWN_SECONDS downTo 1) {
+                    if (isStartingNow) break
+                    overlayController.updateCountdownState(
+                        CountdownState.Counting(request.strategyName, remaining)
+                    )
+                    delay(1000)
+                }
+            } finally {
+                overlayController.updateCountdownState(CountdownState.Idle)
+                overlayController.setTemporaryCountdownListener(null)
+            }
+
+            triggerLogger.append("倒计时结束，开始准备执行")
+            val chain = chainState.chain.value.filter { it.enabled }
+            if (chain.isEmpty()) {
+                val emptyMsg = "关联的任务配置中没有启用任务"
+                triggerLogger.append(emptyMsg)
+                recordResult(request, ExecutionResult.FAILED_VALIDATION, emptyMsg)
                 return
             }
-        }
 
-        chainState.isLoaded.first { it }
-        if (chainState.activeProfileId.value != request.profileId) {
-            triggerLogger.append("切换任务配置: ${request.profileId}")
-            chainState.switchProfile(request.profileId)
-        }
+            try {
+                val startContext = TaskStartContext(mode = TaskStartMode.SCHEDULED)
+                val decision = prepareTaskStartUseCase.invoke(chain, startContext)
 
-        // 倒计时并同步到悬浮球
-        var isStartingNow = false
-        val originalClick = overlayController.onCountdownClick
-        overlayController.onCountdownClick = {
-            isStartingNow = true
-            triggerLogger.append("用户点击立即执行")
-        }
+                when (decision) {
+                    is TaskStartDecision.Ready -> {
+                        triggerLogger.append("前置条件通过，启用任务 ${chain.size} 项，正在启动 MAA 核心服务...")
 
-        triggerLogger.append("开始倒计时 (${ScheduledExecutionRequest.COUNTDOWN_SECONDS}s)")
+                        val result = compositionService.start(
+                            tasks = decision.plan.params,
+                            clientType = decision.plan.clientType,
+                            isScheduled = true
+                        )
 
-        for (remaining in ScheduledExecutionRequest.COUNTDOWN_SECONDS downTo 1) {
-            if (isStartingNow) break
-            overlayController.updateCountdownState(
-                CountdownState.Counting(request.strategyName, remaining)
-            )
-            delay(1000)
-        }
-
-        overlayController.updateCountdownState(CountdownState.Idle)
-        overlayController.onCountdownClick = originalClick
-
-        triggerLogger.append("倒计时结束，开始准备执行")
-        val chain = chainState.chain.value.filter { it.enabled }
-        if (chain.isEmpty()) {
-            val emptyMsg = "关联的任务配置中没有启用任务"
-            triggerLogger.append(emptyMsg)
-            recordResult(request, ExecutionResult.FAILED_VALIDATION, emptyMsg)
-            return
-        }
-
-        try {
-            val startContext = TaskStartContext(mode = TaskStartMode.SCHEDULED)
-            val decision = prepareTaskStartUseCase.invoke(chain, startContext)
-
-            when (decision) {
-                is TaskStartDecision.Ready -> {
-                    triggerLogger.append("前置条件通过，启用任务 ${chain.size} 项，正在启动 MAA 核心服务...")
-
-                    val result = compositionService.start(
-                        tasks = decision.plan.params,
-                        clientType = decision.plan.clientType,
-                        isScheduled = true
-                    )
-
-                    if (result is MaaCompositionService.StartResult.Success) {
-                        triggerLogger.append("任务启动成功，MAA版本: ${result.version}")
-                        recordResult(request, ExecutionResult.STARTED)
-                    } else {
-                        val failMsg = "MaaCore 启动失败: $result"
-                        triggerLogger.append(failMsg)
-                        recordResult(request, ExecutionResult.FAILED_START, failMsg)
+                        if (result is MaaCompositionService.StartResult.Success) {
+                            triggerLogger.append("任务启动成功，MAA版本: ${result.version}")
+                            recordResult(request, ExecutionResult.STARTED)
+                        } else {
+                            val failMsg = "MaaCore 启动失败: $result"
+                            triggerLogger.append(failMsg)
+                            recordResult(request, ExecutionResult.FAILED_START, failMsg)
+                        }
+                    }
+                    is TaskStartDecision.Blocked -> {
+                        val blockMsg = "任务被拦截，原因: ${decision.reason}"
+                        triggerLogger.append(blockMsg)
+                        recordResult(request, ExecutionResult.FAILED_VALIDATION, blockMsg)
+                    }
+                    is TaskStartDecision.RequiresConfirmation -> {
+                        val confirmMsg = "需要确认，但前台模式无法自动确认，取消执行"
+                        triggerLogger.append(confirmMsg)
+                        recordResult(request, ExecutionResult.FAILED_VALIDATION, confirmMsg)
                     }
                 }
-                is TaskStartDecision.Blocked -> {
-                    val blockMsg = "任务被拦截，原因: ${decision.reason}"
-                    triggerLogger.append(blockMsg)
-                    recordResult(request, ExecutionResult.FAILED_VALIDATION, blockMsg)
-                }
-                is TaskStartDecision.RequiresConfirmation -> {
-                    val confirmMsg = "需要确认，但前台模式无法自动确认，取消执行"
-                    triggerLogger.append(confirmMsg)
-                    recordResult(request, ExecutionResult.FAILED_VALIDATION, confirmMsg)
-                }
+            } catch (e: Exception) {
+                val errMsg = "解析任务并启动时发生异常: ${e.message}"
+                triggerLogger.append(errMsg)
+                recordResult(request, ExecutionResult.FAILED_START, errMsg)
             }
-        } catch (e: Exception) {
-            val errMsg = "解析任务并启动时发生异常: ${e.message}"
-            triggerLogger.append(errMsg)
-            recordResult(request, ExecutionResult.FAILED_START, errMsg)
         }
     }
 

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ForegroundScheduleStarter.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ForegroundScheduleStarter.kt
@@ -16,9 +16,8 @@ import com.aliothmoon.maameow.schedule.model.ExecutionResult
 import com.aliothmoon.maameow.schedule.model.ScheduledExecutionRequest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * 专供前台悬浮球模式使用的静默启动器。
@@ -32,10 +31,15 @@ class ForegroundScheduleStarter(
     private val scheduleRepository: ScheduleStrategyRepository,
     private val appSettingsManager: AppSettingsManager,
 ) {
-    private val mutex = Mutex()
+    private val executing = AtomicBoolean(false)
 
     suspend fun executeSilentStart(request: ScheduledExecutionRequest) {
-        mutex.withLock {
+        if (!executing.compareAndSet(false, true)) {
+            triggerLogger.append("已有定时任务正在准备执行，跳过本次请求")
+            recordResult(request, ExecutionResult.SKIPPED_BUSY, "另一个定时任务正在执行")
+            return
+        }
+        try {
             Timber.i("SilentStarter: 接管前台悬浮球定时请求 ${request.requestId}")
 
             if (compositionService.state.value == MaaExecutionState.RUNNING ||
@@ -134,6 +138,8 @@ class ForegroundScheduleStarter(
                 triggerLogger.append(errMsg)
                 recordResult(request, ExecutionResult.FAILED_START, errMsg)
             }
+        } finally {
+            executing.set(false)
         }
     }
 

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ForegroundScheduleStarter.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ForegroundScheduleStarter.kt
@@ -1,0 +1,139 @@
+package com.aliothmoon.maameow.schedule.service
+
+import com.aliothmoon.maameow.data.preferences.AppSettingsManager
+import com.aliothmoon.maameow.data.preferences.TaskChainState
+import com.aliothmoon.maameow.domain.service.MaaCompositionService
+import com.aliothmoon.maameow.domain.state.MaaExecutionState
+import com.aliothmoon.maameow.domain.usecase.PrepareTaskStartUseCase
+import com.aliothmoon.maameow.domain.usecase.TaskStartContext
+import com.aliothmoon.maameow.domain.usecase.TaskStartDecision
+import com.aliothmoon.maameow.domain.usecase.TaskStartMode
+import com.aliothmoon.maameow.overlay.OverlayController
+import com.aliothmoon.maameow.schedule.data.ScheduleStrategyRepository
+import com.aliothmoon.maameow.schedule.model.CountdownState
+import com.aliothmoon.maameow.schedule.model.ExecutionResult
+import com.aliothmoon.maameow.schedule.model.ScheduledExecutionRequest
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import timber.log.Timber
+
+/**
+ * 专供前台悬浮球模式使用的静默启动器。
+ */
+class ForegroundScheduleStarter(
+    private val overlayController: OverlayController,
+    private val prepareTaskStartUseCase: PrepareTaskStartUseCase,
+    private val chainState: TaskChainState,
+    private val compositionService: MaaCompositionService,
+    private val triggerLogger: ScheduleTriggerLogger,
+    private val scheduleRepository: ScheduleStrategyRepository
+) {
+    suspend fun executeSilentStart(request: ScheduledExecutionRequest) {
+        Timber.i("SilentStarter: 接管前台悬浮球定时请求 ${request.requestId}")
+
+        if (compositionService.state.value == MaaExecutionState.RUNNING ||
+            compositionService.state.value == MaaExecutionState.STARTING) {
+            if (request.forceStart) {
+                triggerLogger.append("强制启动: 停止当前运行任务")
+                compositionService.stop()
+            } else {
+                val busyMsg = "有任务正在运行，跳过定时执行"
+                triggerLogger.append(busyMsg)
+                recordResult(request, ExecutionResult.SKIPPED_BUSY, busyMsg)
+                return
+            }
+        }
+
+        chainState.isLoaded.first { it }
+        if (chainState.activeProfileId.value != request.profileId) {
+            triggerLogger.append("切换任务配置: ${request.profileId}")
+            chainState.switchProfile(request.profileId)
+        }
+
+        // 倒计时并同步到悬浮球
+        var isStartingNow = false
+        val originalClick = overlayController.onCountdownClick
+        overlayController.onCountdownClick = {
+            isStartingNow = true
+            triggerLogger.append("用户点击立即执行")
+        }
+
+        triggerLogger.append("开始倒计时 (${ScheduledExecutionRequest.COUNTDOWN_SECONDS}s)")
+
+        for (remaining in ScheduledExecutionRequest.COUNTDOWN_SECONDS downTo 1) {
+            if (isStartingNow) break
+            overlayController.updateCountdownState(
+                CountdownState.Counting(request.strategyName, remaining)
+            )
+            delay(1000)
+        }
+
+        overlayController.updateCountdownState(CountdownState.Idle)
+        overlayController.onCountdownClick = originalClick
+
+        triggerLogger.append("倒计时结束，开始准备执行")
+        val chain = chainState.chain.value.filter { it.enabled }
+        if (chain.isEmpty()) {
+            val emptyMsg = "关联的任务配置中没有启用任务"
+            triggerLogger.append(emptyMsg)
+            recordResult(request, ExecutionResult.FAILED_VALIDATION, emptyMsg)
+            return
+        }
+
+        try {
+            val startContext = TaskStartContext(mode = TaskStartMode.SCHEDULED)
+            val decision = prepareTaskStartUseCase.invoke(chain, startContext)
+
+            when (decision) {
+                is TaskStartDecision.Ready -> {
+                    triggerLogger.append("前置条件通过，启用任务 ${chain.size} 项，正在启动 MAA 核心服务...")
+
+                    val result = compositionService.start(
+                        tasks = decision.plan.params,
+                        clientType = decision.plan.clientType,
+                        isScheduled = true
+                    )
+
+                    if (result is MaaCompositionService.StartResult.Success) {
+                        triggerLogger.append("任务启动成功，MAA版本: ${result.version}")
+                        recordResult(request, ExecutionResult.STARTED)
+                    } else {
+                        val failMsg = "MaaCore 启动失败: $result"
+                        triggerLogger.append(failMsg)
+                        recordResult(request, ExecutionResult.FAILED_START, failMsg)
+                    }
+                }
+                is TaskStartDecision.Blocked -> {
+                    val blockMsg = "任务被拦截，原因: ${decision.reason}"
+                    triggerLogger.append(blockMsg)
+                    recordResult(request, ExecutionResult.FAILED_VALIDATION, blockMsg)
+                }
+                is TaskStartDecision.RequiresConfirmation -> {
+                    val confirmMsg = "需要确认，但前台模式无法自动确认，取消执行"
+                    triggerLogger.append(confirmMsg)
+                    recordResult(request, ExecutionResult.FAILED_VALIDATION, confirmMsg)
+                }
+            }
+        } catch (e: Exception) {
+            val errMsg = "解析任务并启动时发生异常: ${e.message}"
+            triggerLogger.append(errMsg)
+            recordResult(request, ExecutionResult.FAILED_START, errMsg)
+        }
+    }
+
+    /**
+     * 向日志器和数据库同时写入最终状态，闭合日志会话
+     */
+    private suspend fun recordResult(
+        request: ScheduledExecutionRequest,
+        result: ExecutionResult,
+        message: String? = null
+    ) {
+        triggerLogger.end(result, message)
+        scheduleRepository.recordExecutionResult(
+            strategyId = request.strategyId,
+            result = result,
+            message = message
+        )
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduleExecutionService.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduleExecutionService.kt
@@ -32,7 +32,6 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.android.ext.android.inject
 import timber.log.Timber
-import com.aliothmoon.maameow.schedule.service.ScheduleTriggerLogger
 
 class ScheduleExecutionService : Service() {
 
@@ -41,7 +40,7 @@ class ScheduleExecutionService : Service() {
         private const val NOTIFICATION_ID = 9001
         private const val RESULT_NOTIFICATION_ID = 9002
         private const val CHANNEL_ID = "schedule_execution"
-        private val dataReadyTimeout = 5.seconds
+        private const val DATA_READY_TIMEOUT_MS = 5_000L
     }
 
     private val repository: ScheduleStrategyRepository by inject()
@@ -109,7 +108,7 @@ class ScheduleExecutionService : Service() {
         )
 
         triggerLogger.append("检查锁屏状态...")
-        val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+        val keyguardManager = getSystemService(KEYGUARD_SERVICE) as KeyguardManager
         if (keyguardManager.isKeyguardLocked) {
             Timber.i("$TAG: 设备锁屏中，跳过本次定时执行: %s", strategy.name)
             triggerLogger.append("设备锁屏，跳过本次执行")
@@ -168,7 +167,7 @@ class ScheduleExecutionService : Service() {
     }
 
     private suspend fun awaitStrategy(strategyId: String): ScheduleStrategy? {
-        return withTimeoutOrNull(dataReadyTimeout) {
+        return withTimeoutOrNull(DATA_READY_TIMEOUT_MS) {
             repository.isLoaded.first { it }
             repository.getById(strategyId)
         }
@@ -193,7 +192,7 @@ class ScheduleExecutionService : Service() {
     }
 
     private fun ensureNotificationChannel() {
-        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         val channel = NotificationChannel(
             CHANNEL_ID,
             getString(R.string.notification_channel_schedule),
@@ -248,7 +247,7 @@ class ScheduleExecutionService : Service() {
             .setContentIntent(buildContentIntent())
             .setAutoCancel(true)
             .build()
-        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         manager.notify(RESULT_NOTIFICATION_ID, notification)
     }
 

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduleExecutionService.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduleExecutionService.kt
@@ -15,6 +15,9 @@ import androidx.core.app.NotificationCompat
 import com.aliothmoon.maameow.MainActivity
 import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.manager.RemoteServiceManager
+import com.aliothmoon.maameow.data.preferences.AppSettingsManager
+import com.aliothmoon.maameow.domain.models.OverlayControlMode
+import com.aliothmoon.maameow.domain.models.RunMode
 import com.aliothmoon.maameow.schedule.data.ScheduleStrategyRepository
 import com.aliothmoon.maameow.schedule.model.ExecutionResult
 import com.aliothmoon.maameow.schedule.model.ScheduleStrategy
@@ -25,6 +28,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.android.ext.android.inject
 import timber.log.Timber
@@ -37,13 +41,16 @@ class ScheduleExecutionService : Service() {
         private const val NOTIFICATION_ID = 9001
         private const val RESULT_NOTIFICATION_ID = 9002
         private const val CHANNEL_ID = "schedule_execution"
-        private const val DATA_READY_TIMEOUT_MS = 5_000L
+        private val dataReadyTimeout = 5.seconds
     }
 
     private val repository: ScheduleStrategyRepository by inject()
     private val alarmManager: ScheduleAlarmManager by inject()
     private val triggerLogger: ScheduleTriggerLogger by inject()
+    private val appSettingsManager: AppSettingsManager by inject()
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val silentStarter: ForegroundScheduleStarter by inject()
+
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -123,18 +130,30 @@ class ScheduleExecutionService : Service() {
         }
         triggerLogger.append("设备未锁屏，连接服务...")
 
-        val ctx = this
-        val launched = withTimeoutOrNull(10_000L) {
-            runCatching {
-                RemoteServiceManager.useRemoteService(timeoutMs = 8_000L) {
-                    it.startActivity(request.toLaunchIntent(ctx))
+        // 前台 + 悬浮球 + 允许前台定时：不拉起 Activity 通过 Starter 提交
+        val isForegroundFloatBall = appSettingsManager.runMode.value == RunMode.FOREGROUND
+                && appSettingsManager.overlayControlMode.value == OverlayControlMode.FLOAT_BALL
+                && appSettingsManager.allowForegroundScheduledTask.value
+
+        var launched = true
+
+        if (isForegroundFloatBall) {
+            triggerLogger.append("前台悬浮球模式，直接提交定时请求")
+            silentStarter.executeSilentStart(request)
+        } else {
+            val ctx = this
+            launched = withTimeoutOrNull(10.seconds) {
+                runCatching {
+                    RemoteServiceManager.useRemoteService(timeoutMs = 8_000L) {
+                        it.startActivity(request.toLaunchIntent(ctx))
+                    }
+                }.getOrElse { error ->
+                    Timber.w(error, "$TAG: 拉起界面前连接服务失败")
+                    triggerLogger.append("连接服务失败: ${error.message}")
+                    false
                 }
-            }.getOrElse { error ->
-                Timber.w(error, "$TAG: 拉起界面前连接服务失败")
-                triggerLogger.append("连接服务失败: ${error.message}")
-                false
-            }
-        } ?: false
+            } ?: false
+        }
 
         if (!launched) {
             triggerLogger.append("未能拉起界面")
@@ -150,7 +169,7 @@ class ScheduleExecutionService : Service() {
     }
 
     private suspend fun awaitStrategy(strategyId: String): ScheduleStrategy? {
-        return withTimeoutOrNull(DATA_READY_TIMEOUT_MS) {
+        return withTimeoutOrNull(dataReadyTimeout) {
             repository.isLoaded.first { it }
             repository.getById(strategyId)
         }

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduleExecutionService.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduleExecutionService.kt
@@ -16,7 +16,7 @@ import com.aliothmoon.maameow.MainActivity
 import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.manager.RemoteServiceManager
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
-import com.aliothmoon.maameow.domain.models.OverlayControlMode
+
 import com.aliothmoon.maameow.domain.models.RunMode
 import com.aliothmoon.maameow.schedule.data.ScheduleStrategyRepository
 import com.aliothmoon.maameow.schedule.model.ExecutionResult
@@ -130,15 +130,14 @@ class ScheduleExecutionService : Service() {
         }
         triggerLogger.append("设备未锁屏，连接服务...")
 
-        // 前台 + 悬浮球 + 允许前台定时：不拉起 Activity 通过 Starter 提交
-        val isForegroundFloatBall = appSettingsManager.runMode.value == RunMode.FOREGROUND
-                && appSettingsManager.overlayControlMode.value == OverlayControlMode.FLOAT_BALL
+        // 前台 + 允许前台定时：不拉起 Activity，通过 Starter 静默提交
+        val isForegroundSilent = appSettingsManager.runMode.value == RunMode.FOREGROUND
                 && appSettingsManager.allowForegroundScheduledTask.value
 
         var launched = true
 
-        if (isForegroundFloatBall) {
-            triggerLogger.append("前台悬浮球模式，直接提交定时请求")
+        if (isForegroundSilent) {
+            triggerLogger.append("前台模式（已允许静默），直接提交定时请求")
             silentStarter.executeSilentStart(request)
         } else {
             val ctx = this

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduledLaunchCoordinator.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduledLaunchCoordinator.kt
@@ -125,8 +125,11 @@ class ScheduledLaunchCoordinator(
             }
         }
 
-        if (appSettingsManager.runMode.value != RunMode.BACKGROUND) {
-            reject(request, ExecutionResult.FAILED_VALIDATION, "当前运行模式不是后台模式")
+        val isBackgroundMode = appSettingsManager.runMode.value == RunMode.BACKGROUND
+        val allowForeground = appSettingsManager.allowForegroundScheduledTask.value
+
+        if (!isBackgroundMode && !allowForeground) {
+            reject(request, ExecutionResult.FAILED_VALIDATION, "当前运行模式不是后台模式，且未开启“允许前台定时任务”开关")
             return
         }
 

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduledLaunchCoordinator.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduledLaunchCoordinator.kt
@@ -2,7 +2,6 @@ package com.aliothmoon.maameow.schedule.service
 
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
 import com.aliothmoon.maameow.data.preferences.TaskChainState
-import com.aliothmoon.maameow.domain.models.OverlayControlMode
 import com.aliothmoon.maameow.domain.models.RunMode
 import com.aliothmoon.maameow.domain.service.MaaCompositionService
 import com.aliothmoon.maameow.domain.state.MaaExecutionState
@@ -128,15 +127,9 @@ class ScheduledLaunchCoordinator(
 
         val isBackgroundMode = appSettingsManager.runMode.value == RunMode.BACKGROUND
         val allowForeground = appSettingsManager.allowForegroundScheduledTask.value
-        val isFloatBall = appSettingsManager.overlayControlMode.value == OverlayControlMode.FLOAT_BALL
-
         if (!isBackgroundMode) {
             if (!allowForeground) {
                 reject(request, ExecutionResult.FAILED_VALIDATION, "当前运行模式不是后台模式，且未开启“允许前台定时任务”开关")
-                return
-            }
-            if (!isFloatBall) {
-                reject(request, ExecutionResult.FAILED_VALIDATION, "当前运行模式不是后台模式，且控制模式不是悬浮球模式")
                 return
             }
         }

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduledLaunchCoordinator.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduledLaunchCoordinator.kt
@@ -125,13 +125,15 @@ class ScheduledLaunchCoordinator(
             }
         }
 
-        val isBackgroundMode = appSettingsManager.runMode.value == RunMode.BACKGROUND
+        val isForegroundMode = appSettingsManager.runMode.value == RunMode.FOREGROUND
         val allowForeground = appSettingsManager.allowForegroundScheduledTask.value
-        if (!isBackgroundMode) {
-            if (!allowForeground) {
-                reject(request, ExecutionResult.FAILED_VALIDATION, "当前运行模式不是后台模式，且未开启“允许前台定时任务”开关")
-                return
-            }
+        if (isForegroundMode && !allowForeground) {
+            reject(
+                request,
+                ExecutionResult.FAILED_VALIDATION,
+                "当前运行模式不是后台模式，且未开启“允许前台定时任务”开关"
+            )
+            return
         }
 
         triggerLogger.append("等待任务配置加载...")

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduledLaunchCoordinator.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/service/ScheduledLaunchCoordinator.kt
@@ -2,6 +2,7 @@ package com.aliothmoon.maameow.schedule.service
 
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
 import com.aliothmoon.maameow.data.preferences.TaskChainState
+import com.aliothmoon.maameow.domain.models.OverlayControlMode
 import com.aliothmoon.maameow.domain.models.RunMode
 import com.aliothmoon.maameow.domain.service.MaaCompositionService
 import com.aliothmoon.maameow.domain.state.MaaExecutionState
@@ -127,10 +128,17 @@ class ScheduledLaunchCoordinator(
 
         val isBackgroundMode = appSettingsManager.runMode.value == RunMode.BACKGROUND
         val allowForeground = appSettingsManager.allowForegroundScheduledTask.value
+        val isFloatBall = appSettingsManager.overlayControlMode.value == OverlayControlMode.FLOAT_BALL
 
-        if (!isBackgroundMode && !allowForeground) {
-            reject(request, ExecutionResult.FAILED_VALIDATION, "当前运行模式不是后台模式，且未开启“允许前台定时任务”开关")
-            return
+        if (!isBackgroundMode) {
+            if (!allowForeground) {
+                reject(request, ExecutionResult.FAILED_VALIDATION, "当前运行模式不是后台模式，且未开启“允许前台定时任务”开关")
+                return
+            }
+            if (!isFloatBall) {
+                reject(request, ExecutionResult.FAILED_VALIDATION, "当前运行模式不是后台模式，且控制模式不是悬浮球模式")
+                return
+            }
         }
 
         triggerLogger.append("等待任务配置加载...")

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -62,6 +62,8 @@
     <string name="settings_deployment_with_pause_tip">Hold ESC to pause the game while deploying operators for higher precision. Disable if ESC injection misbehaves or some operators are not placed correctly; deployment will fall back to plain swipe</string>
     <string name="settings_force_fullscreen_on_virtual_display">Force FULLSCREEN mode</string>
     <string name="settings_exclude_from_recents_on_background">Hide game from Recents when running</string>
+    <string name="settings_allow_foreground_scheduled_task">Allow scheduled tasks in foreground</string>
+    <string name="settings_allow_foreground_scheduled_task_desc">Allow scheduled tasks even when not in background mode, requires float ball control mode. Countdown will be shown on the float ball — tap it to start immediately. May interfere with current operations. Suitable for cloud phones or dedicated farming devices</string>
     <string name="settings_tasks_override_title">MAA Task Override</string>
     <string name="settings_tasks_override_desc">Do not modify unless you know what you are doing — incorrect values will break MAA</string>
     <string name="settings_tasks_override_edit_title">Edit Config JSON</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -63,7 +63,6 @@
     <string name="settings_force_fullscreen_on_virtual_display">Force FULLSCREEN mode</string>
     <string name="settings_exclude_from_recents_on_background">Hide game from Recents when running</string>
     <string name="settings_allow_foreground_scheduled_task">Allow scheduled tasks in foreground</string>
-    <string name="settings_allow_foreground_scheduled_task_desc">Allows scheduled tasks tto trigger in foreground mode (ap the float ball to start immediately, other modes execute silently)</string>
     <string name="settings_tasks_override_title">MAA Task Override</string>
     <string name="settings_tasks_override_desc">Do not modify unless you know what you are doing — incorrect values will break MAA</string>
     <string name="settings_tasks_override_edit_title">Edit Config JSON</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -63,7 +63,7 @@
     <string name="settings_force_fullscreen_on_virtual_display">Force FULLSCREEN mode</string>
     <string name="settings_exclude_from_recents_on_background">Hide game from Recents when running</string>
     <string name="settings_allow_foreground_scheduled_task">Allow scheduled tasks in foreground</string>
-    <string name="settings_allow_foreground_scheduled_task_desc">Allow scheduled tasks even when not in background mode, requires float ball control mode. Countdown will be shown on the float ball — tap it to start immediately. May interfere with current operations. Suitable for cloud phones or dedicated farming devices</string>
+    <string name="settings_allow_foreground_scheduled_task_desc">Allows scheduled tasks tto trigger in foreground mode (ap the float ball to start immediately, other modes execute silently)</string>
     <string name="settings_tasks_override_title">MAA Task Override</string>
     <string name="settings_tasks_override_desc">Do not modify unless you know what you are doing — incorrect values will break MAA</string>
     <string name="settings_tasks_override_edit_title">Edit Config JSON</string>
@@ -1276,4 +1276,12 @@
     <string name="announcement_dont_show_again_hint">Please read the full announcement and stay for %1$d seconds to enable</string>
     <string name="announcement_scroll_to_bottom_hint">Please read the full announcement first</string>
     <string name="announcement_confirm">Confirm</string>
+
+    <!-- i18n: overlay floatball -->
+    <string name="overlay_floatball_countdown_desc">Countdown, %1$s seconds remaining</string>
+    <string name="overlay_floatball_state_idle">Idle</string>
+    <string name="overlay_floatball_state_starting">Starting</string>
+    <string name="overlay_floatball_state_running">Running</string>
+    <string name="overlay_floatball_state_stopping">Stopping</string>
+    <string name="overlay_floatball_state_error">Error</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,6 +259,8 @@
     <string name="settings_deployment_with_pause_tip">部署干员前模拟按住 ESC 暂停游戏，提高部署精确度。如遇 ESC 注入异常或部分干员部署不到位，可关闭改用普通滑动</string>
     <string name="settings_force_fullscreen_on_virtual_display">强制 FULLSCREEN 模式</string>
     <string name="settings_exclude_from_recents_on_background">游戏不在后台中展示</string>
+    <string name="settings_allow_foreground_scheduled_task">允许在前台模式执行定时任务</string>
+    <string name="settings_allow_foreground_scheduled_task_desc">在前台运行模式下也可触发定时任务，需使用悬浮球控制模式。启用后，倒计时将以数字形式显示在悬浮球上，点击悬浮球可立即执行。可能干扰当前操作，适用于云手机或备用挂机设备</string>
     <string name="settings_tasks_override_title">MAA 任务覆盖</string>
     <string name="settings_tasks_override_desc">如果你不知道这是什么请不要修改，会导致 MAA 无法正常工作</string>
     <string name="settings_tasks_override_edit_title">编辑配置 JSON</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,7 +260,6 @@
     <string name="settings_force_fullscreen_on_virtual_display">强制 FULLSCREEN 模式</string>
     <string name="settings_exclude_from_recents_on_background">游戏不在后台中展示</string>
     <string name="settings_allow_foreground_scheduled_task">允许在前台模式执行定时任务</string>
-    <string name="settings_allow_foreground_scheduled_task_desc">在前台运行模式下也可以触发定时任务（悬浮球模式可点击立即执行，其他模式将静默执行）</string>
     <string name="settings_tasks_override_title">MAA 任务覆盖</string>
     <string name="settings_tasks_override_desc">如果你不知道这是什么请不要修改，会导致 MAA 无法正常工作</string>
     <string name="settings_tasks_override_edit_title">编辑配置 JSON</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,7 +260,7 @@
     <string name="settings_force_fullscreen_on_virtual_display">强制 FULLSCREEN 模式</string>
     <string name="settings_exclude_from_recents_on_background">游戏不在后台中展示</string>
     <string name="settings_allow_foreground_scheduled_task">允许在前台模式执行定时任务</string>
-    <string name="settings_allow_foreground_scheduled_task_desc">在前台运行模式下也可触发定时任务，需使用悬浮球控制模式。启用后，倒计时将以数字形式显示在悬浮球上，点击悬浮球可立即执行。可能干扰当前操作，适用于云手机或备用挂机设备</string>
+    <string name="settings_allow_foreground_scheduled_task_desc">在前台运行模式下也可以触发定时任务（悬浮球模式可点击立即执行，其他模式将静默执行）</string>
     <string name="settings_tasks_override_title">MAA 任务覆盖</string>
     <string name="settings_tasks_override_desc">如果你不知道这是什么请不要修改，会导致 MAA 无法正常工作</string>
     <string name="settings_tasks_override_edit_title">编辑配置 JSON</string>
@@ -1328,4 +1328,12 @@
     <string name="announcement_dont_show_again_hint">请阅读完公告并停留 %1$d 秒后可勾选</string>
     <string name="announcement_scroll_to_bottom_hint">请阅读完公告内容</string>
     <string name="announcement_confirm">确认</string>
+
+    <!-- i18n: overlay floatball -->
+    <string name="overlay_floatball_countdown_desc">正在倒计时，剩余 %1$s 秒</string>
+    <string name="overlay_floatball_state_idle">空闲</string>
+    <string name="overlay_floatball_state_starting">启动中</string>
+    <string name="overlay_floatball_state_running">运行中</string>
+    <string name="overlay_floatball_state_stopping">停止中</string>
+    <string name="overlay_floatball_state_error">错误</string>
 </resources>


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)。

## 关联 Issue

Related #128 

## 变更摘要

针对前台模式（悬浮球控制）无法运行定时调度任务的问题，实现了前台模式下定时任务的静默启动：
* **配置层**：在 `AppSettings` 中新增 `allowForegroundScheduledTask` 开关（允许前台执行定时任务），并补充了中英文 `strings.xml` 资源描述。
* **业务层**：新增 `ForegroundScheduleStarter` 作为前台定时请求的接管中心。在 `ScheduleExecutionService` 中引入前置判断（前台+悬浮球+开关开启），不拉起完整 Activity，而是由 Starter 开启任务分发与防并发拦截。
* **核心拦截**：鉴于做较小的修改在我的能力范围之内无法在应用处于后台时正确获取屏幕朝向，解除了 `MaaCompositionService` 原先在前台模式下对定时非横屏 precondition 校验的限制（新增 `isScheduled` 标志位，仅被定时任务拉起时才忽略横屏判断），确保调度管道畅通。
* **UI 层 (Compose)**：重构了 `FloatBall` 的动态渲染逻辑，引入 `CountdownState` 收集器。当定时剩下 30s 触发时，悬浮球会切换为橙色并实时显示秒级倒计时，支持点击悬浮球直接跳过倒计时立即执行（`onScheduledStartNow`），倒计时结束后自动还原状态。
* **环境优化**：在全局 `.gitignore` 中补充了对 `/gradle/gradle-daemon-jvm.properties` 的本地环境隔离规则。

## 验证

* **测试设备**：小米 Note 13 5G (安卓 15, Shizuku方式启动)
* **运行模式**：RunMode.FOREGROUND + OverlayControlMode.FLOAT_BALL + 开启“允许前台执行定时任务”
* **权限方案**：Shizuku
* **验证路径**：

1. 开启 MAA-Meow，授权Shizuku，设置中打开“允许前台执行定时任务”开关，打开前台模式，并调整为适配的分辨率。
2. 打开悬浮窗，设置任务为“开始唤醒”和“自动公招”，并手动启动明日方舟。
3. 配置于 5 分钟后触发的定时任务。
4. 到点后，悬浮球完美变为橙色并开始显示数字倒计时。
5.1. 倒计时期间点击悬浮球，成功触发 `onScheduledStartNow()`，倒计时终止，悬浮球变绿并顺利拉起后台核心服务（`MaaCompositionService`）执行自动化任务。
5.2. （与 5.1 平行）倒计时期间不点击悬浮球，时间结束后悬浮球变绿并顺利执行自动化任务。
6. 任务结束后，悬浮球平滑退回 IDLE 状态，整体未发生卡顿、泄漏等问题。

同时，我也对原后台模式功能进行了测试，确认没有影响到后台模式运转。  

## 截图 / 日志 / 说明

截图：

* 新选项：
<img width="1080" height="2400" alt="Screenshot_2026-06-07-17-28-49-487_com aliothmoon" src="https://github.com/user-attachments/assets/a36b7e5e-da5f-4a12-9a94-c63f1d0bf8e1" />

* 倒计时：
<img width="1920" height="1080" alt="Screenshot_2026-06-07-17-30-36-230_com hypergryph" src="https://github.com/user-attachments/assets/2d089fc4-12ab-49e5-b85a-0f37089fe9af" />

相关日志：

* 不立即开始执行任务：
```log
预定: 2026-06-07 17:54:00
触发: 2026-06-07 17:53:30
17:53:30.033 策略加载完成:定时任务-1
17:53:30.035 检查锁屏状态...
17:53:30.037 设备未锁屏，连接服务...
17:53:30.038 前台悬浮球模式，直接提交定时请求
17:53:30.042 开始倒计时（30s）
17:54:00.111 倒计时结束，开始准备执行
17:54:00.119 前置条件通过，启用任务2项，正在启动MAA核心服务...
17:54:00.537 任务启动成功，MAA版本:V6.11.1
17:54:00.538 结果:已启动
```

* 立即开始执行任务：
```log
预定:2026-06-07 17:57:00
触发:2026-06-07 17:56:30
17:56:30.038 策略加载完成:定时任务-1
17:56:30.040 检查锁屏状态...
17:56:30.044 设备未锁屏，连接服务...
17:56:30.047 前台悬浮球模式，直接提交定时请求
17:56:30.049 开始倒计时（30s）
17:56:33.503 用户点击立即执行
17:56:34.053 倒计时结束，开始准备执行
17:56:34.057 前置条件通过，启用任务1项，正在启动MAA核心服务...
17:56:34.528 任务启动成功，MAA版本:V6.11.1
17:56:34.529 结果:已启动
```

说明：
* 当前台模式且通过定时任务拉起任务时，会跳过设备朝向检查。因为我无法找到一个应用程序在后台正确获取屏幕朝向的方法。

## Checklist

- [x] 我已阅读并遵守 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)

## Summary by Sourcery

在前台悬浮球模式下启用定时任务执行，新增专用静默启动器、倒计时交互体验以及配置开关。

New Features:
- 新增设置开关，用于在前台模式下启用带悬浮球控制的定时任务。
- 在悬浮球上直接显示定时任务倒计时，并在前台悬浮球模式下支持点按「立即开始」行为。
- 引入 `ForegroundScheduleStarter`，用于在不启动主 Activity 的情况下处理前台定时任务执行。

Enhancements:
- 扩展 `MaaCompositionService`，在前台模式下对定时任务放宽方向（orientation）前置条件，同时保留对手动运行的既有检查。
- 将全局倒计时状态路由到浮层，使悬浮球模式在合适场景下可以替代倒计时对话框。
- 优化定时启动校验逻辑，使前台悬浮球模式仅在用户设置明确启用时才被支持。

Chores:
- 在版本控制中忽略本地 `gradle-daemon` JVM 属性文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable scheduled task execution in foreground float-ball mode with a dedicated silent starter, countdown UX, and configuration toggle.

New Features:
- Add a settings toggle to allow scheduled tasks while in foreground mode with float-ball control.
- Display scheduled task countdown directly on the float ball, including tap-to-start-now behavior in foreground float-ball mode.
- Introduce a ForegroundScheduleStarter to handle foreground scheduled executions without launching the main activity.

Enhancements:
- Extend MaaCompositionService to relax orientation preconditions for scheduled runs in foreground mode while preserving existing checks for manual runs.
- Route global countdown state to the overlay so float-ball mode can replace the countdown dialog when appropriate.
- Refine scheduled launch validation to support foreground float-ball mode only when explicitly enabled by user settings.

Chores:
- Ignore local gradle-daemon JVM properties in version control.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在前台悬浮球模式下启用定时任务执行，新增专用静默启动器、倒计时交互体验以及配置开关。

New Features:
- 新增设置开关，用于在前台模式下启用带悬浮球控制的定时任务。
- 在悬浮球上直接显示定时任务倒计时，并在前台悬浮球模式下支持点按「立即开始」行为。
- 引入 `ForegroundScheduleStarter`，用于在不启动主 Activity 的情况下处理前台定时任务执行。

Enhancements:
- 扩展 `MaaCompositionService`，在前台模式下对定时任务放宽方向（orientation）前置条件，同时保留对手动运行的既有检查。
- 将全局倒计时状态路由到浮层，使悬浮球模式在合适场景下可以替代倒计时对话框。
- 优化定时启动校验逻辑，使前台悬浮球模式仅在用户设置明确启用时才被支持。

Chores:
- 在版本控制中忽略本地 `gradle-daemon` JVM 属性文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable scheduled task execution in foreground float-ball mode with a dedicated silent starter, countdown UX, and configuration toggle.

New Features:
- Add a settings toggle to allow scheduled tasks while in foreground mode with float-ball control.
- Display scheduled task countdown directly on the float ball, including tap-to-start-now behavior in foreground float-ball mode.
- Introduce a ForegroundScheduleStarter to handle foreground scheduled executions without launching the main activity.

Enhancements:
- Extend MaaCompositionService to relax orientation preconditions for scheduled runs in foreground mode while preserving existing checks for manual runs.
- Route global countdown state to the overlay so float-ball mode can replace the countdown dialog when appropriate.
- Refine scheduled launch validation to support foreground float-ball mode only when explicitly enabled by user settings.

Chores:
- Ignore local gradle-daemon JVM properties in version control.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在前台悬浮球模式下启用定时任务执行，新增专用静默启动器、倒计时交互体验以及配置开关。

New Features:
- 新增设置开关，用于在前台模式下启用带悬浮球控制的定时任务。
- 在悬浮球上直接显示定时任务倒计时，并在前台悬浮球模式下支持点按「立即开始」行为。
- 引入 `ForegroundScheduleStarter`，用于在不启动主 Activity 的情况下处理前台定时任务执行。

Enhancements:
- 扩展 `MaaCompositionService`，在前台模式下对定时任务放宽方向（orientation）前置条件，同时保留对手动运行的既有检查。
- 将全局倒计时状态路由到浮层，使悬浮球模式在合适场景下可以替代倒计时对话框。
- 优化定时启动校验逻辑，使前台悬浮球模式仅在用户设置明确启用时才被支持。

Chores:
- 在版本控制中忽略本地 `gradle-daemon` JVM 属性文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable scheduled task execution in foreground float-ball mode with a dedicated silent starter, countdown UX, and configuration toggle.

New Features:
- Add a settings toggle to allow scheduled tasks while in foreground mode with float-ball control.
- Display scheduled task countdown directly on the float ball, including tap-to-start-now behavior in foreground float-ball mode.
- Introduce a ForegroundScheduleStarter to handle foreground scheduled executions without launching the main activity.

Enhancements:
- Extend MaaCompositionService to relax orientation preconditions for scheduled runs in foreground mode while preserving existing checks for manual runs.
- Route global countdown state to the overlay so float-ball mode can replace the countdown dialog when appropriate.
- Refine scheduled launch validation to support foreground float-ball mode only when explicitly enabled by user settings.

Chores:
- Ignore local gradle-daemon JVM properties in version control.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在前台悬浮球模式下启用定时任务执行，新增专用静默启动器、倒计时交互体验以及配置开关。

New Features:
- 新增设置开关，用于在前台模式下启用带悬浮球控制的定时任务。
- 在悬浮球上直接显示定时任务倒计时，并在前台悬浮球模式下支持点按「立即开始」行为。
- 引入 `ForegroundScheduleStarter`，用于在不启动主 Activity 的情况下处理前台定时任务执行。

Enhancements:
- 扩展 `MaaCompositionService`，在前台模式下对定时任务放宽方向（orientation）前置条件，同时保留对手动运行的既有检查。
- 将全局倒计时状态路由到浮层，使悬浮球模式在合适场景下可以替代倒计时对话框。
- 优化定时启动校验逻辑，使前台悬浮球模式仅在用户设置明确启用时才被支持。

Chores:
- 在版本控制中忽略本地 `gradle-daemon` JVM 属性文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable scheduled task execution in foreground float-ball mode with a dedicated silent starter, countdown UX, and configuration toggle.

New Features:
- Add a settings toggle to allow scheduled tasks while in foreground mode with float-ball control.
- Display scheduled task countdown directly on the float ball, including tap-to-start-now behavior in foreground float-ball mode.
- Introduce a ForegroundScheduleStarter to handle foreground scheduled executions without launching the main activity.

Enhancements:
- Extend MaaCompositionService to relax orientation preconditions for scheduled runs in foreground mode while preserving existing checks for manual runs.
- Route global countdown state to the overlay so float-ball mode can replace the countdown dialog when appropriate.
- Refine scheduled launch validation to support foreground float-ball mode only when explicitly enabled by user settings.

Chores:
- Ignore local gradle-daemon JVM properties in version control.

</details>

</details>

</details>