### PR TITLE
feat: Github源支持更新时按照ABI下载

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -99,7 +99,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
           chmod +x ./gradlew
-          ./gradlew clean assembleRelease
+          ./gradlew clean assembleRelease -P PACKAGED_ABI_LABEL=${{ matrix.label }}
 
       - name: Rename APK
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,9 @@ android {
                 arguments("-DANDROID_STL=c++_shared")
             }
         }
+
+
+        buildConfigField("String", "PACKAGED_ABI_LABEL", ("\"${project.findProperty("PACKAGED_ABI_LABEL") ?: "universal"}\""))
     }
 
     signingConfigs {

--- a/app/src/main/java/com/aliothmoon/maameow/data/datasource/update/GitHubAppDownloadUrlResolver.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/datasource/update/GitHubAppDownloadUrlResolver.kt
@@ -14,7 +14,7 @@ class GitHubAppDownloadUrlResolver(
 
     private val json = JsonUtils.common
 
-    override suspend fun resolve(version: String, channel: UpdateChannel): Result<String> {
+    override suspend fun resolve(version: String, channel: UpdateChannel, abi:String): Result<String> {
         return runCatching {
             val tag = if (version.startsWith("v", ignoreCase = true)) version else "v$version"
             val response = httpClient.get(MaaApi.appGitHubReleaseByTag(tag))
@@ -25,7 +25,7 @@ class GitHubAppDownloadUrlResolver(
 
             val release = json.decodeFromString<GitHubRelease>(response.body.string())
 
-            val apkAsset = release.assets.firstOrNull { it.name.endsWith("universal.apk") }
+            val apkAsset = release.assets.firstOrNull { it.name.endsWith("$abi.apk") }
                 ?: throw Exception("Release 中未找到 APK 文件")
 
             apkAsset.browserDownloadUrl

--- a/app/src/main/java/com/aliothmoon/maameow/data/datasource/update/MirrorChyanAppDownloadUrlResolver.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/datasource/update/MirrorChyanAppDownloadUrlResolver.kt
@@ -13,7 +13,7 @@ class MirrorChyanAppDownloadUrlResolver(
     private val appSettingsManager: AppSettingsManager
 ) : AppDownloadUrlResolver {
 
-    override suspend fun resolve(version: String, channel: UpdateChannel): Result<String> {
+    override suspend fun resolve(version: String, channel: UpdateChannel, abi: String): Result<String> {
         val cdk = appSettingsManager.mirrorChyanCdk.value
         if (cdk.isBlank()) {
             return Result.failure(CdkRequiredException())

--- a/app/src/main/java/com/aliothmoon/maameow/domain/service/update/UpdateService.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/service/update/UpdateService.kt
@@ -77,19 +77,20 @@ class UpdateService(
     suspend fun downloadApp(
         source: UpdateSource,
         version: String,
-        channel: UpdateChannel = UpdateChannel.STABLE
+        channel: UpdateChannel = UpdateChannel.STABLE,
+        abi: String
     ): Result<Unit> {
         if (!appDownloading.compareAndSet(false, true)) {
             return Result.success(Unit)   // 已在进行中，幂等跳过
         }
         try {
-            Timber.i("downloadApp start: source=%s, version=%s, channel=%s", source, version, channel)
+            Timber.i("downloadApp start: source=%s, version=%s, channel=%s, abi=%s", source, version, channel, abi)
             _appProcessState.value = UpdateProcessState.Downloading(0, "准备下载...", 0L, 0L)
 
             val resolver = appDownloadResolvers[source]
                 ?: return failApp(UpdateError.UnknownError("不支持的下载源: $source"))
 
-            val url = resolver.resolve(version, channel).getOrElse { e ->
+            val url = resolver.resolve(version, channel, abi).getOrElse { e ->
                 _appProcessState.value = UpdateProcessState.Failed(mapToUpdateError(e))
                 return Result.failure(e)
             }

--- a/app/src/main/java/com/aliothmoon/maameow/domain/service/update/resolver/AppDownloadUrlResolver.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/service/update/resolver/AppDownloadUrlResolver.kt
@@ -3,5 +3,5 @@ package com.aliothmoon.maameow.domain.service.update.resolver
 import com.aliothmoon.maameow.data.model.update.UpdateChannel
 
 interface AppDownloadUrlResolver {
-    suspend fun resolve(version: String, channel: UpdateChannel): Result<String>
+    suspend fun resolve(version: String, channel: UpdateChannel, abi: String): Result<String>
 }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/UpdateViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/UpdateViewModel.kt
@@ -216,7 +216,8 @@ class UpdateViewModel(
                     val result = updateService.downloadApp(
                         source = updateSource.value,
                         version = appAvailable.version,
-                        channel = updateChannel.value
+                        channel = updateChannel.value,
+                        abi = appUpdateAbi
                     )
                     if (result.isFailure) {
                         _toastMessage.tryEmit(appContext.getString(R.string.update_toast_auto_download_app_failed))
@@ -256,6 +257,8 @@ class UpdateViewModel(
 
     val currentAppVersion: String = BuildConfig.VERSION_NAME
 
+    val appUpdateAbi: String = if(updateSource.value == UpdateSource.GITHUB) BuildConfig.PACKAGED_ABI_LABEL else "universal"
+
     fun checkAppUpdate() {
         val currentState = appUpdateState.value
         if (_appChecking.value || currentState is UpdateProcessState.Downloading || currentState is UpdateProcessState.Installing) {
@@ -281,8 +284,8 @@ class UpdateViewModel(
             updateService.downloadApp(
                 source = updateSource.value,
                 version = version,
-                channel = updateChannel.value
-            )
+                channel = updateChannel.value,
+                abi = appUpdateAbi)
         }
     }
 


### PR DESCRIPTION
## Summary by Sourcery

添加对基于 ABI 的应用下载支持，并在更新流水线中传递 ABI 信息。

新功能：
- 支持从 GitHub Releases 中选择并下载特定 ABI 的 APK，而不是总是使用通用（universal）构建。

增强：
- 在更新服务和 URL 解析器中传递 ABI 信息，以便不同的下载来源能够支持 ABI 特定构建。
- 通过新的 `BuildConfig` 字段暴露打包时的 ABI 标记，并通过 Gradle 属性将其接入到发行构建中。

构建：
- 添加 `PACKAGED_ABI_LABEL` `BuildConfig` 字段，并配置发行构建从 GitHub Actions 的 matrix 中接收该字段。

CI：
- 更新 GitHub Actions 的发行工作流，将 ABI 标记传入 Gradle 构建，从而使 ABI 特定的构件能够被正确标记。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add ABI-aware app download support and propagate ABI information through the update pipeline.

New Features:
- Support selecting and downloading ABI-specific APKs from GitHub releases instead of always using universal builds.

Enhancements:
- Propagate ABI information through the update service and URL resolvers so different download sources can honor ABI-specific builds.
- Expose the packaged ABI label via a new BuildConfig field and wire it into release builds using a Gradle property.

Build:
- Add PACKAGED_ABI_LABEL BuildConfig field and configure the release build to receive it from the GitHub Actions matrix.

CI:
- Update the GitHub Actions release workflow to pass the ABI label into the Gradle build so ABI-specific artifacts are labeled correctly.

</details>