### PR TITLE
fix: 清理Android低版本残留进度通知

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/domain/service/TaskExecutionService.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/service/TaskExecutionService.kt
@@ -99,7 +99,7 @@ class TaskExecutionService : Service() {
 
     override fun onDestroy() {
         // 外部 stopService 与 StateFlow 收集存在竞态；此处兜底确保 Live Update 通知被清除。
-        stopForeground(STOP_FOREGROUND_REMOVE)
+        removeActiveNotification()
         observeJob?.cancel()
         serviceScope.cancel()
         super.onDestroy()
@@ -443,6 +443,12 @@ private fun buildProgressInfo(snapshot: TaskNotificationSnapshot): TaskProgressI
         manager.notify(NOTIFICATION_ID, buildNotification(snapshot))
     }
 
+    private fun removeActiveNotification() {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.cancel(NOTIFICATION_ID)
+    }
+
     private fun buildContentIntent(): PendingIntent {
         val intent = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
@@ -456,7 +462,7 @@ private fun buildProgressInfo(snapshot: TaskNotificationSnapshot): TaskProgressI
     }
 
     private fun showResultNotification(title: String, text: String) {
-        stopForeground(STOP_FOREGROUND_REMOVE)
+        removeActiveNotification()
 
         val notification = NotificationCompat.Builder(this, RESULT_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_maa_logo)


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)。

## 关联 Issue

无关联 Issue。

修复 Android 15 及以下设备上，任务结束后降级显示的 Live Updates / 进度通知不会主动清理的问题。


## 变更摘要

- 新增 `removeActiveNotification()`，统一处理活动任务通知清理逻辑
- 在任务结束展示结果通知前，显式移除前台服务通知并取消 `NOTIFICATION_ID`
- 在 Service 销毁兜底路径中复用同一清理逻辑，避免低版本降级通知残留

## 验证

已在a12与a15中完成实机测试，无误


## Checklist

- [x] 我已阅读并遵守 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)

## Summary by Sourcery

在 Android 上统一并强化任务执行通知的清理机制，防止在较低系统版本中留下残留的进度通知。

Bug 修复：
- 确保在 Android 15 及以下版本中，当任务结束或服务被销毁时，前台和已降级的进度通知能够被完全清除。

增强项：
- 引入专门的辅助方法，用于集中处理任务执行服务的活动通知移除逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and strengthen cleanup of task execution notifications on Android to prevent residual progress notifications on lower OS versions.

Bug Fixes:
- Ensure foreground and downgraded progress notifications are fully cleared when tasks finish or the service is destroyed on Android 15 and below.

Enhancements:
- Introduce a dedicated helper method to centralize active notification removal for the task execution service.

</details>