### PR TITLE
feat(theme): add Material You monet toggle

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/MainActivity.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/MainActivity.kt
@@ -67,8 +67,9 @@ class MainActivity : AppCompatActivity() {
         })
         setContent {
             val themeMode by appSettingsManager.themeMode.collectAsStateWithLifecycle()
+            val useSystemMonetColor by appSettingsManager.useSystemMonetColor.collectAsStateWithLifecycle()
 
-            MaaMeowTheme(themeMode = themeMode) {
+            MaaMeowTheme(themeMode = themeMode, useSystemMonetColor = useSystemMonetColor) {
                 AppNavigation(backgroundTaskViewModel = backgroundTaskViewModel)
             }
         }

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -483,4 +483,20 @@ class AppSettingsManager(
         }
     }
 
+
+    // 是否启用系统莫奈主题色（Android 12+ Material You）
+    private fun parseUseSystemMonetColor(raw: String): Boolean =
+        raw.toBooleanStrictOrNull() ?: true
+
+    val useSystemMonetColor: StateFlow<Boolean> = settings
+        .map { parseUseSystemMonetColor(it.useSystemMonetColor) }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, parseUseSystemMonetColor(initialSettings.useSystemMonetColor))
+
+    suspend fun setUseSystemMonetColor(enabled: Boolean) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[useSystemMonetColor] = enabled.toString() }
+        }
+    }
+
 }

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -64,4 +64,10 @@ data class AppSettings(
     @PrefKey(default = "false") val tasksOverrideEnabled: String = "false",
 
     @PrefKey(default = "false") val allowForegroundScheduledTask: String = "false",
+    /**
+     * 是否启用系统莫奈主题色（Android 12+ Material You）
+     * 启用后主题跟随系统壁纸动态取色，关闭则使用内置硬编码蓝色主题
+     * Android 12 以下设备只能使用内置蓝色主题
+     */
+    @PrefKey(default = "true") val useSystemMonetColor: String = "true",
 )

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -69,5 +69,5 @@ data class AppSettings(
      * 启用后主题跟随系统壁纸动态取色，关闭则使用内置硬编码蓝色主题
      * Android 12 以下设备只能使用内置蓝色主题
      */
-    @PrefKey(default = "true") val useSystemMonetColor: String = "true",
+    @PrefKey(default = "false") val useSystemMonetColor: String = "false",
 )

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import android.os.Build as AndroidBuild
 import androidx.compose.material.icons.rounded.Build
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -94,6 +95,7 @@ fun SettingsView(
     val tasksOverrideEnabled by viewModel.tasksOverrideEnabled.collectAsStateWithLifecycle()
     val updateChannel by viewModel.updateChannel.collectAsStateWithLifecycle()
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
+    val useSystemMonetColor by viewModel.useSystemMonetColor.collectAsStateWithLifecycle()
     val backgroundResolution by viewModel.backgroundResolution.collectAsStateWithLifecycle()
     val language by viewModel.language.collectAsStateWithLifecycle()
     val backupMessage by viewModel.backupMessage.collectAsStateWithLifecycle()
@@ -309,6 +311,16 @@ fun SettingsView(
                         onBackendSelected = { viewModel.setStartupBackend(it) }
                     )
                     SettingsDivider(contentColor)
+                    if (AndroidBuild.VERSION.SDK_INT >= AndroidBuild.VERSION_CODES.S) {
+                        SettingSwitchItem(
+                            title = stringResource(R.string.settings_monet_color_title),
+                            description = stringResource(R.string.settings_monet_color_desc),
+                            contentColor = contentColor,
+                            checked = useSystemMonetColor,
+                            onCheckedChange = { viewModel.setUseSystemMonetColor(it) }
+                        )
+                        SettingsDivider(contentColor)
+                    }
                     SettingClickItem(
                         title = stringResource(R.string.settings_achievement_title),
                         description = stringResource(R.string.settings_achievement_desc),

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -20,8 +20,8 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import android.os.Build as AndroidBuild
 import androidx.compose.material.icons.rounded.Build
+import android.os.Build
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -311,7 +311,7 @@ fun SettingsView(
                         onBackendSelected = { viewModel.setStartupBackend(it) }
                     )
                     SettingsDivider(contentColor)
-                    if (AndroidBuild.VERSION.SDK_INT >= AndroidBuild.VERSION_CODES.S) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                         SettingSwitchItem(
                             title = stringResource(R.string.settings_monet_color_title),
                             description = stringResource(R.string.settings_monet_color_desc),

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -239,4 +239,12 @@ class SettingsViewModel(
             resourceLoader.reset()
         }
     }
+
+    // ============ System Monet theme color ============
+    val useSystemMonetColor: StateFlow<Boolean> = appSettingsManager.useSystemMonetColor
+    fun setUseSystemMonetColor(enabled: Boolean) {
+        viewModelScope.launch {
+            appSettingsManager.setUseSystemMonetColor(enabled)
+        }
+    }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/theme/Theme.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/theme/Theme.kt
@@ -1,5 +1,6 @@
 package com.aliothmoon.maameow.theme
 
+import android.os.Build
 import androidx.compose.foundation.IndicationNodeFactory
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.LocalIndication
@@ -9,14 +10,18 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.node.DelegatableNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.platform.LocalContext
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
 
 private val LightBackground = Color(0xFFF5F2ED)
@@ -114,11 +119,13 @@ private val BlueLight = createLightColorScheme(
     primaryContainer = Color(0xFFE5F1FF),
     onPrimaryContainer = Color(0xFF002453)
 )
+
 private val BlueDark = createDarkColorScheme(
     primary = Color(0xFF2B6BCA),
     primaryContainer = Color(0xFF004088),
     onPrimaryContainer = Color(0xFFD6E8FF)
 )
+
 private val BluePureDark = createDarkColorScheme(
     primary = Color(0xFF2B6BCA),
     primaryContainer = Color(0xFF004088),
@@ -160,13 +167,40 @@ object MaaThemeAlphas {
 @Composable
 fun MaaMeowTheme(
     themeMode: AppSettingsManager.ThemeMode = AppSettingsManager.ThemeMode.SYSTEM,
+    useSystemMonetColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when (themeMode) {
-        AppSettingsManager.ThemeMode.SYSTEM -> if (isSystemInDarkTheme()) BlueDark else BlueLight
-        AppSettingsManager.ThemeMode.WHITE -> BlueLight
-        AppSettingsManager.ThemeMode.DARK -> BlueDark
-        AppSettingsManager.ThemeMode.PURE_DARK -> BluePureDark
+    val context = LocalContext.current
+    val systemDarkTheme = isSystemInDarkTheme()
+    val darkTheme = when (themeMode) {
+        AppSettingsManager.ThemeMode.SYSTEM -> systemDarkTheme
+        AppSettingsManager.ThemeMode.WHITE -> false
+        AppSettingsManager.ThemeMode.DARK,
+        AppSettingsManager.ThemeMode.PURE_DARK -> true
+    }
+    val isPureDark = themeMode == AppSettingsManager.ThemeMode.PURE_DARK
+    val colorScheme: ColorScheme = remember(themeMode, useSystemMonetColor, darkTheme, context) {
+        when {
+            // Android 12+ with monet enabled ==> system dynamic color (Material You)
+            useSystemMonetColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val dynamic = if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+                // PURE_DARK keeps the monet-tinted primary but forces pure-black surfaces
+                if (isPureDark) {
+                    dynamic.copy(
+                        background = PureDarkBackground,
+                        surface = PureDarkSurface,
+                        surfaceVariant = PureDarkSurfaceVariant
+                    )
+                } else dynamic
+            }
+            // Otherwise fall back to the built-in blue palette
+            else -> when (themeMode) {
+                AppSettingsManager.ThemeMode.SYSTEM -> if (systemDarkTheme) BlueDark else BlueLight
+                AppSettingsManager.ThemeMode.WHITE -> BlueLight
+                AppSettingsManager.ThemeMode.DARK -> BlueDark
+                AppSettingsManager.ThemeMode.PURE_DARK -> BluePureDark
+            }
+        }
     }
 
     CompositionLocalProvider(

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -49,7 +49,6 @@
     <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
     <string name="settings_monet_color_title">Monet Theme Color</string>
     <string name="settings_monet_color_desc">Use Material You dynamic color on Android 12+. Off uses the built-in blue theme.</string>
-    <string name="common_back">Back</string>
 
     <string name="settings_achievement_title">Achievements</string>
     <string name="settings_achievement_desc">View MaaMeow milestones and hidden easter eggs</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -46,6 +46,11 @@
     <string name="settings_section_other">Other</string>
     <string name="settings_startup_backend_title">Startup Mode</string>
     <string name="settings_startup_backend_desc">Choose how the app obtains system permissions</string>
+    <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
+    <string name="settings_monet_color_title">Monet Theme Color</string>
+    <string name="settings_monet_color_desc">Use Material You dynamic color on Android 12+. Off uses the built-in blue theme.</string>
+    <string name="common_back">Back</string>
+
     <string name="settings_achievement_title">Achievements</string>
     <string name="settings_achievement_desc">View MaaMeow milestones and hidden easter eggs</string>
     <string name="settings_achievement_debug_title">Achievement Debug</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -244,6 +244,11 @@
     <string name="settings_section_other">其他设置</string>
     <string name="settings_startup_backend_title">启动模式</string>
     <string name="settings_startup_backend_desc">选择应用获取系统权限的方式</string>
+    <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
+    <string name="settings_monet_color_title">莫奈主题色</string>
+    <string name="settings_monet_color_desc">Android 12+ 启用 Material You 动态取色；关闭则使用内置蓝色主题</string>
+    <string name="common_back">返回</string>
+
     <string name="settings_achievement_title">成就</string>
     <string name="settings_achievement_desc">查看 MaaMeow 使用记录与隐藏彩蛋</string>
     <string name="settings_achievement_debug_title">成就调试</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,7 +247,6 @@
     <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
     <string name="settings_monet_color_title">莫奈主题色</string>
     <string name="settings_monet_color_desc">Android 12+ 启用 Material You 动态取色；关闭则使用内置蓝色主题</string>
-    <string name="common_back">返回</string>
 
     <string name="settings_achievement_title">成就</string>
     <string name="settings_achievement_desc">查看 MaaMeow 使用记录与隐藏彩蛋</string>


### PR DESCRIPTION
## Summary

Add a Material You monet toggle in Settings > Other. When enabled on Android 12+, the app follows the system dynamic color; when disabled (or on Android 11 and below) it falls back to the built-in blue theme.  mode keeps the monet-tinted primary but forces pure-black surfaces.

## What changed

- :  now takes a  parameter. On Android 12+ with the toggle on,  /  drive the palette; otherwise the existing blue palette is used.
- : new switch item under Settings > Other (Android 12+ only) wired to .
-  +  + : persisted  boolean (default ).
- : collects the preference and passes it into .
-  + : titles and descriptions for the toggle.

## Behavior

- Android 12+: toggle on = system dynamic color, toggle off = built-in blue.
- Android 11 and below: toggle is hidden, app always uses the built-in blue.
- : background, surface, and surfaceVariant are forced to  /  /  regardless of the toggle.

## Verification

- Local build / lint: passed.
- Upstream diff check:  and other touched files preserve all original blank lines and unrelated code paths.
- New toggle uses the same visual style as the existing debug-mode switch.

## 由 Sourcery 提供的摘要

添加一个用户可配置的开关，在受支持的 Android 版本上使用系统的 Material You 动态色彩，并将其接入应用主题。

新功能：
- 引入一个可持久化的设置，用于启用或禁用系统 Monet（Material You）动态色彩的使用。
- 在“设置 > 其他”中添加一个 Monet 主题色彩开关，仅在 Android 12 及以上设备上可见。
- 在应用主题中支持动态的 Material You 配色方案；当 Monet 被禁用或不受支持时，回退到现有的蓝色调色板。

增强：
- 调整主题处理逻辑，使深色模式和纯黑模式的行为独立于色彩调色板派生，并允许在使用动态主色的同时提供纯黑色表面。

文档：
- 添加本地化的英文和中文字符串，用于描述 Monet 主题色彩设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a user-configurable toggle to use system Material You dynamic colors on supported Android versions and wire it into the app theme.

New Features:
- Introduce a persisted setting to enable or disable use of system Monet (Material You) dynamic colors.
- Add a Monet theme color switch in Settings > Other, visible only on Android 12+ devices.
- Support dynamic Material You color schemes in the app theme, falling back to the existing blue palette when Monet is disabled or unsupported.

Enhancements:
- Adjust theme handling to derive dark mode and pure dark behavior independently of the color palette and to allow pure-dark surfaces with dynamic primary colors.

Documentation:
- Add localized English and Chinese strings describing the Monet theme color setting.

</details>