### PR TITLE
feat(settings): add Page Scale font size slider

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -531,4 +531,16 @@ class AppSettingsManager(
         }
     }
 
+    // 页面缩放比例（80~110，默认 100）
+    val fontSizeScale: StateFlow<Int> = settings
+        .map { it.fontSizeScale.toIntOrNull()?.coerceIn(80, 110) ?: 100 }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.fontSizeScale.toIntOrNull()?.coerceIn(80, 110) ?: 100)
+
+    suspend fun setFontSizeScale(scale: Int) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[fontSizeScale] = scale.coerceIn(80, 110).toString() }
+        }
+    }
+
 }

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -77,4 +77,7 @@ data class AppSettings(
      * Android 12 以下设备只能使用内置蓝色主题
      */
     @PrefKey(default = "false") val useSystemMonetColor: String = "false",
+
+    /** 页面缩放比例（80~110，默认 100 = 1.0x） */
+    @PrefKey(default = "100") val fontSizeScale: String = "100",
 )

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -109,6 +110,7 @@ fun SettingsView(
     val updateChannel by viewModel.updateChannel.collectAsStateWithLifecycle()
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
     val useSystemMonetColor by viewModel.useSystemMonetColor.collectAsStateWithLifecycle()
+    val fontSizeScale by viewModel.fontSizeScale.collectAsStateWithLifecycle()
     val backgroundResolution by viewModel.backgroundResolution.collectAsStateWithLifecycle()
     val language by viewModel.language.collectAsStateWithLifecycle()
     val backupMessage by viewModel.backupMessage.collectAsStateWithLifecycle()
@@ -547,6 +549,12 @@ fun SettingsView(
                         onModeSelected = { viewModel.setThemeMode(it) }
                     )
                     SettingsDivider(contentColor)
+                    FontSizeSetting(
+                        contentColor = contentColor,
+                        value = fontSizeScale,
+                        onValueChange = { viewModel.setFontSizeScale(it) }
+                    )
+                    SettingsDivider(contentColor)
                     SettingLanguageItem(
                         contentColor = contentColor,
                         selectedLanguage = language,
@@ -786,6 +794,71 @@ private fun SettingClickItem(
                     text = description,
                     style = MaterialTheme.typography.bodySmall,
                     color = contentColor.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * 字体大小（页面缩放）设置：整数 80~110，默认 100。
+ * 松手后才提交全局缩放。
+ */
+@Composable
+private fun FontSizeSetting(
+    contentColor: Color,
+    value: Int,
+    onValueChange: (Int) -> Unit
+) {
+    var sliderValue by remember { mutableStateOf(value.toFloat()) }
+    LaunchedEffect(value) {
+        sliderValue = value.toFloat()
+    }
+    val current = sliderValue.toInt().coerceIn(80, 110)
+
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.settings_font_size_title),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = contentColor
+                )
+                Text(
+                    text = stringResource(R.string.settings_font_size_summary),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = contentColor.copy(alpha = 0.6f)
+                )
+            }
+            Text(
+                text = current.toString(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = contentColor
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Slider(
+            value = sliderValue,
+            onValueChange = { sliderValue = it },
+            onValueChangeFinished = {
+                onValueChange(sliderValue.toInt().coerceIn(80, 110))
+            },
+            valueRange = 80f..110f,
+            steps = 0,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            listOf(80, 90, 100, 110).forEach { kp ->
+                Text(
+                    text = kp.toString(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = contentColor.copy(alpha = 0.5f)
                 )
             }
         }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -266,4 +266,12 @@ class SettingsViewModel(
             appSettingsManager.setUseSystemMonetColor(enabled)
         }
     }
+
+    // ============ Font Size Scale ============
+    val fontSizeScale: StateFlow<Int> = appSettingsManager.fontSizeScale
+    fun setFontSizeScale(scale: Int) {
+        viewModelScope.launch {
+            appSettingsManager.setFontSizeScale(scale)
+        }
+    }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -59,6 +59,8 @@
     <string name="settings_theme_white">Light</string>
     <string name="settings_theme_dark">Dark</string>
     <string name="settings_theme_pure_dark">Pure Black</string>
+    <string name="settings_font_size_title">Page Scale</string>
+    <string name="settings_font_size_summary">Adjust page content size (80-110)</string>
     <string name="settings_language_title">Language</string>
     <string name="settings_language_system">Follow System</string>
     <string name="settings_language_zh">中文</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,6 +257,8 @@
     <string name="settings_theme_white">白色</string>
     <string name="settings_theme_dark">暗色</string>
     <string name="settings_theme_pure_dark">纯黑</string>
+    <string name="settings_font_size_title">页面缩放</string>
+    <string name="settings_font_size_summary">调整页面内容大小 (80-110)</string>
     <string name="settings_language_title">语言</string>
     <string name="settings_language_system">跟随系统</string>
     <string name="settings_language_zh">中文</string>


### PR DESCRIPTION
## Summary

Add a page scale setting (80-110, default 100) with Material3 Slider in SettingsView.

### Changes

- **AppSettings.kt**: Add `fontSizeScale` field (default "100")
- **AppSettingsManager.kt**: Add `fontSizeScale` StateFlow<Int> + `setFontSizeScale()` setter with coercion to [80, 110]
- **SettingsViewModel.kt**: Expose `fontSizeScale` and `setFontSizeScale()` to the view layer
- **SettingsView.kt**: Add `FontSizeSetting` composable with:
  - Title + summary text
  - Current value display
  - Material3 Slider (range 80-110, step=1 via rounding on release)
  - Label markers at 80/90/100/110 below the slider
- **strings.xml** (zh + en): Add `settings_font_size_title` and `settings_font_size_summary`