### PR TITLE
feat: 增加 Shizuku 快捷入口与服务开关控制

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -165,6 +165,10 @@
 
     <queries>
         <package android:name="moe.shizuku.privileged.api" />
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
     </queries>
 
 </manifest>

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -17,6 +17,7 @@ import com.aliothmoon.maameow.domain.models.AppSettingsSchema
 import com.aliothmoon.maameow.domain.models.OverlayControlMode
 import com.aliothmoon.maameow.domain.models.RemoteBackend
 import com.aliothmoon.maameow.domain.models.RunMode
+import com.aliothmoon.maameow.domain.models.ShizukuLaunchMode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -206,7 +207,26 @@ class AppSettingsManager(
         }
     }
 
-    // 自定义 Shizuku 管理器入口
+    // Shizuku 管理器快捷入口模式
+    val shizukuLaunchMode: StateFlow<ShizukuLaunchMode> = settings
+        .map {
+            runCatching { ShizukuLaunchMode.valueOf(it.shizukuLaunchMode) }
+                .getOrDefault(ShizukuLaunchMode.OFF)
+        }
+        .distinctUntilChanged()
+        .stateIn(
+            scope, SharingStarted.Eagerly,
+            runCatching { ShizukuLaunchMode.valueOf(initialSettings.shizukuLaunchMode) }
+                .getOrDefault(ShizukuLaunchMode.OFF)
+        )
+
+    suspend fun setShizukuLaunchMode(mode: ShizukuLaunchMode) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[shizukuLaunchMode] = mode.name }
+        }
+    }
+
+    // 自定义 Shizuku 管理器入口包名
     val shizukuLaunchPackage: StateFlow<String> = settings
         .map { it.shizukuLaunchPackage }
         .distinctUntilChanged()

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -206,6 +206,18 @@ class AppSettingsManager(
         }
     }
 
