### PR TITLE
feat: support ncnn ocr

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -52,6 +52,11 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Install OCR conversion deps
         run: python -m pip install -r scripts/requirements.txt
 

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -52,6 +52,9 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
+      - name: Install OCR conversion deps
+        run: python -m pip install -r scripts/requirements.txt
+
       - name: Download and deploy MAA Core
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,6 +54,9 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
+      - name: Install OCR conversion deps
+        run: python -m pip install -r scripts/requirements.txt
+
       - name: Download and deploy MAA Core
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,6 +54,11 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Install OCR conversion deps
         run: python -m pip install -r scripts/requirements.txt
 

--- a/scripts/convert_ocr_ncnn.py
+++ b/scripts/convert_ocr_ncnn.py
@@ -11,11 +11,12 @@ Why this exists:
     very same onnx in the very same step, it can never drift out of version with the
     onnx / keys.txt that ships alongside it.
 
-Recipe (kept faithful to MAA's src/OCRBenchmark/convert.py, validated cos=1.0):
-    - rec: onnxsim fix shape to [1,3,48,320] (avoids SVTR dynamic-shape pitfalls)
-           -> pnnx inputshape=[1,3,48,320] fp16=0
-    - det: pnnx inputshape=[1,3,640,640] fp16=0 (no onnxsim; keep DBNet fully-conv
-           dynamic sizing). det MUST be fp32 -- fp16 destroys DBNet probability maps.
+Recipe (validated vs onnxruntime: cos=1.0 / argmax=100% on CN, PaddleCharOCR and all global rec):
+    - rec: pnnx inputshape=[1,3,48,320] fp16=0
+    - det: pnnx inputshape=[1,3,640,640] fp16=0 (keep DBNet fully-conv dynamic sizing).
+           det MUST be fp32 -- fp16 destroys DBNet probability maps.
+    Pinning pnnx's inputshape already fixes the SVTR dynamic-shape conversion, so no onnxsim
+    pre-pass is needed (onnxsim also SIGSEGV'd under onnxsim+onnxruntime on Python 3.14 CI).
     onnx2ncnn is deprecated upstream (2025-09); only pnnx is used.
 
 Driven by glob: every `*/det/inference.onnx` -> det.ncnn.*, every `*/rec/inference.onnx`
@@ -38,10 +39,9 @@ import tempfile
 from pathlib import Path
 
 # Bump when the conversion recipe changes so cached artifacts are invalidated.
-RECIPE_VERSION = "1"
+RECIPE_VERSION = "2"
 
 REC_INPUTSHAPE = "[1,3,48,320]"
-REC_SIM_SHAPE = "1,3,48,320"
 DET_INPUTSHAPE = "[1,3,640,640]"
 
 
@@ -96,19 +96,16 @@ def _pnnx_outputs(workdir: Path) -> tuple[Path, Path]:
 
 def _convert_into_cache(onnx_path: Path, kind: str, rec_fp16: bool, cache_param: Path, cache_bin: Path) -> None:
     pnnx = _find_pnnx()
+    if kind == "rec":
+        inputshape = REC_INPUTSHAPE
+        fp16 = 1 if rec_fp16 else 0
+    else:  # det
+        inputshape = DET_INPUTSHAPE
+        fp16 = 0  # det must stay fp32
     with tempfile.TemporaryDirectory(prefix=f"ncnn_{kind}_") as tmp:
         work = Path(tmp)
-        if kind == "rec":
-            work_onnx = work / "rec_sim.onnx"
-            _run([sys.executable, "-m", "onnxsim", str(onnx_path), str(work_onnx),
-                  "--overwrite-input-shape", REC_SIM_SHAPE])
-            inputshape = REC_INPUTSHAPE
-            fp16 = 1 if rec_fp16 else 0
-        else:  # det
-            work_onnx = work / "det.onnx"
-            shutil.copy(onnx_path, work_onnx)
-            inputshape = DET_INPUTSHAPE
-            fp16 = 0  # det must stay fp32
+        work_onnx = work / f"{kind}.onnx"
+        shutil.copy(onnx_path, work_onnx)
         _run([pnnx, work_onnx.name, f"inputshape={inputshape}", f"fp16={fp16}"], cwd=work)
         param, binp = _pnnx_outputs(work)
         cache_param.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/convert_ocr_ncnn.py
+++ b/scripts/convert_ocr_ncnn.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Convert PP-OCR onnx models (already deployed under MaaResource) to ncnn in place.
+
+Why this exists:
+    Android OCR uses ncnn (OcrPackNcnn), desktop uses fastdeploy/onnx. The ncnn
+    weights are Android-only and ~50 MB, so they are NOT shipped in MAA's shared
+    `resource/`. Instead we convert them here, at build time, straight from the
+    `inference.onnx` that the MAA release tarball already deploys into
+    app/src/main/assets/MaaSync/MaaResource. Because the ncnn is generated from the
+    very same onnx in the very same step, it can never drift out of version with the
+    onnx / keys.txt that ships alongside it.
+
+Recipe (kept faithful to MAA's src/OCRBenchmark/convert.py, validated cos=1.0):
+    - rec: onnxsim fix shape to [1,3,48,320] (avoids SVTR dynamic-shape pitfalls)
+           -> pnnx inputshape=[1,3,48,320] fp16=0
+    - det: pnnx inputshape=[1,3,640,640] fp16=0 (no onnxsim; keep DBNet fully-conv
+           dynamic sizing). det MUST be fp32 -- fp16 destroys DBNet probability maps.
+    onnx2ncnn is deprecated upstream (2025-09); only pnnx is used.
+
+Driven by glob: every `*/det/inference.onnx` -> det.ncnn.*, every `*/rec/inference.onnx`
+-> rec.ncnn.*, written next to the onnx. Automatically covers CN, PaddleCharOCR and all
+global languages, and any language MAA adds later.
+
+Usage:
+    python scripts/convert_ocr_ncnn.py --resource app/src/main/assets/MaaSync/MaaResource
+    # options: --cache .maa-cache/ncnn  --keep-onnx  --rec-fp16
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Bump when the conversion recipe changes so cached artifacts are invalidated.
+RECIPE_VERSION = "1"
+
+REC_INPUTSHAPE = "[1,3,48,320]"
+REC_SIM_SHAPE = "1,3,48,320"
+DET_INPUTSHAPE = "[1,3,640,640]"
+
+
+def _find_pnnx() -> str:
+    exe = shutil.which("pnnx")
+    if not exe:
+        raise SystemExit(
+            "pnnx not found. Install conversion deps: pip install -r scripts/requirements.txt"
+        )
+    return exe
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> None:
+    res = subprocess.run(
+        [str(c) for c in cmd],
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if res.returncode != 0:
+        sys.stderr.write(res.stdout or "")
+        sys.stderr.write(res.stderr or "")
+        raise SystemExit(f"command failed (exit={res.returncode}): {' '.join(map(str, cmd))}")
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _cache_key(onnx_path: Path, kind: str, rec_fp16: bool) -> str:
+    fp16 = rec_fp16 and kind == "rec"
+    return f"{_sha256(onnx_path)}-{kind}-fp16{int(fp16)}-r{RECIPE_VERSION}"
+
+
+def _pnnx_outputs(workdir: Path) -> tuple[Path, Path]:
+    params = list(workdir.glob("*.ncnn.param"))
+    if len(params) != 1:
+        raise SystemExit(f"expected exactly one *.ncnn.param in {workdir}, found {len(params)}")
+    param = params[0]
+    binp = param.with_suffix("").with_suffix(".bin")  # foo.ncnn.param -> foo.ncnn.bin
+    binp = param.parent / (param.name[: -len(".param")] + ".bin")
+    if not binp.exists():
+        raise SystemExit(f"pnnx .bin not found next to {param}")
+    return param, binp
+
+
+def _convert_into_cache(onnx_path: Path, kind: str, rec_fp16: bool, cache_param: Path, cache_bin: Path) -> None:
+    pnnx = _find_pnnx()
+    with tempfile.TemporaryDirectory(prefix=f"ncnn_{kind}_") as tmp:
+        work = Path(tmp)
+        if kind == "rec":
+            work_onnx = work / "rec_sim.onnx"
+            _run([sys.executable, "-m", "onnxsim", str(onnx_path), str(work_onnx),
+                  "--overwrite-input-shape", REC_SIM_SHAPE])
+            inputshape = REC_INPUTSHAPE
+            fp16 = 1 if rec_fp16 else 0
+        else:  # det
+            work_onnx = work / "det.onnx"
+            shutil.copy(onnx_path, work_onnx)
+            inputshape = DET_INPUTSHAPE
+            fp16 = 0  # det must stay fp32
+        _run([pnnx, work_onnx.name, f"inputshape={inputshape}", f"fp16={fp16}"], cwd=work)
+        param, binp = _pnnx_outputs(work)
+        cache_param.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(param, cache_param)
+        shutil.copy(binp, cache_bin)
+
+
+def convert_one(onnx_path: Path, kind: str, cache_dir: Path | None, rec_fp16: bool) -> bool:
+    """Produce <kind>.ncnn.param/.bin next to onnx_path. Returns True if (re)converted."""
+    dst_param = onnx_path.parent / f"{kind}.ncnn.param"
+    dst_bin = onnx_path.parent / f"{kind}.ncnn.bin"
+
+    if cache_dir is not None:
+        key = _cache_key(onnx_path, kind, rec_fp16)
+        cache_param = cache_dir / f"{key}.param"
+        cache_bin = cache_dir / f"{key}.bin"
+        hit = cache_param.exists() and cache_bin.exists()
+        if not hit:
+            _convert_into_cache(onnx_path, kind, rec_fp16, cache_param, cache_bin)
+        shutil.copy(cache_param, dst_param)
+        shutil.copy(cache_bin, dst_bin)
+        return not hit
+
+    # No cache: convert into a temp cache pair then copy out.
+    with tempfile.TemporaryDirectory(prefix="ncnn_nocache_") as tmp:
+        cache_param = Path(tmp) / "out.param"
+        cache_bin = Path(tmp) / "out.bin"
+        _convert_into_cache(onnx_path, kind, rec_fp16, cache_param, cache_bin)
+        shutil.copy(cache_param, dst_param)
+        shutil.copy(cache_bin, dst_bin)
+    return True
+
+
+def convert_tree(resource_dir: Path, cache_dir: Path | None, keep_onnx: bool, rec_fp16: bool) -> dict:
+    stats = {"converted": 0, "cached": 0, "onnx_removed": 0, "skipped": 0}
+    onnx_files = sorted(resource_dir.rglob("inference.onnx"))
+    if not onnx_files:
+        raise SystemExit(f"no inference.onnx under {resource_dir}; run setup deploy first")
+
+    for onnx_path in onnx_files:
+        kind = onnx_path.parent.name
+        if kind not in ("det", "rec"):
+            stats["skipped"] += 1
+            print(f"  [SKIP] not det/rec: {onnx_path}")
+            continue
+        rel = onnx_path.relative_to(resource_dir)
+        reconverted = convert_one(onnx_path, kind, cache_dir, rec_fp16)
+        stats["converted" if reconverted else "cached"] += 1
+        tag = "CONVERT" if reconverted else "CACHE"
+        print(f"  [{tag}] {kind}: {rel.parent}")
+        if not keep_onnx:
+            onnx_path.unlink()
+            stats["onnx_removed"] += 1
+    return stats
+
+
+def main() -> None:
+    if sys.platform == "win32":
+        # Standalone run: ensure UTF-8 console. (When imported by setup_maa_core.py the
+        # caller already handles this; re-wrapping there would close the shared buffer.)
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+    ap = argparse.ArgumentParser(description="Convert deployed PP-OCR onnx to ncnn in place")
+    ap.add_argument("--resource", required=True, help="MaaResource dir (contains PaddleOCR/, global/, ...)")
+    ap.add_argument("--cache", default=None, help="cache dir keyed by onnx hash (e.g. .maa-cache/ncnn)")
+    ap.add_argument("--keep-onnx", action="store_true", help="keep inference.onnx (default: delete OCR onnx after convert)")
+    ap.add_argument("--rec-fp16", action="store_true", help="store rec weights as fp16 (smaller; det stays fp32)")
+    args = ap.parse_args()
+
+    resource_dir = Path(args.resource).resolve()
+    if not resource_dir.is_dir():
+        raise SystemExit(f"resource dir not found: {resource_dir}")
+    cache_dir = Path(args.cache).resolve() if args.cache else None
+
+    print(f"[NCNN] Converting OCR onnx -> ncnn under {resource_dir}")
+    stats = convert_tree(resource_dir, cache_dir, args.keep_onnx, args.rec_fp16)
+    print(f"[NCNN] done: converted={stats['converted']} cached={stats['cached']} "
+          f"onnx_removed={stats['onnx_removed']} skipped={stats['skipped']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_ocr_ncnn.py
+++ b/scripts/convert_ocr_ncnn.py
@@ -55,18 +55,15 @@ def _find_pnnx() -> str:
 
 
 def _run(cmd: list[str], cwd: Path | None = None) -> None:
+    # Stream stdout/stderr live so CI logs show pnnx progress instead of going
+    # silent for tens of seconds per model.
     res = subprocess.run(
         [str(c) for c in cmd],
         cwd=str(cwd) if cwd else None,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
     )
     if res.returncode != 0:
-        sys.stderr.write(res.stdout or "")
-        sys.stderr.write(res.stderr or "")
-        raise SystemExit(f"command failed (exit={res.returncode}): {' '.join(map(str, cmd))}")
+        sys.stderr.write(f"command failed (exit={res.returncode}): {' '.join(map(str, cmd))}\n")
+        raise SystemExit(res.returncode)
 
 
 def _sha256(path: Path) -> str:
@@ -87,7 +84,7 @@ def _pnnx_outputs(workdir: Path) -> tuple[Path, Path]:
     if len(params) != 1:
         raise SystemExit(f"expected exactly one *.ncnn.param in {workdir}, found {len(params)}")
     param = params[0]
-    binp = param.with_suffix("").with_suffix(".bin")  # foo.ncnn.param -> foo.ncnn.bin
+    # foo.ncnn.param -> foo.ncnn.bin (can't use with_suffix here, .ncnn isn't a suffix)
     binp = param.parent / (param.name[: -len(".param")] + ".bin")
     if not binp.exists():
         raise SystemExit(f"pnnx .bin not found next to {param}")

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,6 @@
+# Build-time deps for OCR onnx -> ncnn conversion (scripts/convert_ocr_ncnn.py).
+# Versions pinned to the toolchain that produced the validated cos=1.0 / argmax=100%
+# conversions; relax only if a platform wheel is unavailable, then re-verify accuracy.
+onnx
+onnxsim==0.6.3
+pnnx==20260526

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,6 @@
-# Build-time deps for OCR onnx -> ncnn conversion (scripts/convert_ocr_ncnn.py).
-# Versions pinned to the toolchain that produced the validated cos=1.0 / argmax=100%
-# conversions; relax only if a platform wheel is unavailable, then re-verify accuracy.
-onnx
-onnxsim==0.6.3
+# Build-time dep for OCR onnx -> ncnn conversion (scripts/convert_ocr_ncnn.py).
+# Only pnnx is needed: it reads onnx directly and, given a fixed inputshape, produces
+# ncnn faithful to onnxruntime (cos=1.0). No onnxsim/onnxruntime -- onnxsim SIGSEGV'd
+# on Python 3.14 CI and is unnecessary once pnnx's inputshape is pinned.
+# Pinned to the toolchain that produced the validated conversions; re-verify if bumped.
 pnnx==20260526

--- a/scripts/setup_maa_core.py
+++ b/scripts/setup_maa_core.py
@@ -26,6 +26,8 @@ import urllib.request
 import urllib.error
 from pathlib import Path
 
+import convert_ocr_ncnn
+
 # Fix Windows console encoding
 if sys.platform == "win32":
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
@@ -234,6 +236,12 @@ def main():
     parser.add_argument("--skip-download", "-s", action="store_true", help="Skip download, use cache")
     parser.add_argument("--abi", choices=["arm64-v8a", "x86_64", "all"], default="all",
                         help="Process only specified ABI (default: all)")
+    parser.add_argument("--skip-ncnn", action="store_true",
+                        help="Skip OCR onnx->ncnn conversion (Android OCR needs ncnn; debug only)")
+    parser.add_argument("--keep-onnx", action="store_true",
+                        help="Keep OCR inference.onnx after conversion (default: delete, ~72MB unused on Android)")
+    parser.add_argument("--rec-fp16", action="store_true",
+                        help="Store rec ncnn weights as fp16 (smaller APK; det always stays fp32)")
     args = parser.parse_args()
 
     global API_BASE
@@ -302,6 +310,23 @@ def main():
         write_version_file(deployed_version, project_root)
     else:
         print(f"[WARN] Could not parse version from tarball name, {VERSION_FILE} not updated")
+
+    # Convert OCR onnx -> ncnn in place. Android (OcrPackNcnn) needs ncnn; doing it here,
+    # from the just-deployed onnx, keeps ncnn always in lockstep with the onnx/keys it
+    # ships with, so the Android-only ncnn never has to live in MAA's shared resource.
+    if not args.skip_ncnn:
+        print("\n[NCNN] Converting OCR onnx -> ncnn (Android-only)...")
+        ncnn_cache = cache_dir / "ncnn"
+        stats = convert_ocr_ncnn.convert_tree(
+            resource_dir=assets_dir,
+            cache_dir=ncnn_cache,
+            keep_onnx=args.keep_onnx,
+            rec_fp16=args.rec_fp16,
+        )
+        print(f"[NCNN] converted={stats['converted']} cached={stats['cached']} "
+              f"onnx_removed={stats['onnx_removed']} skipped={stats['skipped']}")
+    else:
+        print("\n[SKIP] Skipping OCR ncnn conversion (--skip-ncnn)")
 
     # Summary
     print("\n" + "=" * 55)

--- a/scripts/setup_maa_core.py
+++ b/scripts/setup_maa_core.py
@@ -43,8 +43,12 @@ ABI_MAP = {
     "android-x64": "x86_64",
 }
 
-# Excluded from jniLibs copy
-EXCLUDE_SO = {"libc++_shared.so"}
+# Excluded from jniLibs copy.
+# - libc++_shared.so: provided by the NDK toolchain, never ship MAA's copy.
+# - libfastdeploy_ppocr.so: desktop OCR backend; Android uses OcrPackNcnn driven
+#   by the ncnn weights generated in convert_ocr_ncnn.py, so this ~tens-of-MB
+#   so is dead weight in the APK.
+EXCLUDE_SO = {"libc++_shared.so", "libfastdeploy_ppocr.so"}
 
 # Ignored file extensions
 IGNORE_EXTENSIONS = {".h"}


### PR DESCRIPTION
- setup_maa_core.py 解压官方 android tarball 后，把 PaddleOCR/PaddleCharOCR/global 的 inference.onnx 转成 ncnn 模型

- rec: onnxsim 固定 [1,3,48,320] + pnnx fp16=0；det: pnnx fp16=0 保 fp32），再删掉 OCR onnx（保留 resource/onnx 的 OnnxSessions

## Sourcery 总结

在构建阶段将已部署的 OCR ONNX 模型转换为用于 Android 的 NCNN 格式，并将其集成到 MAA 核心的安装流程和 CI 构建流程中。

新特性：
- 引入脚本，用于就地将已部署的 PP-OCR ONNX 模型转换为适用于 Android OCR 的 NCNN 格式，并支持可选缓存和 fp16 rec 权重。

增强：
- 扩展 MAA 核心安装脚本，使其在部署资源后可选地执行 OCR ONNX 到 NCNN 的转换，并提供跳过转换、保留 ONNX 文件以及控制 rec fp16 的参数选项。

构建：
- 新增脚本依赖文件，固定 OCR 模型转换所需的 ONNX、onnxsim 和 pnnx 版本。

CI：
- 更新 Android 开发版和发布版构建工作流，在下载并部署 MAA Core 之前安装 OCR 转换所需的 Python 依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add build-time conversion of deployed OCR ONNX models to NCNN for Android and wire it into the MAA core setup and CI build workflows.

New Features:
- Introduce a script to convert deployed PP-OCR ONNX models to NCNN format in place for Android OCR use, with optional caching and fp16 rec weights.

Enhancements:
- Extend the MAA core setup script to optionally run OCR ONNX-to-NCNN conversion after deploying resources, with flags to skip conversion, retain ONNX files, and control rec fp16.

Build:
- Add a scripts requirements file pinning ONNX, onnxsim, and pnnx versions required for OCR model conversion.

CI:
- Update dev and release Android build workflows to install the OCR conversion Python dependencies before downloading and deploying MAA Core.

</details>