### PR TITLE
fix(connect): 始终启用 force_stop

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/domain/service/MaaCompositionService.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/service/MaaCompositionService.kt
@@ -420,9 +420,7 @@ class MaaCompositionService(
                 put("height", height)
             })
             put("display_id", displayId)
-            if (displayId != 0) {
-                put("force_stop", true)
-            }
+            put("force_stop", true)
         }.toString()
     }
 


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)。

## 关联 Issue

#132 

## 变更摘要

- 移除 buildConnectConfig 中 if (displayId != 0) 条件，前台模式也启用 force_stop

## 验证

- Android Studio 编译通过
- 前台模式启动“开始唤醒”任务后在游戏中再次运行“开始唤醒”，游戏被杀死并重启。后台模式于此相同。

## 截图 / 日志 / 说明

无，这是一个简单改动。

## Checklist

- [x] 我已阅读并遵守 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)

## Summary by Sourcery

Bug Fixes:
- 通过在启用前移除显示 ID 检查，确保在前台模式下也能应用强制停止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure force-stop is applied in foreground mode by removing the display ID check before enabling it.

</details>