### PR TITLE
fix(root): 按安卓版本切换服务运行身份

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/manager/RootRemoteServiceConnector.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/manager/RootRemoteServiceConnector.kt
@@ -1,6 +1,7 @@
 package com.aliothmoon.maameow.manager
 
 import android.content.Context
+import android.os.Build
 import android.os.IBinder
 import android.os.Process
 import com.aliothmoon.maameow.BuildConfig
@@ -152,6 +153,9 @@ object RootRemoteServiceConnector : RemoteServiceConnectorBackend {
             append(shellQuote(RemoteServiceImpl::class.java.name))
             append(" --uid=")
             append(uid)
+            if (RootServiceUidPolicy.shouldKeepRoot(Build.VERSION.SDK_INT)) {
+                append(" --keep-root")
+            }
             append(" --log-file=")
             append(shellQuote(logFile.absolutePath))
             if (BuildConfig.DEBUG) {

--- a/app/src/main/java/com/aliothmoon/maameow/manager/RootRemoteServiceConnector.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/manager/RootRemoteServiceConnector.kt
@@ -153,7 +153,15 @@ object RootRemoteServiceConnector : RemoteServiceConnectorBackend {
             append(shellQuote(RemoteServiceImpl::class.java.name))
             append(" --uid=")
             append(uid)
-            if (RootServiceUidPolicy.shouldKeepRoot(Build.VERSION.SDK_INT)) {
+            /*
+             * Android 12L（API 32）及以下创建 VirtualDisplay 时需要以 shell（UID 2000）
+             * 身份运行，因此不传 --keep-root，由 native launcher 主动降权。
+             *
+             * Android 13（TIRAMISU，API 33）及以上则保持 Root（UID 0），否则部分设备
+             * 的 shell 身份没有 INJECT_EVENTS 权限，InputManager.injectInputEvent() 会拒绝
+             * MaaCore 的点击和滑动事件。
+             */
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 append(" --keep-root")
             }
             append(" --log-file=")

--- a/app/src/main/java/com/aliothmoon/maameow/manager/RootServiceUidPolicy.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/manager/RootServiceUidPolicy.kt
@@ -1,9 +1,0 @@
-package com.aliothmoon.maameow.manager
-
-object RootServiceUidPolicy {
-
-    // Android 13+（API 33+）开始 system/display/input 相关限制显著增强
-    private const val KEEP_ROOT_MIN_API = 33
-
-    fun shouldKeepRoot(apiLevel: Int): Boolean = apiLevel >= KEEP_ROOT_MIN_API
-}

--- a/app/src/main/java/com/aliothmoon/maameow/manager/RootServiceUidPolicy.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/manager/RootServiceUidPolicy.kt
@@ -1,0 +1,8 @@
+package com.aliothmoon.maameow.manager
+
+object RootServiceUidPolicy {
+
+    private const val KEEP_ROOT_MIN_API = 33
+
+    fun shouldKeepRoot(apiLevel: Int): Boolean = apiLevel >= KEEP_ROOT_MIN_API
+}

--- a/app/src/main/java/com/aliothmoon/maameow/manager/RootServiceUidPolicy.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/manager/RootServiceUidPolicy.kt
@@ -2,6 +2,7 @@ package com.aliothmoon.maameow.manager
 
 object RootServiceUidPolicy {
 
+    // Android 13+（API 33+）开始 system/display/input 相关限制显著增强
     private const val KEEP_ROOT_MIN_API = 33
 
     fun shouldKeepRoot(apiLevel: Int): Boolean = apiLevel >= KEEP_ROOT_MIN_API

--- a/app/src/main/native/launcher.c
+++ b/app/src/main/native/launcher.c
@@ -197,7 +197,7 @@ static void exec_app_process(const LauncherArgs *args) {
 /* ── main ── */
 
 int main(int argc, char **argv) {
-    LauncherArgs args;
+    LauncherArgs args = {0};
 
     if (!parse_args(argc, argv, &args)) {
         LOGE("Missing required launcher args");

--- a/app/src/main/native/launcher.c
+++ b/app/src/main/native/launcher.c
@@ -57,6 +57,7 @@ typedef struct {
     const char *debug_name;
     const char *log_file;
     int uid;
+    bool keep_root;
 } LauncherArgs;
 
 /* ── 文件日志 ── */
@@ -116,6 +117,7 @@ static bool parse_args(int argc, char **argv, LauncherArgs *out) {
                 return false;
             }
         }
+        else if (strcmp(argv[i], "--keep-root") == 0) out->keep_root = true;
     }
 
     return out->apk_path != NULL
@@ -222,27 +224,29 @@ int main(int argc, char **argv) {
     }
 
     if (child == 0) {
-        static const size_t kGidCount =
-                sizeof(kRequiredShellGids) / sizeof(kRequiredShellGids[0]);
+        if (!args.keep_root) {
+            static const size_t kGidCount =
+                    sizeof(kRequiredShellGids) / sizeof(kRequiredShellGids[0]);
 
-        int sg_ret = setgroups((int) kGidCount, kRequiredShellGids);
-        if (sg_ret != 0) {
-            LOGFW("setgroups(%zu gids) failed: %s — continuing", kGidCount, strerror(errno));
-        } else {
-            LOGFI("setgroups(%zu gids): ok", kGidCount);
-        }
+            int sg_ret = setgroups((int) kGidCount, kRequiredShellGids);
+            if (sg_ret != 0) {
+                LOGFW("setgroups(%zu gids) failed: %s — continuing", kGidCount, strerror(errno));
+            } else {
+                LOGFI("setgroups(%zu gids): ok", kGidCount);
+            }
 
-        if (setresgid(kShellUid, kShellUid, kShellUid) != 0) {
-            LOGFE("setresgid(%u) failed: %s", (unsigned) kShellUid, strerror(errno));
-            _exit(1);
-        }
-        LOGFI("setresgid(%u): ok", (unsigned) kShellUid);
+            if (setresgid(kShellUid, kShellUid, kShellUid) != 0) {
+                LOGFE("setresgid(%u) failed: %s", (unsigned) kShellUid, strerror(errno));
+                _exit(1);
+            }
+            LOGFI("setresgid(%u): ok", (unsigned) kShellUid);
 
-        if (setresuid(kShellUid, kShellUid, kShellUid) != 0) {
-            LOGFE("setresuid(%u) failed: %s", (unsigned) kShellUid, strerror(errno));
-            _exit(1);
+            if (setresuid(kShellUid, kShellUid, kShellUid) != 0) {
+                LOGFE("setresuid(%u) failed: %s", (unsigned) kShellUid, strerror(errno));
+                _exit(1);
+            }
+            LOGFI("setresuid(%u): ok — exec app_process", (unsigned) kShellUid);
         }
-        LOGFI("setresuid(%u): ok — exec app_process", (unsigned) kShellUid);
 
         exec_app_process(&args);
         _exit(1);


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)。

## 关联 Issue

无

## 变更摘要

以API33作为分界线：
Android 13 及以上保持 Root UID 以支持输入注入。
Android 12L 及以下继续降权为 Shell UID，兼容虚拟显示创建。

## 验证
在HyperOS3.0（Android16）设备上测试，可以正常获取INJECT_EVENTS，进行点击。

## 截图 / 日志 / 说明



https://github.com/user-attachments/assets/e0a83c7c-52f8-4906-9601-d41b7659b941


## Checklist

- [x] 我已阅读并遵守 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)

## Summary by Sourcery

调整 root 服务启动器，使其根据 Android API 级别有条件地保留 root 权限，同时保持在较旧版本上的现有行为。

增强内容：
- 在原生启动器中引入 `keep-root` 标志，可选地跳过降级到 shell UID。
- 添加 `RootServiceUidPolicy`，根据最小 API 级别（当前为 33）来决定是否保留 root，并在通过 `RootRemoteServiceConnector` 启动服务进程时将其接入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust root service launcher to conditionally retain root privileges based on Android API level while keeping existing behavior for older versions.

Enhancements:
- Introduce a keep-root flag in the native launcher to optionally skip dropping to the shell UID.
- Add RootServiceUidPolicy to decide whether to keep root based on a minimum API level (currently 33) and wire it into RootRemoteServiceConnector when spawning the service process.

</details>