+    // 自定义 Shizuku 管理器入口
+    val shizukuLaunchPackage: StateFlow<String> = settings
+        .map { it.shizukuLaunchPackage }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.shizukuLaunchPackage)
+
+    suspend fun setShizukuLaunchPackage(packageName: String) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[shizukuLaunchPackage] = packageName.trim() }
+        }
+    }
+
     // 游戏启动时静音
     val muteOnGameLaunch: StateFlow<Boolean> = settings
         .map { it.muteOnGameLaunch.toBooleanStrictOrNull() ?: false }

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -25,6 +25,11 @@ data class AppSettings(
 
     @PrefKey(default = "false") val skipShizukuCheck: String = "false",
 
+    /**
+     * 自定义 Shizuku 管理器入口包名，留空时使用官方 Shizuku。
+     */
+    @PrefKey(default = "") val shizukuLaunchPackage: String = "",
+
     @PrefKey(default = "false") val muteOnGameLaunch: String = "false",
 
     @PrefKey(default = "false") val closeAppOnTaskEnd: String = "false",

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -26,8 +26,10 @@ data class AppSettings(
     @PrefKey(default = "false") val skipShizukuCheck: String = "false",
 
     /**
-     * 自定义 Shizuku 管理器入口包名，留空时使用官方 Shizuku。
+     * Shizuku 管理器快捷入口设置。
+     * 模式默认关闭；自定义包名仅在 CUSTOM 模式下作为打开入口使用。
      */
+    @PrefKey(default = "OFF") val shizukuLaunchMode: String = "OFF",
     @PrefKey(default = "") val shizukuLaunchPackage: String = "",
 
     @PrefKey(default = "false") val muteOnGameLaunch: String = "false",

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/ShizukuLaunchMode.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/ShizukuLaunchMode.kt
@@ -1,0 +1,7 @@
+package com.aliothmoon.maameow.domain.models
+
+enum class ShizukuLaunchMode {
+    OFF,
+    OFFICIAL,
+    CUSTOM
+}

--- a/app/src/main/java/com/aliothmoon/maameow/manager/ShizukuInstallHelper.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/manager/ShizukuInstallHelper.kt
@@ -20,7 +20,7 @@ object ShizukuInstallHelper {
         NOT_INSTALLED       // 均未检测到，需要安装
     }
 
-    fun checkStatus(context: Context): ShizukuStatus {
+    fun checkStatus(context: Context, customPackageName: String = ""): ShizukuStatus {
         val isSui = try { Sui.init(context.packageName) } catch (_: Exception) { false }
 
         if (isSui) {
@@ -31,12 +31,8 @@ object ShizukuInstallHelper {
             return ShizukuStatus.READY
         }
 
-        val appInstalled = try {
-            context.packageManager.getPackageInfo(SHIZUKU_PACKAGE, 0)
-            true
-        } catch (_: PackageManager.NameNotFoundException) {
-            false
-        }
+        val appInstalled = isPackageInstalled(context, SHIZUKU_PACKAGE) ||
+                isPackageInstalled(context, customPackageName)
 
         return if (appInstalled) ShizukuStatus.APP_NOT_RUNNING
         else ShizukuStatus.NOT_INSTALLED
@@ -59,6 +55,44 @@ object ShizukuInstallHelper {
             true
         } catch (e: Exception) {
             Timber.e(e, "Failed to install Shizuku")
+            false
+        }
+    }
+
+    fun openShizuku(context: Context, customPackageName: String = ""): Boolean {
+        return try {
+            // 自定义入口不可用时回退官方 Shizuku，保证默认流程仍可用。
+            val intent = launchIntentForPackage(context, customPackageName)
+                ?: launchIntentForPackage(context, SHIZUKU_PACKAGE)
+                ?: return false
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+            true
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to open Shizuku")
+            false
+        }
+    }
+
+    fun getLaunchAppLabel(context: Context, packageName: String): String? {
+        if (packageName.isBlank()) return null
+        return runCatching {
+            val info = context.packageManager.getApplicationInfo(packageName, 0)
+            context.packageManager.getApplicationLabel(info).toString()
+        }.getOrNull()
+    }
+
+    private fun launchIntentForPackage(context: Context, packageName: String): Intent? {
+        if (packageName.isBlank()) return null
+        return context.packageManager.getLaunchIntentForPackage(packageName)
+    }
+
+    private fun isPackageInstalled(context: Context, packageName: String): Boolean {
+        if (packageName.isBlank()) return false
+        return try {
+            context.packageManager.getPackageInfo(packageName, 0)
+            true
+        } catch (_: PackageManager.NameNotFoundException) {
             false
         }
     }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/AdaptiveTaskPromptDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/AdaptiveTaskPromptDialog.kt
@@ -363,7 +363,7 @@ private fun TaskPromptCard(
                         ) {
                             Text(confirmText, maxLines = 1, style = MaterialTheme.typography.bodySmall)
                         }
-                        dismissText?.let {
+                        dismissText?.takeIf { it.isNotBlank() }?.let {
                             TextButton(
                                 onClick = onDismissRequest,
                                 contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
@@ -467,7 +467,7 @@ private fun TaskPromptButtons(
         }
 
         // 取消/辅助按钮：Text
-        dismissText?.let {
+        dismissText?.takeIf { it.isNotBlank() }?.let {
             TextButton(
                 onClick = onDismissRequest,
                 shape = MaterialTheme.shapes.large

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/ShizukuPermissionDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/ShizukuPermissionDialog.kt
@@ -13,20 +13,26 @@ fun ShizukuPermissionDialog(
     message: String,
     isRequesting: Boolean,
     onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    confirmText: String? = null,
+    dismissText: String? = null,
+    dismissOnOutsideClick: Boolean = true,
 ) {
+    val resolvedDismissText = dismissText ?: stringResource(R.string.common_cancel)
+
     AdaptiveTaskPromptDialog(
         visible = true,
         title = title,
         message = message,
         onConfirm = onConfirm,
-        onDismissRequest = {}, // 不允许通过关闭请求取消
-        dismissOnOutsideClick = false,
+        onDismissRequest = onDismiss,
+        dismissOnOutsideClick = dismissOnOutsideClick,
         confirmText = if (isRequesting) {
             stringResource(R.string.shizuku_auth_requesting)
         } else {
-            stringResource(R.string.shizuku_auth_grant_now)
+            confirmText ?: stringResource(R.string.shizuku_auth_grant_now)
         },
-        dismissText = null,
+        dismissText = resolvedDismissText,
         icon = Icons.Rounded.Build,
         confirmColor = MaterialTheme.colorScheme.primary
     )

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/state/HomeUiState.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/state/HomeUiState.kt
@@ -13,6 +13,7 @@ data class HomeUiState(
     val serviceStatusText: UiText = UiText.Empty,
     val serviceStatusColor: StatusColorType = StatusColorType.NEUTRAL,
     val serviceStatusLoading: Boolean = false,
+    val remoteServiceActive: Boolean = false,
     val resourceInitState: ResourceInitState = ResourceInitState.NotChecked,
     val runMode: RunMode = RunMode.BACKGROUND,
     val overlayControlMode: OverlayControlMode = OverlayControlMode.FLOAT_BALL,
@@ -20,4 +21,3 @@ data class HomeUiState(
     val showRunModeUnsupportedDialog: Boolean = false,
     val runModeUnsupportedMessage: UiText = UiText.Empty
 )
-

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
@@ -207,7 +207,7 @@ fun BackgroundTaskView(
         var isRequestingRemoteAccess by remember { mutableStateOf(false) }
         val canOpenShizukuShortcut = permissions.startupBackend == RemoteBackend.SHIZUKU &&
                 shizukuLaunchMode != ShizukuLaunchMode.OFF
-        val shortcutPackageName = if (shizukuLaunchMode == ShizukuLaunchMode.CUSTOM) {
+        val shortcutPackageName = if (shizukuLaunchMode != ShizukuLaunchMode.OFF) {
             shizukuLaunchPackage
         } else {
             ""

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
@@ -81,10 +81,13 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.constant.DefaultDisplayConfig
+import com.aliothmoon.maameow.domain.models.RemoteBackend
+import com.aliothmoon.maameow.domain.models.ShizukuLaunchMode
 import com.aliothmoon.maameow.domain.service.MaaCompositionService
 import com.aliothmoon.maameow.domain.service.UnifiedStateDispatcher
 import com.aliothmoon.maameow.domain.state.MaaExecutionState
 import com.aliothmoon.maameow.manager.PermissionManager
+import com.aliothmoon.maameow.manager.ShizukuInstallHelper
 import com.aliothmoon.maameow.presentation.components.AdaptiveTaskPromptDialog
 import com.aliothmoon.maameow.presentation.components.ShizukuPermissionDialog
 import com.aliothmoon.maameow.presentation.view.panel.PanelHeader
@@ -135,6 +138,7 @@ fun BackgroundTaskView(
     permissionManager: PermissionManager = koinInject(),
     screenSaverManager: ScreenSaverOverlayManager = koinInject(),
     appWatchdog: AppWatchdog = koinInject(),
+    appSettingsManager: AppSettingsManager = koinInject(),
 ) {
 
     val coroutineScope = rememberCoroutineScope()
@@ -143,6 +147,8 @@ fun BackgroundTaskView(
     val markers by viewModel.markers.collectAsStateWithLifecycle()
     val displayResolution by compositionService.displayResolution.collectAsStateWithLifecycle()
     val permissions by permissionManager.state.collectAsStateWithLifecycle()
+    val shizukuLaunchMode by appSettingsManager.shizukuLaunchMode.collectAsStateWithLifecycle()
+    val shizukuLaunchPackage by appSettingsManager.shizukuLaunchPackage.collectAsStateWithLifecycle()
     val isChainLoaded by viewModel.chainState.isLoaded.collectAsStateWithLifecycle()
     var hasInitialized by rememberSaveable { mutableStateOf(false) }
     if (isChainLoaded) {
@@ -191,33 +197,85 @@ fun BackgroundTaskView(
         )
     )
 
-    if (!permissions.remoteAccessGranted) {
+    var showRemoteAccessDialog by remember { mutableStateOf(true) }
+
+    LaunchedEffect(permissions.remoteAccessGranted, permissions.startupBackend) {
+        showRemoteAccessDialog = !permissions.remoteAccessGranted
+    }
+
+    if (!permissions.remoteAccessGranted && showRemoteAccessDialog) {
         var isRequestingRemoteAccess by remember { mutableStateOf(false) }
+        val canOpenShizukuShortcut = permissions.startupBackend == RemoteBackend.SHIZUKU &&
+                shizukuLaunchMode != ShizukuLaunchMode.OFF
+        val shortcutPackageName = if (shizukuLaunchMode == ShizukuLaunchMode.CUSTOM) {
+            shizukuLaunchPackage
+        } else {
+            ""
+        }
         ShizukuPermissionDialog(
             title = stringResource(
                 R.string.bg_shizuku_permission_title,
                 permissions.startupBackend.display
             ),
-            message = stringResource(
-                R.string.bg_shizuku_permission_message,
-                permissions.startupBackend.display
-            ),
+            message = if (canOpenShizukuShortcut) {
+                stringResource(
+                    R.string.bg_shizuku_permission_message,
+                    permissions.startupBackend.display
+                )
+            } else {
+                stringResource(
+                    R.string.bg_remote_access_unavailable_message,
+                    permissions.startupBackend.display
+                )
+            },
             isRequesting = isRequestingRemoteAccess,
             onConfirm = {
                 if (isRequestingRemoteAccess) return@ShizukuPermissionDialog
+                if (canOpenShizukuShortcut) {
+                    val opened = ShizukuInstallHelper.openShizuku(context, shortcutPackageName)
+                    if (!opened) {
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.home_toast_open_shizuku_failed),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                    return@ShizukuPermissionDialog
+                }
                 coroutineScope.launch {
                     isRequestingRemoteAccess = true
                     val granted = permissionManager.requestRemoteAccess()
                     isRequestingRemoteAccess = false
                     if (!granted) {
+                        val message = if (!permissions.isStartupBackendAvailable(permissions.startupBackend)) {
+                            context.getString(
+                                R.string.bg_toast_remote_access_unavailable,
+                                permissions.startupBackend.display
+                            )
+                        } else {
+                            permissionNotAcquiredFormat.format(currentPermissionLabel)
+                        }
                         Toast.makeText(
                             context,
-                            permissionNotAcquiredFormat.format(currentPermissionLabel),
+                            message,
                             Toast.LENGTH_SHORT
                         ).show()
                     }
                 }
-            })
+            },
+            onDismiss = { showRemoteAccessDialog = false },
+            confirmText = if (canOpenShizukuShortcut) {
+                stringResource(R.string.dialog_shizuku_open_app)
+            } else {
+                null
+            },
+            dismissText = if (canOpenShizukuShortcut) {
+                stringResource(R.string.common_cancel)
+            } else {
+                ""
+            },
+            dismissOnOutsideClick = canOpenShizukuShortcut
+        )
     }
 
 
@@ -496,6 +554,10 @@ fun BackgroundTaskView(
                                 Button(
                                     onClick = {
                                         focusManager.clearFocus()
+                                        if (!permissions.remoteAccessGranted) {
+                                            showRemoteAccessDialog = true
+                                            return@Button
+                                        }
                                         when (state.current) {
                                             PanelTab.TASKS -> viewModel.onStartTasks()
                                             PanelTab.AUTO_BATTLE -> copilotViewModel.onStart()

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
@@ -258,13 +258,7 @@ fun HomeView(
                         appVersion = appVersion,
                         serviceStatusColor = uiState.serviceStatusColor,
                         serviceStatusText = uiState.serviceStatusText,
-                        serviceStatusLoading = uiState.serviceStatusLoading,
-                        remoteServiceActive = uiState.remoteServiceActive,
-                        isLoading = uiState.isLoading,
-                        showShizukuShortcut = permissionState.startupBackend == RemoteBackend.SHIZUKU &&
-                                shizukuLaunchMode != ShizukuLaunchMode.OFF,
-                        onOpenShizuku = { viewModel.onOpenShizuku() },
-                        onToggleRemoteService = { viewModel.onToggleRemoteService() }
+                        serviceStatusLoading = uiState.serviceStatusLoading
                     )
                 }
 
@@ -291,6 +285,17 @@ fun HomeView(
                         onRequestBatteryWhitelist = { viewModel.onRequestBatteryWhitelist(context) },
                         onRequestAccessibility = { viewModel.onRequestAccessibility(context) },
                         onRequestNotification = { viewModel.onRequestNotification(context) }
+                    )
+                }
+
+                item {
+                    HomeServiceActionButtons(
+                        remoteServiceActive = uiState.remoteServiceActive,
+                        isLoading = uiState.isLoading,
+                        showShizukuShortcut = permissionState.startupBackend == RemoteBackend.SHIZUKU &&
+                                shizukuLaunchMode != ShizukuLaunchMode.OFF,
+                        onOpenShizuku = { viewModel.onOpenShizuku() },
+                        onToggleRemoteService = { viewModel.onToggleRemoteService() }
                     )
                 }
 
@@ -413,12 +418,7 @@ private fun ScreenInfoCard(
     appVersion: String,
     serviceStatusColor: StatusColorType,
     serviceStatusText: UiText,
-    serviceStatusLoading: Boolean,
-    remoteServiceActive: Boolean,
-    isLoading: Boolean,
-    showShizukuShortcut: Boolean,
-    onOpenShizuku: () -> Unit,
-    onToggleRemoteService: () -> Unit
+    serviceStatusLoading: Boolean
 ) {
     val serviceStatusLabel = serviceStatusText.asString()
     Card(
@@ -533,103 +533,107 @@ private fun ScreenInfoCard(
                     }
                 }
             }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
+        }
+    }
+}
+
+@Composable
+private fun HomeServiceActionButtons(
+    remoteServiceActive: Boolean,
+    isLoading: Boolean,
+    showShizukuShortcut: Boolean,
+    onOpenShizuku: () -> Unit,
+    onToggleRemoteService: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        val serviceButtonContent: @Composable RowScope.() -> Unit = {
+            Icon(
+                imageVector = Icons.Rounded.Refresh,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.size(6.dp))
+            Text(
+                text = stringResource(
+                    if (remoteServiceActive) R.string.home_btn_close_service
+                    else R.string.home_btn_open_service
+                ),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                maxLines = 2,
+                textAlign = TextAlign.Center
+            )
+        }
+        if (remoteServiceActive) {
+            OutlinedButton(
+                onClick = onToggleRemoteService,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = MaterialTheme.shapes.large,
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error.copy(alpha = 0.82f)
+                ),
+                border = BorderStroke(
+                    1.dp,
+                    MaterialTheme.colorScheme.error.copy(alpha = 0.45f)
+                ),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                enabled = !isLoading,
+                content = serviceButtonContent
+            )
+        } else {
+            OutlinedButton(
+                onClick = onToggleRemoteService,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = MaterialTheme.shapes.large,
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.primary
+                ),
+                border = BorderStroke(
+                    1.dp,
+                    MaterialTheme.colorScheme.primary.copy(alpha = 0.55f)
+                ),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                enabled = !isLoading,
+                content = serviceButtonContent
+            )
+        }
+        if (showShizukuShortcut) {
+            OutlinedButton(
+                onClick = onOpenShizuku,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = MaterialTheme.shapes.large,
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.secondary
+                ),
+                border = BorderStroke(
+                    1.dp,
+                    MaterialTheme.colorScheme.secondary.copy(alpha = 0.55f)
+                ),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                enabled = !isLoading
             ) {
-                if (showShizukuShortcut) {
-                    OutlinedButton(
-                        onClick = onOpenShizuku,
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(52.dp),
-                        shape = MaterialTheme.shapes.large,
-                        colors = ButtonDefaults.outlinedButtonColors(
-                            contentColor = MaterialTheme.colorScheme.primary
-                        ),
-                        border = BorderStroke(
-                            1.dp,
-                            MaterialTheme.colorScheme.primary.copy(alpha = 0.55f)
-                        ),
-                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
-                        enabled = !isLoading
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.Build,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp)
-                        )
-                        Spacer(modifier = Modifier.size(6.dp))
-                        Text(
-                            text = stringResource(R.string.home_btn_open_shizuku),
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium,
-                            maxLines = 2,
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.weight(1f, fill = false)
-                        )
-                    }
-                }
-                val serviceButtonModifier = Modifier
-                    .then(
-                        if (showShizukuShortcut) Modifier.weight(1f)
-                        else Modifier.fillMaxWidth()
-                    )
-                    .height(52.dp)
-                val serviceButtonContentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
-                val serviceButtonContent: @Composable RowScope.() -> Unit = {
-                    Icon(
-                        imageVector = Icons.Rounded.Refresh,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp)
-                    )
-                    Spacer(modifier = Modifier.size(6.dp))
-                    Text(
-                        text = stringResource(
-                            if (remoteServiceActive) R.string.home_btn_close_service
-                            else R.string.home_btn_open_service
-                        ),
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        maxLines = 2,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.weight(1f, fill = false)
-                    )
-                }
-                if (remoteServiceActive) {
-                    OutlinedButton(
-                        onClick = onToggleRemoteService,
-                        modifier = serviceButtonModifier,
-                        shape = MaterialTheme.shapes.large,
-                        colors = ButtonDefaults.outlinedButtonColors(
-                            contentColor = MaterialTheme.colorScheme.error.copy(alpha = 0.82f)
-                        ),
-                        border = BorderStroke(
-                            1.dp,
-                            MaterialTheme.colorScheme.error.copy(alpha = 0.45f)
-                        ),
-                        contentPadding = serviceButtonContentPadding,
-                        enabled = !isLoading,
-                        content = serviceButtonContent
-                    )
-                } else {
-                    OutlinedButton(
-                        onClick = onToggleRemoteService,
-                        modifier = serviceButtonModifier,
-                        shape = MaterialTheme.shapes.large,
-                        colors = ButtonDefaults.outlinedButtonColors(
-                            contentColor = MaterialTheme.colorScheme.primary
-                        ),
-                        border = BorderStroke(
-                            1.dp,
-                            MaterialTheme.colorScheme.primary.copy(alpha = 0.55f)
-                        ),
-                        contentPadding = serviceButtonContentPadding,
-                        enabled = !isLoading,
-                        content = serviceButtonContent
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Rounded.Build,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.size(6.dp))
+                Text(
+                    text = stringResource(R.string.home_btn_open_shizuku),
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 2,
+                    textAlign = TextAlign.Center
+                )
             }
         }
     }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -26,6 +27,7 @@ import androidx.compose.material.icons.rounded.Build
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
 import androidx.compose.material.icons.rounded.KeyboardArrowUp
+import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -72,7 +74,6 @@ import com.aliothmoon.maameow.domain.models.RemoteBackend
 import com.aliothmoon.maameow.domain.models.RunMode
 import com.aliothmoon.maameow.domain.state.ResourceInitState
 import com.aliothmoon.maameow.manager.PermissionManager
-import com.aliothmoon.maameow.manager.RemoteServiceManager
 import com.aliothmoon.maameow.manager.ShizukuInstallHelper
 import com.aliothmoon.maameow.presentation.components.AdaptiveTaskPromptDialog
 import com.aliothmoon.maameow.presentation.components.ChangelogDialog
@@ -107,7 +108,6 @@ fun HomeView(
     val permissionState by permissionManager.state.collectAsStateWithLifecycle()
     val resourceVersion by updateViewModel.currentResourceVersion.collectAsStateWithLifecycle()
     val appVersion = updateViewModel.currentAppVersion
-    val state by RemoteServiceManager.state.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
     val (width, height) = Misc.getScreenSize(context)
@@ -256,7 +256,11 @@ fun HomeView(
                         appVersion = appVersion,
                         serviceStatusColor = uiState.serviceStatusColor,
                         serviceStatusText = uiState.serviceStatusText,
-                        serviceStatusLoading = uiState.serviceStatusLoading
+                        serviceStatusLoading = uiState.serviceStatusLoading,
+                        remoteServiceActive = uiState.remoteServiceActive,
+                        isLoading = uiState.isLoading,
+                        onOpenShizuku = { viewModel.onOpenShizuku() },
+                        onToggleRemoteService = { viewModel.onToggleRemoteService() }
                     )
                 }
 
@@ -308,65 +312,17 @@ fun HomeView(
                     }
                 }
 
-                if (
-                    state !is RemoteServiceManager.ServiceState.Connected
-                    && state !is RemoteServiceManager.ServiceState.Connecting
-                    && permissionState.remoteAccessGranted
-                ) {
-                    item {
-                        OutlinedButton(
-                            onClick = { viewModel.onReloadServices() },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(48.dp),
-                            shape = MaterialTheme.shapes.large,
-                            enabled = !uiState.isLoading
-                        ) {
-                            Text(
-                                text = stringResource(R.string.home_btn_reload_services),
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = FontWeight.Medium
-                            )
-                        }
-                    }
-                }
-
-                item {
-                    OutlinedButton(
-                        onClick = {
-                            Timber.d("关闭所有服务")
-                            viewModel.onStopAllServices()
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(48.dp),
-                        colors = ButtonDefaults.outlinedButtonColors(
-                            contentColor = MaterialTheme.colorScheme.error
-                        ),
-                        border = BorderStroke(
-                            1.dp,
-                            MaterialTheme.colorScheme.error.copy(alpha = 0.6f)
-                        ),
-                        shape = MaterialTheme.shapes.large,
-                        enabled = !uiState.isLoading
-                    ) {
-                        Text(
-                            text = stringResource(R.string.home_btn_stop_all_services),
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.Medium
-                        )
-                    }
-                }
             }
         }
 
         // Shizuku/Sui 检测
         val skipShizukuCheck by appSettingsManager.skipShizukuCheck.collectAsStateWithLifecycle()
-        var shizukuStatus by remember {
-            mutableStateOf(ShizukuInstallHelper.checkStatus(context))
+        val shizukuLaunchPackage by appSettingsManager.shizukuLaunchPackage.collectAsStateWithLifecycle()
+        var shizukuStatus by remember(shizukuLaunchPackage) {
+            mutableStateOf(ShizukuInstallHelper.checkStatus(context, shizukuLaunchPackage))
         }
-        LifecycleResumeEffect(Unit) {
-            shizukuStatus = ShizukuInstallHelper.checkStatus(context)
+        LifecycleResumeEffect(shizukuLaunchPackage) {
+            shizukuStatus = ShizukuInstallHelper.checkStatus(context, shizukuLaunchPackage)
             onPauseOrDispose {}
         }
         if (permissionState.startupBackend == RemoteBackend.SHIZUKU && !skipShizukuCheck) {
@@ -402,11 +358,7 @@ fun HomeView(
                         icon = Icons.Rounded.Build,
                         confirmText = stringResource(R.string.dialog_shizuku_open_app),
                         onConfirm = {
-                            runCatching {
-                                val intent =
-                                    context.packageManager.getLaunchIntentForPackage("moe.shizuku.privileged.api")
-                                if (intent != null) context.startActivity(intent)
-                            }
+                            ShizukuInstallHelper.openShizuku(context, shizukuLaunchPackage)
                         },
                         neutralText = if (permissionState.rootAvailable)
                             stringResource(R.string.dialog_shizuku_switch_to_root)
@@ -452,7 +404,11 @@ private fun ScreenInfoCard(
     appVersion: String,
     serviceStatusColor: StatusColorType,
     serviceStatusText: UiText,
-    serviceStatusLoading: Boolean
+    serviceStatusLoading: Boolean,
+    remoteServiceActive: Boolean,
+    isLoading: Boolean,
+    onOpenShizuku: () -> Unit,
+    onToggleRemoteService: () -> Unit
 ) {
     val serviceStatusLabel = serviceStatusText.asString()
     Card(
@@ -565,6 +521,89 @@ private fun ScreenInfoCard(
                             color = statusColor
                         )
                     }
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OutlinedButton(
+                    onClick = onOpenShizuku,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(52.dp),
+                    shape = MaterialTheme.shapes.large,
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                    enabled = !isLoading
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Build,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.size(6.dp))
+                    Text(
+                        text = stringResource(R.string.home_btn_open_shizuku),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 2,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.weight(1f, fill = false)
+                    )
+                }
+                val serviceButtonModifier = Modifier
+                    .weight(1f)
+                    .height(52.dp)
+                val serviceButtonContentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+                val serviceButtonContent: @Composable RowScope.() -> Unit = {
+                    Icon(
+                        imageVector = Icons.Rounded.Refresh,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.size(6.dp))
+                    Text(
+                        text = stringResource(
+                            if (remoteServiceActive) R.string.home_btn_close_service
+                            else R.string.home_btn_open_service
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 2,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.weight(1f, fill = false)
+                    )
+                }
+                if (remoteServiceActive) {
+                    OutlinedButton(
+                        onClick = onToggleRemoteService,
+                        modifier = serviceButtonModifier,
+                        shape = MaterialTheme.shapes.large,
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error.copy(alpha = 0.82f)
+                        ),
+                        border = BorderStroke(
+                            1.dp,
+                            MaterialTheme.colorScheme.error.copy(alpha = 0.45f)
+                        ),
+                        contentPadding = serviceButtonContentPadding,
+                        enabled = !isLoading,
+                        content = serviceButtonContent
+                    )
+                } else {
+                    Button(
+                        onClick = onToggleRemoteService,
+                        modifier = serviceButtonModifier,
+                        shape = MaterialTheme.shapes.large,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary,
+                            contentColor = MaterialTheme.colorScheme.onPrimary
+                        ),
+                        contentPadding = serviceButtonContentPadding,
+                        enabled = !isLoading,
+                        content = serviceButtonContent
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
@@ -322,7 +322,7 @@ fun HomeView(
         // Shizuku/Sui 检测
         val skipShizukuCheck by appSettingsManager.skipShizukuCheck.collectAsStateWithLifecycle()
         val shizukuLaunchPackage by appSettingsManager.shizukuLaunchPackage.collectAsStateWithLifecycle()
-        val shizukuStatusPackage = if (shizukuLaunchMode == ShizukuLaunchMode.CUSTOM) {
+        val shizukuStatusPackage = if (shizukuLaunchMode != ShizukuLaunchMode.OFF) {
             shizukuLaunchPackage
         } else {
             ""
@@ -545,6 +545,13 @@ private fun ScreenInfoCard(
                             .weight(1f)
                             .height(52.dp),
                         shape = MaterialTheme.shapes.large,
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.primary
+                        ),
+                        border = BorderStroke(
+                            1.dp,
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.55f)
+                        ),
                         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
                         enabled = !isLoading
                     ) {
@@ -607,13 +614,16 @@ private fun ScreenInfoCard(
                         content = serviceButtonContent
                     )
                 } else {
-                    Button(
+                    OutlinedButton(
                         onClick = onToggleRemoteService,
                         modifier = serviceButtonModifier,
                         shape = MaterialTheme.shapes.large,
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                            contentColor = MaterialTheme.colorScheme.onPrimary
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.primary
+                        ),
+                        border = BorderStroke(
+                            1.dp,
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.55f)
                         ),
                         contentPadding = serviceButtonContentPadding,
                         enabled = !isLoading,

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
@@ -72,6 +72,7 @@ import com.aliothmoon.maameow.data.permission.PermissionState
 import com.aliothmoon.maameow.domain.models.OverlayControlMode
 import com.aliothmoon.maameow.domain.models.RemoteBackend
 import com.aliothmoon.maameow.domain.models.RunMode
+import com.aliothmoon.maameow.domain.models.ShizukuLaunchMode
 import com.aliothmoon.maameow.domain.state.ResourceInitState
 import com.aliothmoon.maameow.manager.PermissionManager
 import com.aliothmoon.maameow.manager.ShizukuInstallHelper
@@ -111,6 +112,7 @@ fun HomeView(
 
     val context = LocalContext.current
     val (width, height) = Misc.getScreenSize(context)
+    val shizukuLaunchMode by appSettingsManager.shizukuLaunchMode.collectAsStateWithLifecycle()
 
     val startupDialog by updateViewModel.startupUpdateDialog.collectAsStateWithLifecycle()
 
@@ -259,6 +261,8 @@ fun HomeView(
                         serviceStatusLoading = uiState.serviceStatusLoading,
                         remoteServiceActive = uiState.remoteServiceActive,
                         isLoading = uiState.isLoading,
+                        showShizukuShortcut = permissionState.startupBackend == RemoteBackend.SHIZUKU &&
+                                shizukuLaunchMode != ShizukuLaunchMode.OFF,
                         onOpenShizuku = { viewModel.onOpenShizuku() },
                         onToggleRemoteService = { viewModel.onToggleRemoteService() }
                     )
@@ -318,11 +322,16 @@ fun HomeView(
         // Shizuku/Sui 检测
         val skipShizukuCheck by appSettingsManager.skipShizukuCheck.collectAsStateWithLifecycle()
         val shizukuLaunchPackage by appSettingsManager.shizukuLaunchPackage.collectAsStateWithLifecycle()
-        var shizukuStatus by remember(shizukuLaunchPackage) {
-            mutableStateOf(ShizukuInstallHelper.checkStatus(context, shizukuLaunchPackage))
+        val shizukuStatusPackage = if (shizukuLaunchMode == ShizukuLaunchMode.CUSTOM) {
+            shizukuLaunchPackage
+        } else {
+            ""
         }
-        LifecycleResumeEffect(shizukuLaunchPackage) {
-            shizukuStatus = ShizukuInstallHelper.checkStatus(context, shizukuLaunchPackage)
+        var shizukuStatus by remember(shizukuStatusPackage) {
+            mutableStateOf(ShizukuInstallHelper.checkStatus(context, shizukuStatusPackage))
+        }
+        LifecycleResumeEffect(shizukuStatusPackage) {
+            shizukuStatus = ShizukuInstallHelper.checkStatus(context, shizukuStatusPackage)
             onPauseOrDispose {}
         }
         if (permissionState.startupBackend == RemoteBackend.SHIZUKU && !skipShizukuCheck) {
@@ -358,7 +367,7 @@ fun HomeView(
                         icon = Icons.Rounded.Build,
                         confirmText = stringResource(R.string.dialog_shizuku_open_app),
                         onConfirm = {
-                            ShizukuInstallHelper.openShizuku(context, shizukuLaunchPackage)
+                            ShizukuInstallHelper.openShizuku(context, shizukuStatusPackage)
                         },
                         neutralText = if (permissionState.rootAvailable)
                             stringResource(R.string.dialog_shizuku_switch_to_root)
@@ -407,6 +416,7 @@ private fun ScreenInfoCard(
     serviceStatusLoading: Boolean,
     remoteServiceActive: Boolean,
     isLoading: Boolean,
+    showShizukuShortcut: Boolean,
     onOpenShizuku: () -> Unit,
     onToggleRemoteService: () -> Unit
 ) {
@@ -528,32 +538,37 @@ private fun ScreenInfoCard(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                OutlinedButton(
-                    onClick = onOpenShizuku,
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(52.dp),
-                    shape = MaterialTheme.shapes.large,
-                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
-                    enabled = !isLoading
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.Build,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp)
-                    )
-                    Spacer(modifier = Modifier.size(6.dp))
-                    Text(
-                        text = stringResource(R.string.home_btn_open_shizuku),
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        maxLines = 2,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.weight(1f, fill = false)
-                    )
+                if (showShizukuShortcut) {
+                    OutlinedButton(
+                        onClick = onOpenShizuku,
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(52.dp),
+                        shape = MaterialTheme.shapes.large,
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                        enabled = !isLoading
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.Build,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.size(6.dp))
+                        Text(
+                            text = stringResource(R.string.home_btn_open_shizuku),
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 2,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.weight(1f, fill = false)
+                        )
+                    }
                 }
                 val serviceButtonModifier = Modifier
-                    .weight(1f)
+                    .then(
+                        if (showShizukuShortcut) Modifier.weight(1f)
+                        else Modifier.fillMaxWidth()
+                    )
                     .height(52.dp)
                 val serviceButtonContentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
                 val serviceButtonContent: @Composable RowScope.() -> Unit = {

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -1,5 +1,6 @@
 package com.aliothmoon.maameow.presentation.view.settings
 
+import android.content.Context
 import android.content.Intent
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -13,14 +14,17 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.rounded.Build
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -28,6 +32,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -59,8 +64,10 @@ import com.aliothmoon.maameow.domain.service.AchievementReporter
 import com.aliothmoon.maameow.domain.service.LogExportService
 import com.aliothmoon.maameow.domain.service.ResourceInitService
 import com.aliothmoon.maameow.domain.state.ResourceInitState
+import com.aliothmoon.maameow.manager.ShizukuInstallHelper
 import com.aliothmoon.maameow.presentation.components.AdaptiveTaskPromptDialog
 import com.aliothmoon.maameow.presentation.components.InfoCard
+import com.aliothmoon.maameow.presentation.components.ITextField
 import com.aliothmoon.maameow.presentation.components.ReInitializeConfirmDialog
 import com.aliothmoon.maameow.presentation.components.ResourceInitDialog
 import com.aliothmoon.maameow.presentation.components.TopAppBar
@@ -69,7 +76,10 @@ import com.aliothmoon.maameow.theme.MaaDesignTokens
 import com.aliothmoon.maameow.utils.Misc
 import com.aliothmoon.maameow.utils.i18n.LocaleBootstrap.resolveSelectedLanguage
 import com.aliothmoon.maameow.utils.i18n.resolve
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
@@ -88,6 +98,7 @@ fun SettingsView(
     val autoDownloadUpdate by viewModel.autoDownloadUpdate.collectAsStateWithLifecycle()
     val startupBackend by viewModel.startupBackend.collectAsStateWithLifecycle()
     val skipShizukuCheck by viewModel.skipShizukuCheck.collectAsStateWithLifecycle()
+    val shizukuLaunchPackage by viewModel.shizukuLaunchPackage.collectAsStateWithLifecycle()
     val deploymentWithPause by viewModel.deploymentWithPause.collectAsStateWithLifecycle()
     val forceFullscreenOnVirtualDisplay by viewModel.forceFullscreenOnVirtualDisplay.collectAsStateWithLifecycle()
     val allowForegroundScheduledTask by viewModel.allowForegroundScheduledTask.collectAsStateWithLifecycle()
@@ -113,6 +124,29 @@ fun SettingsView(
     ) { uri ->
         uri ?: return@rememberLauncherForActivityResult
         context.contentResolver.openInputStream(uri)?.let { viewModel.importConfig(it) }
+    }
+
+    var showShizukuAppPicker by remember { mutableStateOf(false) }
+    var shizukuAppPickerLoadKey by remember { mutableStateOf(0) }
+    var shizukuAppSearch by remember { mutableStateOf("") }
+    var shizukuAppOptions by remember { mutableStateOf<List<ShizukuLaunchAppOption>?>(null) }
+    var shizukuAppLoadFailed by remember { mutableStateOf(false) }
+
+    LaunchedEffect(showShizukuAppPicker, shizukuAppPickerLoadKey) {
+        if (!showShizukuAppPicker) return@LaunchedEffect
+
+        shizukuAppLoadFailed = false
+        shizukuAppOptions = null
+        shizukuAppOptions = try {
+            withContext(Dispatchers.IO) {
+                loadShizukuLaunchApps(context.applicationContext)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            shizukuAppLoadFailed = true
+            emptyList()
+        }
     }
 
     backupMessage?.let { msg ->
@@ -168,6 +202,113 @@ fun SettingsView(
         ResourceInitDialog(
             state = resourceInitState,
             onRetry = {}
+        )
+    }
+
+    if (showShizukuAppPicker) {
+        val searchText = shizukuAppSearch.trim()
+        val filteredOptions = shizukuAppOptions
+            ?.filter { option ->
+                searchText.isBlank() ||
+                        option.label.contains(searchText, ignoreCase = true) ||
+                        option.packageName.contains(searchText, ignoreCase = true)
+            }
+            .orEmpty()
+
+        AdaptiveTaskPromptDialog(
+            visible = true,
+            title = stringResource(R.string.settings_shizuku_launch_app_picker_title),
+            icon = Icons.Rounded.Build,
+            confirmText = stringResource(R.string.common_close),
+            dismissText = "",
+            onConfirm = { showShizukuAppPicker = false },
+            onDismissRequest = { showShizukuAppPicker = false },
+            content = {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    when {
+                        shizukuAppOptions == null -> {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 12.dp),
+                                horizontalArrangement = Arrangement.Center,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                CircularProgressIndicator()
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Text(
+                                    text = stringResource(R.string.settings_shizuku_launch_app_loading),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+
+                        shizukuAppLoadFailed -> {
+                            Text(
+                                text = stringResource(R.string.settings_shizuku_launch_app_picker_failed),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        }
+
+                        else -> {
+                            ITextField(
+                                value = shizukuAppSearch,
+                                onValueChange = { shizukuAppSearch = it },
+                                placeholder = stringResource(R.string.settings_shizuku_launch_app_search_hint),
+                                singleLine = true
+                            )
+
+                            if (filteredOptions.isEmpty()) {
+                                Text(
+                                    text = stringResource(R.string.settings_shizuku_launch_app_empty),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            } else {
+                                LazyColumn(
+                                    modifier = Modifier.heightIn(max = 320.dp),
+                                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    items(filteredOptions, key = { it.packageName }) { option ->
+                                        Column(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            verticalArrangement = Arrangement.spacedBy(2.dp)
+                                        ) {
+                                            Column(
+                                                modifier = Modifier
+                                                    .fillMaxWidth()
+                                                    .clip(RoundedCornerShape(8.dp))
+                                                    .clickable {
+                                                        viewModel.setShizukuLaunchPackage(option.packageName)
+                                                        showShizukuAppPicker = false
+                                                    }
+                                                    .padding(horizontal = 8.dp, vertical = 10.dp),
+                                                verticalArrangement = Arrangement.spacedBy(2.dp)
+                                            ) {
+                                                Text(
+                                                    text = option.label,
+                                                    style = MaterialTheme.typography.bodyLarge,
+                                                    color = MaterialTheme.colorScheme.onSurface
+                                                )
+                                                Text(
+                                                    text = option.packageName,
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         )
     }
 
@@ -352,6 +493,29 @@ fun SettingsView(
                         enabled = startupBackend == RemoteBackend.SHIZUKU,
                         onCheckedChange = { viewModel.setSkipShizukuCheck(it) }
                     )
+                    SettingsDivider(contentColor)
+                    val shizukuLaunchAppName = ShizukuInstallHelper.getLaunchAppLabel(
+                        context,
+                        shizukuLaunchPackage
+                    )
+                    val shizukuLaunchAppDescription = if (shizukuLaunchPackage.isBlank()) {
+                        stringResource(R.string.settings_shizuku_launch_app_default_desc)
+                    } else {
+                        stringResource(
+                            R.string.settings_shizuku_launch_app_selected_desc,
+                            shizukuLaunchAppName ?: shizukuLaunchPackage
+                        )
+                    }
+                    SettingClickItem(
+                        title = stringResource(R.string.settings_shizuku_launch_app_title),
+                        description = shizukuLaunchAppDescription,
+                        contentColor = contentColor
+                    ) {
+                        // 先展示弹窗，再异步查询应用列表，避免点击后长时间无反馈。
+                        shizukuAppSearch = ""
+                        shizukuAppPickerLoadKey += 1
+                        showShizukuAppPicker = true
+                    }
                     SettingsDivider(contentColor)
                     SettingSwitchItem(
                         title = stringResource(R.string.settings_deployment_with_pause),
@@ -888,4 +1052,28 @@ private fun SettingRemoteBackendItem(
             }
         }
     }
+}
+
+private data class ShizukuLaunchAppOption(
+    val label: String,
+    val packageName: String
+)
+
+private fun loadShizukuLaunchApps(context: Context): List<ShizukuLaunchAppOption> {
+    val packageManager = context.packageManager
+    val launcherIntent = Intent(Intent.ACTION_MAIN).apply {
+        addCategory(Intent.CATEGORY_LAUNCHER)
+    }
+
+    // 应用列表查询较慢，调用方应在 IO 线程执行。
+    return packageManager.queryIntentActivities(launcherIntent, 0)
+        .mapNotNull { resolveInfo ->
+            val packageName = resolveInfo.activityInfo?.packageName ?: return@mapNotNull null
+            val label = resolveInfo.loadLabel(packageManager).toString()
+                .takeIf { it.isNotBlank() }
+                ?: packageName
+            ShizukuLaunchAppOption(label = label, packageName = packageName)
+        }
+        .distinctBy { it.packageName }
+        .sortedWith(compareBy<ShizukuLaunchAppOption, String>(String.CASE_INSENSITIVE_ORDER) { it.label })
 }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -61,6 +61,7 @@ import com.aliothmoon.maameow.constant.Routes
 import com.aliothmoon.maameow.data.model.update.UpdateChannel
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
 import com.aliothmoon.maameow.domain.models.RemoteBackend
+import com.aliothmoon.maameow.domain.models.ShizukuLaunchMode
 import com.aliothmoon.maameow.domain.service.AchievementReporter
 import com.aliothmoon.maameow.domain.service.LogExportService
 import com.aliothmoon.maameow.domain.service.ResourceInitService
@@ -99,6 +100,7 @@ fun SettingsView(
     val autoDownloadUpdate by viewModel.autoDownloadUpdate.collectAsStateWithLifecycle()
     val startupBackend by viewModel.startupBackend.collectAsStateWithLifecycle()
     val skipShizukuCheck by viewModel.skipShizukuCheck.collectAsStateWithLifecycle()
+    val shizukuLaunchMode by viewModel.shizukuLaunchMode.collectAsStateWithLifecycle()
     val shizukuLaunchPackage by viewModel.shizukuLaunchPackage.collectAsStateWithLifecycle()
     val deploymentWithPause by viewModel.deploymentWithPause.collectAsStateWithLifecycle()
     val forceFullscreenOnVirtualDisplay by viewModel.forceFullscreenOnVirtualDisplay.collectAsStateWithLifecycle()
@@ -129,6 +131,7 @@ fun SettingsView(
     }
 
     var showShizukuAppPicker by remember { mutableStateOf(false) }
+    var showShizukuLaunchModePicker by remember { mutableStateOf(false) }
     var shizukuAppPickerLoadKey by remember { mutableStateOf(0) }
     var shizukuAppSearch by remember { mutableStateOf("") }
     var shizukuAppOptions by remember { mutableStateOf<List<ShizukuLaunchAppOption>?>(null) }
@@ -204,6 +207,51 @@ fun SettingsView(
         ResourceInitDialog(
             state = resourceInitState,
             onRetry = {}
+        )
+    }
+
+    if (showShizukuLaunchModePicker) {
+        AdaptiveTaskPromptDialog(
+            visible = true,
+            title = stringResource(R.string.settings_shizuku_launch_mode_picker_title),
+            icon = Icons.Rounded.Build,
+            confirmText = stringResource(R.string.common_close),
+            dismissText = "",
+            onConfirm = { showShizukuLaunchModePicker = false },
+            onDismissRequest = { showShizukuLaunchModePicker = false },
+            content = {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    ShizukuLaunchMode.entries.forEach { mode ->
+                        val selected = mode == shizukuLaunchMode
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(8.dp))
+                                .selectable(
+                                    selected = selected,
+                                    onClick = {
+                                        viewModel.setShizukuLaunchMode(mode)
+                                        showShizukuLaunchModePicker = false
+                                    },
+                                    role = Role.RadioButton
+                                )
+                                .padding(vertical = 6.dp)
+                        ) {
+                            RadioButton(selected = selected, onClick = null)
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                text = shizukuLaunchModeLabel(mode),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
+                }
+            }
         )
     }
 
@@ -452,6 +500,55 @@ fun SettingsView(
                         onBackendSelected = { viewModel.setStartupBackend(it) }
                     )
                     SettingsDivider(contentColor)
+                    if (startupBackend == RemoteBackend.SHIZUKU) {
+                        val shizukuLaunchModeDescription = if (shizukuLaunchMode == ShizukuLaunchMode.OFF) {
+                            stringResource(R.string.settings_shizuku_launch_mode_desc_off)
+                        } else {
+                            stringResource(
+                                R.string.settings_shizuku_launch_mode_desc_on,
+                                shizukuLaunchModeLabel(shizukuLaunchMode)
+                            )
+                        }
+                        SettingClickItem(
+                            title = stringResource(R.string.settings_shizuku_launch_mode_title),
+                            description = shizukuLaunchModeDescription,
+                            contentColor = contentColor
+                        ) {
+                            showShizukuLaunchModePicker = true
+                        }
+                        SettingsDivider(contentColor)
+                        AnimatedVisibility(
+                            visible = shizukuLaunchMode == ShizukuLaunchMode.CUSTOM,
+                            enter = expandVertically(),
+                            exit = shrinkVertically()
+                        ) {
+                            Column {
+                                val shizukuLaunchAppName = ShizukuInstallHelper.getLaunchAppLabel(
+                                    context,
+                                    shizukuLaunchPackage
+                                )
+                                val shizukuLaunchAppDescription = if (shizukuLaunchPackage.isBlank()) {
+                                    stringResource(R.string.settings_shizuku_launch_app_default_desc)
+                                } else {
+                                    stringResource(
+                                        R.string.settings_shizuku_launch_app_selected_desc,
+                                        shizukuLaunchAppName ?: shizukuLaunchPackage
+                                    )
+                                }
+                                SettingClickItem(
+                                    title = stringResource(R.string.settings_shizuku_launch_app_title),
+                                    description = shizukuLaunchAppDescription,
+                                    contentColor = contentColor
+                                ) {
+                                    // 先展示弹窗，再异步查询应用列表，避免点击后长时间无反馈。
+                                    shizukuAppSearch = ""
+                                    shizukuAppPickerLoadKey += 1
+                                    showShizukuAppPicker = true
+                                }
+                                SettingsDivider(contentColor)
+                            }
+                        }
+                    }
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                         SettingSwitchItem(
                             title = stringResource(R.string.settings_monet_color_title),
@@ -505,29 +602,6 @@ fun SettingsView(
                         enabled = startupBackend == RemoteBackend.SHIZUKU,
                         onCheckedChange = { viewModel.setSkipShizukuCheck(it) }
                     )
-                    SettingsDivider(contentColor)
-                    val shizukuLaunchAppName = ShizukuInstallHelper.getLaunchAppLabel(
-                        context,
-                        shizukuLaunchPackage
-                    )
-                    val shizukuLaunchAppDescription = if (shizukuLaunchPackage.isBlank()) {
-                        stringResource(R.string.settings_shizuku_launch_app_default_desc)
-                    } else {
-                        stringResource(
-                            R.string.settings_shizuku_launch_app_selected_desc,
-                            shizukuLaunchAppName ?: shizukuLaunchPackage
-                        )
-                    }
-                    SettingClickItem(
-                        title = stringResource(R.string.settings_shizuku_launch_app_title),
-                        description = shizukuLaunchAppDescription,
-                        contentColor = contentColor
-                    ) {
-                        // 先展示弹窗，再异步查询应用列表，避免点击后长时间无反馈。
-                        shizukuAppSearch = ""
-                        shizukuAppPickerLoadKey += 1
-                        showShizukuAppPicker = true
-                    }
                     SettingsDivider(contentColor)
                     SettingSwitchItem(
                         title = stringResource(R.string.settings_deployment_with_pause),
@@ -1063,6 +1137,15 @@ private fun SettingRemoteBackendItem(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun shizukuLaunchModeLabel(mode: ShizukuLaunchMode): String {
+    return when (mode) {
+        ShizukuLaunchMode.OFF -> stringResource(R.string.settings_shizuku_launch_mode_off)
+        ShizukuLaunchMode.OFFICIAL -> stringResource(R.string.settings_shizuku_launch_mode_official)
+        ShizukuLaunchMode.CUSTOM -> stringResource(R.string.settings_shizuku_launch_mode_custom)
     }
 }
 

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -131,7 +131,6 @@ fun SettingsView(
     }
 
     var showShizukuAppPicker by remember { mutableStateOf(false) }
-    var showShizukuLaunchModePicker by remember { mutableStateOf(false) }
     var shizukuAppPickerLoadKey by remember { mutableStateOf(0) }
     var shizukuAppSearch by remember { mutableStateOf("") }
     var shizukuAppOptions by remember { mutableStateOf<List<ShizukuLaunchAppOption>?>(null) }
@@ -207,51 +206,6 @@ fun SettingsView(
         ResourceInitDialog(
             state = resourceInitState,
             onRetry = {}
-        )
-    }
-
-    if (showShizukuLaunchModePicker) {
-        AdaptiveTaskPromptDialog(
-            visible = true,
-            title = stringResource(R.string.settings_shizuku_launch_mode_picker_title),
-            icon = Icons.Rounded.Build,
-            confirmText = stringResource(R.string.common_close),
-            dismissText = "",
-            onConfirm = { showShizukuLaunchModePicker = false },
-            onDismissRequest = { showShizukuLaunchModePicker = false },
-            content = {
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    ShizukuLaunchMode.entries.forEach { mode ->
-                        val selected = mode == shizukuLaunchMode
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(8.dp))
-                                .selectable(
-                                    selected = selected,
-                                    onClick = {
-                                        viewModel.setShizukuLaunchMode(mode)
-                                        showShizukuLaunchModePicker = false
-                                    },
-                                    role = Role.RadioButton
-                                )
-                                .padding(vertical = 6.dp)
-                        ) {
-                            RadioButton(selected = selected, onClick = null)
-                            Spacer(modifier = Modifier.width(4.dp))
-                            Text(
-                                text = shizukuLaunchModeLabel(mode),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                        }
-                    }
-                }
-            }
         )
     }
 
@@ -501,24 +455,20 @@ fun SettingsView(
                     )
                     SettingsDivider(contentColor)
                     if (startupBackend == RemoteBackend.SHIZUKU) {
-                        val shizukuLaunchModeDescription = if (shizukuLaunchMode == ShizukuLaunchMode.OFF) {
-                            stringResource(R.string.settings_shizuku_launch_mode_desc_off)
-                        } else {
-                            stringResource(
-                                R.string.settings_shizuku_launch_mode_desc_on,
-                                shizukuLaunchModeLabel(shizukuLaunchMode)
-                            )
-                        }
-                        SettingClickItem(
+                        SettingSwitchItem(
                             title = stringResource(R.string.settings_shizuku_launch_mode_title),
-                            description = shizukuLaunchModeDescription,
-                            contentColor = contentColor
-                        ) {
-                            showShizukuLaunchModePicker = true
-                        }
+                            description = stringResource(R.string.settings_shizuku_launch_mode_desc),
+                            contentColor = contentColor,
+                            checked = shizukuLaunchMode != ShizukuLaunchMode.OFF,
+                            onCheckedChange = { checked ->
+                                viewModel.setShizukuLaunchMode(
+                                    if (checked) ShizukuLaunchMode.CUSTOM else ShizukuLaunchMode.OFF
+                                )
+                            }
+                        )
                         SettingsDivider(contentColor)
                         AnimatedVisibility(
-                            visible = shizukuLaunchMode == ShizukuLaunchMode.CUSTOM,
+                            visible = shizukuLaunchMode != ShizukuLaunchMode.OFF,
                             enter = expandVertically(),
                             exit = shrinkVertically()
                         ) {
@@ -544,6 +494,20 @@ fun SettingsView(
                                     shizukuAppSearch = ""
                                     shizukuAppPickerLoadKey += 1
                                     showShizukuAppPicker = true
+                                }
+                                SettingsDivider(contentColor)
+                                SettingClickItem(
+                                    title = stringResource(R.string.settings_shizuku_launch_app_reset_title),
+                                    description = stringResource(
+                                        if (shizukuLaunchPackage.isBlank()) {
+                                            R.string.settings_shizuku_launch_app_reset_default_desc
+                                        } else {
+                                            R.string.settings_shizuku_launch_app_reset_desc
+                                        }
+                                    ),
+                                    contentColor = contentColor
+                                ) {
+                                    viewModel.setShizukuLaunchPackage("")
                                 }
                                 SettingsDivider(contentColor)
                             }
@@ -1137,15 +1101,6 @@ private fun SettingRemoteBackendItem(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun shizukuLaunchModeLabel(mode: ShizukuLaunchMode): String {
-    return when (mode) {
-        ShizukuLaunchMode.OFF -> stringResource(R.string.settings_shizuku_launch_mode_off)
-        ShizukuLaunchMode.OFFICIAL -> stringResource(R.string.settings_shizuku_launch_mode_official)
-        ShizukuLaunchMode.CUSTOM -> stringResource(R.string.settings_shizuku_launch_mode_custom)
     }
 }
 

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/HomeViewModel.kt
@@ -335,13 +335,13 @@ class HomeViewModel(
     }
 
     fun onOpenShizuku() {
-        val opened = when (appSettingsManager.shizukuLaunchMode.value) {
-            ShizukuLaunchMode.OFFICIAL -> ShizukuInstallHelper.openShizuku(application)
-            ShizukuLaunchMode.CUSTOM -> ShizukuInstallHelper.openShizuku(
+        val opened = if (appSettingsManager.shizukuLaunchMode.value == ShizukuLaunchMode.OFF) {
+            false
+        } else {
+            ShizukuInstallHelper.openShizuku(
                 application,
                 appSettingsManager.shizukuLaunchPackage.value
             )
-            ShizukuLaunchMode.OFF -> false
         }
         if (!opened) {
             Toast.makeText(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/HomeViewModel.kt
@@ -19,6 +19,7 @@ import com.aliothmoon.maameow.domain.state.MaaExecutionState
 import com.aliothmoon.maameow.manager.PermissionManager
 import com.aliothmoon.maameow.manager.RemoteServiceManager
 import com.aliothmoon.maameow.manager.RemoteServiceManager.useRemoteService
+import com.aliothmoon.maameow.manager.ShizukuInstallHelper
 import com.aliothmoon.maameow.overlay.OverlayController
 import com.aliothmoon.maameow.presentation.state.HomeUiState
 import com.aliothmoon.maameow.presentation.state.StatusColorType
@@ -80,7 +81,9 @@ class HomeViewModel(
                 compositionService.state
             ) { serviceState, resourceState, executionState ->
                 Timber.i("ServiceState collect $serviceState $resourceState $executionState")
-                when {
+                val remoteServiceActive = serviceState is RemoteServiceManager.ServiceState.Connected ||
+                        serviceState is RemoteServiceManager.ServiceState.Connecting
+                val status = when {
                     serviceState is RemoteServiceManager.ServiceState.Died ||
                             serviceState is RemoteServiceManager.ServiceState.Error ->
                         Triple(uiTextOf(R.string.home_status_service_error), StatusColorType.ERROR, false)
@@ -113,12 +116,15 @@ class HomeViewModel(
                     else ->
                         Triple(uiTextOf(R.string.home_status_ready), StatusColorType.PRIMARY, false)
                 }
-            }.collect { (text, color, loading) ->
+                Pair(status, remoteServiceActive)
+            }.collect { (status, remoteServiceActive) ->
+                val (text, color, loading) = status
                 _uiState.update {
                     it.copy(
                         serviceStatusText = text,
                         serviceStatusColor = color,
-                        serviceStatusLoading = loading
+                        serviceStatusLoading = loading,
+                        remoteServiceActive = remoteServiceActive
                     )
                 }
             }
@@ -327,44 +333,92 @@ class HomeViewModel(
         }
     }
 
-    fun onReloadServices() {
+    fun onOpenShizuku() {
+        val opened = ShizukuInstallHelper.openShizuku(
+            application,
+            appSettingsManager.shizukuLaunchPackage.value
+        )
+        if (!opened) {
+            Toast.makeText(
+                application,
+                application.getString(R.string.home_toast_open_shizuku_failed),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+
+    fun onToggleRemoteService() {
+        if (_uiState.value.remoteServiceActive) {
+            onCloseRemoteService()
+        } else {
+            onOpenRemoteService()
+        }
+    }
+
+    private fun onOpenRemoteService() {
         viewModelScope.launch {
             try {
                 _uiState.update { it.copy(isLoading = true) }
 
-                RemoteServiceManager.unbind()
+                permissionManager.refresh()
+                val state = permissionManager.permissions
+                val backend = state.startupBackend
+                if (!state.isStartupBackendAvailable(backend)) {
+                    _uiState.update { it.copy(isLoading = false) }
+                    Toast.makeText(
+                        application,
+                        application.getString(R.string.home_toast_backend_unavailable, backend.display),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    return@launch
+                }
+
+                if (!state.remoteAccessGranted) {
+                    val granted = permissionManager.requestRemoteAccess()
+                    if (!granted) {
+                        _uiState.update { it.copy(isLoading = false) }
+                        Toast.makeText(
+                            application,
+                            application.getString(R.string.home_toast_backend_auth_failed, backend.display),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        return@launch
+                    }
+                }
+
                 RemoteServiceManager.bind()
 
-                Timber.i("onReloadServices: Services reloaded")
+                Timber.i("onOpenRemoteService: Service binding started")
                 _uiState.update { it.copy(isLoading = false) }
             } catch (e: Exception) {
-                Timber.e(e, "Error reloading services")
+                Timber.e(e, "Error opening remote service")
                 _uiState.update { it.copy(isLoading = false) }
                 Toast.makeText(
                     application,
-                    application.getString(R.string.home_toast_reload_services_failed, e.message.orEmpty()),
+                    application.getString(R.string.home_toast_open_service_failed, e.message.orEmpty()),
                     Toast.LENGTH_SHORT
                 ).show()
             }
         }
     }
 
-    fun onStopAllServices() {
+    private fun onCloseRemoteService() {
         viewModelScope.launch {
             try {
                 _uiState.update { it.copy(isLoading = true) }
 
+                // 先关闭依赖远程服务的入口，避免继续操作已断开的 Binder。
                 overlayController.hideAll()
                 RemoteServiceManager.unbind()
 
-                Timber.i("onStopAllServices: All services stopped")
+                Timber.i("onCloseRemoteService: Service unbound")
                 _uiState.update { it.copy(isLoading = false) }
             } catch (e: Exception) {
-                Timber.e(e, "Error stopping all services")
+                Timber.e(e, "Error closing remote service")
                 _uiState.update { it.copy(isLoading = false) }
                 Toast.makeText(
                     application,
-                    application.getString(R.string.home_toast_stop_services_failed, e.message.orEmpty()),
+                    application.getString(R.string.home_toast_close_service_failed, e.message.orEmpty()),
                     Toast.LENGTH_SHORT
                 ).show()
             }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/HomeViewModel.kt
@@ -11,6 +11,7 @@ import com.aliothmoon.maameow.constant.DisplayMode
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
 import com.aliothmoon.maameow.domain.models.OverlayControlMode
 import com.aliothmoon.maameow.domain.models.RunMode
+import com.aliothmoon.maameow.domain.models.ShizukuLaunchMode
 import com.aliothmoon.maameow.domain.service.MaaCompositionService
 import com.aliothmoon.maameow.domain.service.MaaResourceLoader
 import com.aliothmoon.maameow.domain.service.ResourceInitService
@@ -334,10 +335,14 @@ class HomeViewModel(
     }
 
     fun onOpenShizuku() {
-        val opened = ShizukuInstallHelper.openShizuku(
-            application,
-            appSettingsManager.shizukuLaunchPackage.value
-        )
+        val opened = when (appSettingsManager.shizukuLaunchMode.value) {
+            ShizukuLaunchMode.OFFICIAL -> ShizukuInstallHelper.openShizuku(application)
+            ShizukuLaunchMode.CUSTOM -> ShizukuInstallHelper.openShizuku(
+                application,
+                appSettingsManager.shizukuLaunchPackage.value
+            )
+            ShizukuLaunchMode.OFF -> false
+        }
         if (!opened) {
             Toast.makeText(
                 application,

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -147,6 +147,15 @@ class SettingsViewModel(
         }
     }
 
+    val shizukuLaunchPackage: StateFlow<String> = appSettingsManager.shizukuLaunchPackage
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "")
+
+    fun setShizukuLaunchPackage(packageName: String) {
+        viewModelScope.launch {
+            appSettingsManager.setShizukuLaunchPackage(packageName)
+        }
+    }
+
     val deploymentWithPause: StateFlow<Boolean> = appSettingsManager.deploymentWithPause
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import com.aliothmoon.maameow.data.preferences.ConfigBackupManager
 import com.aliothmoon.maameow.data.preferences.TaskChainState
 import com.aliothmoon.maameow.data.resource.ResourceDataManager
 import com.aliothmoon.maameow.domain.models.RemoteBackend
+import com.aliothmoon.maameow.domain.models.ShizukuLaunchMode
 import com.aliothmoon.maameow.domain.service.AchievementReporter
 import com.aliothmoon.maameow.domain.service.MaaResourceLoader
 import com.aliothmoon.maameow.manager.PermissionManager
@@ -149,6 +150,15 @@ class SettingsViewModel(
 
     val shizukuLaunchPackage: StateFlow<String> = appSettingsManager.shizukuLaunchPackage
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "")
+
+    val shizukuLaunchMode: StateFlow<ShizukuLaunchMode> = appSettingsManager.shizukuLaunchMode
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ShizukuLaunchMode.OFF)
+
+    fun setShizukuLaunchMode(mode: ShizukuLaunchMode) {
+        viewModelScope.launch {
+            appSettingsManager.setShizukuLaunchMode(mode)
+        }
+    }
 
     fun setShizukuLaunchPackage(packageName: String) {
         viewModelScope.launch {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -66,16 +66,14 @@
     <string name="settings_background_resolution_title">Background Resolution</string>
     <string name="settings_background_resolution_desc">Background mode only</string>
     <string name="settings_skip_shizuku_check">Skip Shizuku Check</string>
-    <string name="settings_shizuku_launch_mode_title">Show Shizuku Shortcut on Home</string>
-    <string name="settings_shizuku_launch_mode_desc_off">Currently off</string>
-    <string name="settings_shizuku_launch_mode_desc_on">Currently on: %1$s</string>
-    <string name="settings_shizuku_launch_mode_picker_title">Select Home Shortcut</string>
-    <string name="settings_shizuku_launch_mode_off">Default Off</string>
-    <string name="settings_shizuku_launch_mode_official">Open Official Shizuku</string>
-    <string name="settings_shizuku_launch_mode_custom">Custom Shizuku</string>
+    <string name="settings_shizuku_launch_mode_title">Enable Shortcut</string>
+    <string name="settings_shizuku_launch_mode_desc">Show a Shizuku shortcut on Home; official Shizuku is used when no app is selected.</string>
     <string name="settings_shizuku_launch_app_title">Custom Shizuku App</string>
-    <string name="settings_shizuku_launch_app_default_desc">No custom app selected</string>
+    <string name="settings_shizuku_launch_app_default_desc">Using official Shizuku</string>
     <string name="settings_shizuku_launch_app_selected_desc">Currently using: %1$s</string>
+    <string name="settings_shizuku_launch_app_reset_title">Restore Default Shortcut</string>
+    <string name="settings_shizuku_launch_app_reset_desc">Clear the custom app and use the default Shizuku shortcut</string>
+    <string name="settings_shizuku_launch_app_reset_default_desc">Already using the default Shizuku shortcut</string>
     <string name="settings_shizuku_launch_app_picker_title">Select Shizuku App</string>
     <string name="settings_shizuku_launch_app_picker_failed">Failed to load app list</string>
     <string name="settings_shizuku_launch_app_loading">Loading app list…</string>
@@ -189,7 +187,7 @@
     <string name="home_overlay_close">Close Control Panel</string>
 
     <!-- home: action buttons -->
-    <string name="home_btn_open_shizuku">Open Shizuku</string>
+    <string name="home_btn_open_shizuku">Shortcut</string>
     <string name="home_btn_open_service">Open Service</string>
     <string name="home_btn_close_service">Close Service</string>
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -62,6 +62,14 @@
     <string name="settings_background_resolution_title">Background Resolution</string>
     <string name="settings_background_resolution_desc">Background mode only</string>
     <string name="settings_skip_shizuku_check">Skip Shizuku Check</string>
+    <string name="settings_shizuku_launch_app_title">Custom Shizuku App</string>
+    <string name="settings_shizuku_launch_app_default_desc">Currently using official Shizuku</string>
+    <string name="settings_shizuku_launch_app_selected_desc">Currently using: %1$s</string>
+    <string name="settings_shizuku_launch_app_picker_title">Select Shizuku App</string>
+    <string name="settings_shizuku_launch_app_picker_failed">Failed to load app list</string>
+    <string name="settings_shizuku_launch_app_loading">Loading app list…</string>
+    <string name="settings_shizuku_launch_app_search_hint">Search app name or package</string>
+    <string name="settings_shizuku_launch_app_empty">No matching apps found</string>
     <string name="settings_deployment_with_pause">Deploy operators while paused</string>
     <string name="settings_deployment_with_pause_tip">Hold ESC to pause the game while deploying operators for higher precision. Disable if ESC injection misbehaves or some operators are not placed correctly; deployment will fall back to plain swipe</string>
     <string name="settings_force_fullscreen_on_virtual_display">Force FULLSCREEN mode</string>
@@ -170,8 +178,9 @@
     <string name="home_overlay_close">Close Control Panel</string>
 
     <!-- home: action buttons -->
-    <string name="home_btn_reload_services">Reload Services</string>
-    <string name="home_btn_stop_all_services">Stop All Services</string>
+    <string name="home_btn_open_shizuku">Open Shizuku</string>
+    <string name="home_btn_open_service">Open Service</string>
+    <string name="home_btn_close_service">Close Service</string>
 
     <!-- home: service status strings -->
     <string name="home_status_service_error">Service Error</string>
@@ -197,8 +206,9 @@
     <string name="home_toast_missing_permissions_separator">, </string>
     <string name="home_toast_start_overlay_failed">Failed to start overlay: %1$s</string>
     <string name="home_toast_stop_overlay_failed">Failed to stop overlay: %1$s</string>
-    <string name="home_toast_reload_services_failed">Failed to reload services: %1$s</string>
-    <string name="home_toast_stop_services_failed">Failed to stop services: %1$s</string>
+    <string name="home_toast_open_shizuku_failed">Failed to open Shizuku. Please make sure Shizuku is installed</string>
+    <string name="home_toast_open_service_failed">Failed to open service: %1$s</string>
+    <string name="home_toast_close_service_failed">Failed to close service: %1$s</string>
     <string name="home_toast_change_resolution_failed">Failed to change resolution: %1$s</string>
     <string name="home_toast_reset_resolution_failed">Failed to reset resolution: %1$s</string>
     <string name="home_toast_not_16_9_resolution">Current resolution is not 16:9. Please use background task or adjust the resolution</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -66,8 +66,15 @@
     <string name="settings_background_resolution_title">Background Resolution</string>
     <string name="settings_background_resolution_desc">Background mode only</string>
     <string name="settings_skip_shizuku_check">Skip Shizuku Check</string>
+    <string name="settings_shizuku_launch_mode_title">Show Shizuku Shortcut on Home</string>
+    <string name="settings_shizuku_launch_mode_desc_off">Currently off</string>
+    <string name="settings_shizuku_launch_mode_desc_on">Currently on: %1$s</string>
+    <string name="settings_shizuku_launch_mode_picker_title">Select Home Shortcut</string>
+    <string name="settings_shizuku_launch_mode_off">Default Off</string>
+    <string name="settings_shizuku_launch_mode_official">Open Official Shizuku</string>
+    <string name="settings_shizuku_launch_mode_custom">Custom Shizuku</string>
     <string name="settings_shizuku_launch_app_title">Custom Shizuku App</string>
-    <string name="settings_shizuku_launch_app_default_desc">Currently using official Shizuku</string>
+    <string name="settings_shizuku_launch_app_default_desc">No custom app selected</string>
     <string name="settings_shizuku_launch_app_selected_desc">Currently using: %1$s</string>
     <string name="settings_shizuku_launch_app_picker_title">Select Shizuku App</string>
     <string name="settings_shizuku_launch_app_picker_failed">Failed to load app list</string>
@@ -313,6 +320,8 @@
     <!-- background task: permission & toast -->
     <string name="bg_shizuku_permission_title">%1$s Permission Required</string>
     <string name="bg_shizuku_permission_message">The background task page depends on the %1$s service. This prompt will keep showing until access is granted.</string>
+    <string name="bg_remote_access_unavailable_message">%1$s is unavailable. Please check whether the corresponding service is running.\n\nThis dialog will keep showing until the corresponding service starts and access is granted.</string>
+    <string name="bg_toast_remote_access_unavailable">%1$s is unavailable. Please check whether the corresponding service is running.</string>
     <string name="bg_toast_permission_not_acquired">%1$s not acquired, please try again</string>
     <string name="bg_toast_service_died">MaaService terminated unexpectedly. Please try restarting</string>
     <string name="bg_toast_app_died">Game process is not running or was killed unexpectedly</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -187,9 +187,9 @@
     <string name="home_overlay_close">Close Control Panel</string>
 
     <!-- home: action buttons -->
-    <string name="home_btn_open_shizuku">Shortcut</string>
-    <string name="home_btn_open_service">Open Service</string>
-    <string name="home_btn_close_service">Close Service</string>
+    <string name="home_btn_open_shizuku">Shizuku Shortcut</string>
+    <string name="home_btn_open_service">Reload All Services</string>
+    <string name="home_btn_close_service">Close All Services</string>
 
     <!-- home: service status strings -->
     <string name="home_status_service_error">Service Error</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,16 +264,14 @@
     <string name="settings_background_resolution_title">后台分辨率</string>
     <string name="settings_background_resolution_desc">仅后台模式生效</string>
     <string name="settings_skip_shizuku_check">跳过 Shizuku 检查</string>
-    <string name="settings_shizuku_launch_mode_title">主页显示 Shizuku 快捷入口</string>
-    <string name="settings_shizuku_launch_mode_desc_off">当前已关闭</string>
-    <string name="settings_shizuku_launch_mode_desc_on">当前已开启：%1$s</string>
-    <string name="settings_shizuku_launch_mode_picker_title">选择主页快捷入口</string>
-    <string name="settings_shizuku_launch_mode_off">默认关闭</string>
-    <string name="settings_shizuku_launch_mode_official">打开官方 Shizuku</string>
-    <string name="settings_shizuku_launch_mode_custom">自定义 Shizuku</string>
+    <string name="settings_shizuku_launch_mode_title">打开快捷入口</string>
+    <string name="settings_shizuku_launch_mode_desc">开启后首页显示 Shizuku 快捷入口；未选择应用时使用官方 Shizuku。</string>
     <string name="settings_shizuku_launch_app_title">自选 Shizuku 应用</string>
-    <string name="settings_shizuku_launch_app_default_desc">尚未选择自定义应用</string>
+    <string name="settings_shizuku_launch_app_default_desc">当前使用官方 Shizuku</string>
     <string name="settings_shizuku_launch_app_selected_desc">当前使用：%1$s</string>
+    <string name="settings_shizuku_launch_app_reset_title">恢复默认入口</string>
+    <string name="settings_shizuku_launch_app_reset_desc">清空自选应用，使用默认 Shizuku 入口</string>
+    <string name="settings_shizuku_launch_app_reset_default_desc">当前已使用默认 Shizuku 入口</string>
     <string name="settings_shizuku_launch_app_picker_title">选择 Shizuku 应用</string>
     <string name="settings_shizuku_launch_app_picker_failed">加载应用列表失败</string>
     <string name="settings_shizuku_launch_app_loading">正在加载应用列表…</string>
@@ -391,7 +389,7 @@
     <string name="home_overlay_close">关闭操作面板</string>
 
     <!-- home: action buttons -->
-    <string name="home_btn_open_shizuku">打开 Shizuku</string>
+    <string name="home_btn_open_shizuku">快捷入口</string>
     <string name="home_btn_open_service">打开服务</string>
     <string name="home_btn_close_service">关闭服务</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,8 +264,15 @@
     <string name="settings_background_resolution_title">后台分辨率</string>
     <string name="settings_background_resolution_desc">仅后台模式生效</string>
     <string name="settings_skip_shizuku_check">跳过 Shizuku 检查</string>
+    <string name="settings_shizuku_launch_mode_title">主页显示 Shizuku 快捷入口</string>
+    <string name="settings_shizuku_launch_mode_desc_off">当前已关闭</string>
+    <string name="settings_shizuku_launch_mode_desc_on">当前已开启：%1$s</string>
+    <string name="settings_shizuku_launch_mode_picker_title">选择主页快捷入口</string>
+    <string name="settings_shizuku_launch_mode_off">默认关闭</string>
+    <string name="settings_shizuku_launch_mode_official">打开官方 Shizuku</string>
+    <string name="settings_shizuku_launch_mode_custom">自定义 Shizuku</string>
     <string name="settings_shizuku_launch_app_title">自选 Shizuku 应用</string>
-    <string name="settings_shizuku_launch_app_default_desc">当前使用官方 Shizuku</string>
+    <string name="settings_shizuku_launch_app_default_desc">尚未选择自定义应用</string>
     <string name="settings_shizuku_launch_app_selected_desc">当前使用：%1$s</string>
     <string name="settings_shizuku_launch_app_picker_title">选择 Shizuku 应用</string>
     <string name="settings_shizuku_launch_app_picker_failed">加载应用列表失败</string>
@@ -515,6 +522,8 @@
     <!-- background task: permission & toast -->
     <string name="bg_shizuku_permission_title">需要%1$s权限</string>
     <string name="bg_shizuku_permission_message">后台任务页面依赖%1$s服务，授权成功前将持续显示该提示。</string>
+    <string name="bg_remote_access_unavailable_message">%1$s 不可用，请检查对应服务是否启动。\n\n在对应服务启动并完成授权前，此弹窗会持续显示。</string>
+    <string name="bg_toast_remote_access_unavailable">%1$s不可用，请检查对应服务是否启动。</string>
     <string name="bg_toast_permission_not_acquired">%1$s未获取，请重试</string>
     <string name="bg_toast_service_died">MaaService 异常关闭，请尝试重新启动</string>
     <string name="bg_toast_app_died">游戏进程未启动或被异常关闭</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,14 @@
     <string name="settings_background_resolution_title">后台分辨率</string>
     <string name="settings_background_resolution_desc">仅后台模式生效</string>
     <string name="settings_skip_shizuku_check">跳过 Shizuku 检查</string>
+    <string name="settings_shizuku_launch_app_title">自选 Shizuku 应用</string>
+    <string name="settings_shizuku_launch_app_default_desc">当前使用官方 Shizuku</string>
+    <string name="settings_shizuku_launch_app_selected_desc">当前使用：%1$s</string>
+    <string name="settings_shizuku_launch_app_picker_title">选择 Shizuku 应用</string>
+    <string name="settings_shizuku_launch_app_picker_failed">加载应用列表失败</string>
+    <string name="settings_shizuku_launch_app_loading">正在加载应用列表…</string>
+    <string name="settings_shizuku_launch_app_search_hint">搜索应用名或包名</string>
+    <string name="settings_shizuku_launch_app_empty">未找到匹配应用</string>
     <string name="settings_deployment_with_pause">暂停时部署干员</string>
     <string name="settings_deployment_with_pause_tip">部署干员前模拟按住 ESC 暂停游戏，提高部署精确度。如遇 ESC 注入异常或部分干员部署不到位，可关闭改用普通滑动</string>
     <string name="settings_force_fullscreen_on_virtual_display">强制 FULLSCREEN 模式</string>
@@ -372,8 +380,9 @@
     <string name="home_overlay_close">关闭操作面板</string>
 
     <!-- home: action buttons -->
-    <string name="home_btn_reload_services">重新加载服务</string>
-    <string name="home_btn_stop_all_services">关闭所有服务</string>
+    <string name="home_btn_open_shizuku">打开 Shizuku</string>
+    <string name="home_btn_open_service">打开服务</string>
+    <string name="home_btn_close_service">关闭服务</string>
 
     <!-- home: service status strings -->
     <string name="home_status_service_error">服务异常</string>
@@ -399,8 +408,9 @@
     <string name="home_toast_missing_permissions_separator">、</string>
     <string name="home_toast_start_overlay_failed">启动悬浮窗失败: %1$s</string>
     <string name="home_toast_stop_overlay_failed">停止悬浮窗失败: %1$s</string>
-    <string name="home_toast_reload_services_failed">重新加载服务失败: %1$s</string>
-    <string name="home_toast_stop_services_failed">关闭服务失败: %1$s</string>
+    <string name="home_toast_open_shizuku_failed">打开 Shizuku 失败，请确认已安装 Shizuku</string>
+    <string name="home_toast_open_service_failed">打开服务失败: %1$s</string>
+    <string name="home_toast_close_service_failed">关闭服务失败: %1$s</string>
     <string name="home_toast_change_resolution_failed">修改分辨率失败: %1$s</string>
     <string name="home_toast_reset_resolution_failed">重置分辨率失败: %1$s</string>
     <string name="home_toast_not_16_9_resolution">当前分辨率不是 16:9，请使用后台任务或调整分辨率</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -389,9 +389,9 @@
     <string name="home_overlay_close">关闭操作面板</string>
 
     <!-- home: action buttons -->
-    <string name="home_btn_open_shizuku">快捷入口</string>
-    <string name="home_btn_open_service">打开服务</string>
-    <string name="home_btn_close_service">关闭服务</string>
+    <string name="home_btn_open_shizuku">Shizuku快捷入口</string>
+    <string name="home_btn_open_service">重新加载服务</string>
+    <string name="home_btn_close_service">关闭所有服务</string>
 
     <!-- home: service status strings -->
     <string name="home_status_service_error">服务异常</string>


### PR DESCRIPTION
## 关联内容

- 关联 Issue：无
- 需求来源：
  - 希望首页服务状态区域可以直接打开 Shizuku，减少排查服务未启动、未授权或连接异常时的操作路径。
  - 希望远程服务支持更直观的打开 / 关闭入口。
  - 部分用户使用第三方魔改 Shizuku 管理器，需要支持自选 Shizuku 应用入口。

## 变更摘要

- 在首页服务状态卡片下新增 `打开 Shizuku` 快捷按钮。
- 将服务操作改为状态化按钮：
  - 服务关闭时显示蓝色 `打开服务`
  - 服务开启或启动中时显示轻量红色描边 `关闭服务`
- 新增设置项 `自选 Shizuku 应用`，位置位于 `跳过 Shizuku 检查` 下方、`暂停时部署干员` 上方。
- 自选 Shizuku 应用改为应用内选择弹窗：
  - 点击后立即显示弹窗，避免应用列表加载时看起来无响应
  - 加载中显示进度指示
  - 支持按应用名或包名搜索
  - 列表项使用普通整行布局，避免某些系统主题下胶囊按钮导致文字显示不全
- `ShizukuInstallHelper` 统一处理 Shizuku 打开逻辑：
  - 优先打开用户自选应用
  - 未配置或拉起失败时回退官方 Shizuku 包名
  - 检查 Shizuku 状态时兼容自选应用包名

## 验证

- [x] Samsung Galaxy S25 Ultra 16GB 真机测试通过
- [x] 首页点击 `打开 Shizuku` 可正常拉起配置的 Shizuku / 第三方 Shizuku 应用
- [x] 服务关闭时按钮显示为 `打开服务`，点击后可启动服务
- [x] 服务开启时按钮显示为轻量红色描边 `关闭服务`，点击后可关闭服务
- [x] 设置页 `自选 Shizuku 应用` 点击后会立即显示弹窗和加载状态
- [x] 应用列表加载完成后可搜索应用名或包名并保存选择
- [x] 自选应用列表项在三星设备上不再显示为系统胶囊按钮，文字显示空间更充足
- [x] 中英文字符串 key 集合已检查一致


## 兼容性与影响范围

- 影响范围集中在首页服务状态卡片、设置页、Shizuku 启动辅助逻辑和字符串资源。
- 未新增第三方依赖。
- 新增一个可选 DataStore 配置项 `shizukuLaunchPackage`，默认空值时保持原官方 Shizuku 行为。
- 新增 launcher 查询声明，用于 Android 11+ 下加载可启动应用列表。
- 服务开关仍沿用现有 `RemoteServiceManager.bind()` / `unbind()` 流程，不新增远端服务 API。
- 关闭服务前会先收起依赖远程服务的本地控制入口，避免继续操作已断开的 Binder。

## 截图与素材

- 真机设备：Samsung Galaxy S25 Ultra 16GB
- 权限方案：Shizuku
- 截图 / 录屏：如附录文件所示

## 提交前检查清单

- [x] PR 目标分支建议为 `main`
- [x] PR 标题符合约定式提交格式
- [x] 变更范围单一，没有混入依赖升级或无关重构
- [x] 已说明变更原因、影响范围和验证结果
- [x] 涉及 Shizuku / 后台服务行为，已说明兼容性影响
- [x] 已进行真机验证

## Checklist

- [x] 我已阅读并遵守 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)

https://github.com/user-attachments/assets/fc313aea-1d47-4f76-bbf9-9fb2268d2b69

## Summary by Sourcery

在主屏幕添加 Shizuku 快捷入口，支持选择自定义 Shizuku 应用，并提供有状态的远程服务开启/关闭控制。

New Features:
- 在服务状态卡片上提供一个主屏按钮，可直接打开 Shizuku。
- 在设置中新增选项，用于选择自定义的 Shizuku 管理器应用，以用于启动和状态检查。
- 新增有状态的远程服务控制按钮，可根据当前连接状态在开启和关闭服务之间切换。

Enhancements:
- 通过 `ShizukuInstallHelper` 优化 Shizuku 启动处理，包括回退到官方应用以及自定义应用标签解析。
- 改进 Shizuku 状态对话框和自适应对话按钮，以更好地处理可选的关闭（dismiss）操作。

Build:
- 在 manifest 中声明额外的 launcher 查询，用于为 Shizuku 应用选择器加载可启动的应用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a Shizuku quick entry on the home screen, support selecting a custom Shizuku app, and expose a stateful remote service open/close control.

New Features:
- Provide a home screen button to open Shizuku directly from the service status card.
- Introduce a settings option to choose a custom Shizuku manager app used for launch and status checks.
- Add a stateful remote service control button that toggles between opening and closing the service based on current connection state.

Enhancements:
- Refine Shizuku launch handling via ShizukuInstallHelper, including fallback to the official app and custom app label resolution.
- Improve the Shizuku status dialog and adaptive dialog buttons to better handle optional dismiss actions.

Build:
- Declare an additional launcher query in the manifest to load launchable apps for the Shizuku app picker.

</details>