### PR TITLE
feat: 字体缩放功能

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/MainActivity.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/MainActivity.kt
@@ -8,7 +8,10 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -68,9 +71,18 @@ class MainActivity : AppCompatActivity() {
         setContent {
             val themeMode by appSettingsManager.themeMode.collectAsStateWithLifecycle()
             val useSystemMonetColor by appSettingsManager.useSystemMonetColor.collectAsStateWithLifecycle()
+            val fontSizeScale by appSettingsManager.fontSizeScale.collectAsStateWithLifecycle()
 
             MaaMeowTheme(themeMode = themeMode, useSystemMonetColor = useSystemMonetColor) {
-                AppNavigation(backgroundTaskViewModel = backgroundTaskViewModel)
+                val baseDensity = LocalDensity.current
+                CompositionLocalProvider(
+                    LocalDensity provides Density(
+                        density = baseDensity.density * fontSizeScale / 100f,
+                        fontScale = baseDensity.fontScale
+                    )
+                ) {
+                    AppNavigation(backgroundTaskViewModel = backgroundTaskViewModel)
+                }
             }
         }
     }

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -40,6 +40,16 @@ class AppSettingsManager(
 
     companion object {
         val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "app_settings")
+
+        /** 页面缩放范围 */
+        const val FONT_SIZE_SCALE_MIN = 80
+        const val FONT_SIZE_SCALE_MAX = 110
+        const val FONT_SIZE_SCALE_DEFAULT = 100
+
+        /** 从存储原始值解析为合法的 font size scale */
+        fun parseFontSizeScale(raw: String): Int =
+            raw.toIntOrNull()?.coerceIn(FONT_SIZE_SCALE_MIN, FONT_SIZE_SCALE_MAX)
+                ?: FONT_SIZE_SCALE_DEFAULT
     }
 
     val settings: Flow<AppSettings> = with(AppSettingsSchema) { context.dataStore.flow }
@@ -530,5 +540,18 @@ class AppSettingsManager(
             context.dataStore.edit { it[useSystemMonetColor] = enabled.toString() }
         }
     }
+
+    // 页面缩放比例（80~110，默认 100）
+    val fontSizeScale: StateFlow<Int> = settings
+        .map { parseFontSizeScale(it.fontSizeScale) }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, parseFontSizeScale(initialSettings.fontSizeScale))
+
+    suspend fun setFontSizeScale(scale: Int) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[fontSizeScale] = scale.coerceIn(FONT_SIZE_SCALE_MIN, FONT_SIZE_SCALE_MAX).toString() }
+        }
+    }
+
 
 }

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -77,4 +77,7 @@ data class AppSettings(
      * Android 12 以下设备只能使用内置蓝色主题
      */
     @PrefKey(default = "false") val useSystemMonetColor: String = "false",
+
+    /** 页面缩放比例（80~110，默认 100 = 1.0x） */
+    @PrefKey(default = "100") val fontSizeScale: String = "100",
 )

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -23,16 +23,24 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.rounded.Build
 import androidx.compose.material3.CircularProgressIndicator
 import android.os.Build
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,6 +60,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.aliothmoon.maameow.BuildConfig
@@ -109,6 +118,7 @@ fun SettingsView(
     val updateChannel by viewModel.updateChannel.collectAsStateWithLifecycle()
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
     val useSystemMonetColor by viewModel.useSystemMonetColor.collectAsStateWithLifecycle()
+    val fontSizeScale by viewModel.fontSizeScale.collectAsStateWithLifecycle()
     val backgroundResolution by viewModel.backgroundResolution.collectAsStateWithLifecycle()
     val language by viewModel.language.collectAsStateWithLifecycle()
     val backupMessage by viewModel.backupMessage.collectAsStateWithLifecycle()
@@ -513,23 +523,6 @@ fun SettingsView(
                             }
                         }
                     }
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                        SettingSwitchItem(
-                            title = stringResource(R.string.settings_monet_color_title),
-                            description = stringResource(R.string.settings_monet_color_desc),
-                            contentColor = contentColor,
-                            checked = useSystemMonetColor,
-                            onCheckedChange = { viewModel.setUseSystemMonetColor(it) }
-                        )
-                        SettingsDivider(contentColor)
-                    }
-                    SettingClickItem(
-                        title = stringResource(R.string.settings_achievement_title),
-                        description = stringResource(R.string.settings_achievement_desc),
-                        contentColor = contentColor
-                    ) {
-                        navController.navigate(Routes.ACHIEVEMENT)
-                    }
                     if (BuildConfig.DEBUG) {
                         SettingsDivider(contentColor)
                         SettingClickItem(
@@ -541,10 +534,14 @@ fun SettingsView(
                         }
                     }
                     SettingsDivider(contentColor)
-                    SettingThemeModeItem(
+                    SettingThemeSection(
                         contentColor = contentColor,
                         selectedMode = themeMode,
-                        onModeSelected = { viewModel.setThemeMode(it) }
+                        onModeSelected = { viewModel.setThemeMode(it) },
+                        useSystemMonetColor = useSystemMonetColor,
+                        onMonetColorChanged = { viewModel.setUseSystemMonetColor(it) },
+                        fontSizeScale = fontSizeScale,
+                        onFontSizeScaleChanged = { viewModel.setFontSizeScale(it) }
                     )
                     SettingsDivider(contentColor)
                     SettingLanguageItem(
@@ -708,54 +705,99 @@ fun SettingsView(
 }
 
 @Composable
-private fun SettingThemeModeItem(
+private fun SettingThemeSection(
     contentColor: Color,
     selectedMode: AppSettingsManager.ThemeMode,
-    onModeSelected: (AppSettingsManager.ThemeMode) -> Unit
+    onModeSelected: (AppSettingsManager.ThemeMode) -> Unit,
+    useSystemMonetColor: Boolean,
+    onMonetColorChanged: (Boolean) -> Unit,
+    fontSizeScale: Int,
+    onFontSizeScaleChanged: (Int) -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = MaaDesignTokens.Spacing.listItemVertical),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        Text(
-            text = stringResource(R.string.settings_theme_title),
-            style = MaterialTheme.typography.bodyLarge,
-            color = contentColor
-        )
-        Row(modifier = Modifier.fillMaxWidth()) {
-            val modes = listOf(
-                AppSettingsManager.ThemeMode.SYSTEM to stringResource(R.string.settings_theme_system),
-                AppSettingsManager.ThemeMode.WHITE to stringResource(R.string.settings_theme_white),
-                AppSettingsManager.ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
-                AppSettingsManager.ThemeMode.PURE_DARK to stringResource(R.string.settings_theme_pure_dark)
+    var expanded by remember { mutableStateOf(false) }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // 标题行：点击展开/收起
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { expanded = !expanded }
+                .padding(vertical = MaaDesignTokens.Spacing.listItemVertical),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.settings_theme_title),
+                style = MaterialTheme.typography.bodyLarge,
+                color = contentColor,
+                modifier = Modifier.weight(1f)
             )
-            modes.forEach { (mode, label) ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
-                    modifier = Modifier
-                        .weight(1f)
-                        .clip(RoundedCornerShape(8.dp))
-                        .selectable(
-                            selected = mode == selectedMode,
-                            onClick = { onModeSelected(mode) },
-                            role = Role.RadioButton
-                        )
-                ) {
-                    RadioButton(
-                        selected = mode == selectedMode,
-                        onClick = null
+            Icon(
+                imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = null,
+                tint = contentColor.copy(alpha = 0.6f)
+            )
+        }
+        // 展开内容：主题模式 + 莫奈色 + 页面缩放
+        AnimatedVisibility(visible = expanded) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // 主题模式选择
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    val modes = listOf(
+                        AppSettingsManager.ThemeMode.SYSTEM to stringResource(R.string.settings_theme_system),
+                        AppSettingsManager.ThemeMode.WHITE to stringResource(R.string.settings_theme_white),
+                        AppSettingsManager.ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
+                        AppSettingsManager.ThemeMode.PURE_DARK to stringResource(R.string.settings_theme_pure_dark)
                     )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = label,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = contentColor,
-                        maxLines = 1
-                    )
+                    modes.forEach { (mode, label) ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center,
+                            modifier = Modifier
+                                .weight(1f)
+                                .clip(RoundedCornerShape(8.dp))
+                                .selectable(
+                                    selected = mode == selectedMode,
+                                    onClick = { onModeSelected(mode) },
+                                    role = Role.RadioButton
+                                )
+                        ) {
+                            RadioButton(
+                                selected = mode == selectedMode,
+                                onClick = null
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                text = label,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = contentColor,
+                                maxLines = 1
+                            )
+                        }
+                    }
                 }
+                // 莫奈主题色（SDK >= S）
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(R.string.settings_monet_color_title),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = contentColor,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Switch(checked = useSystemMonetColor, onCheckedChange = onMonetColorChanged)
+                    }
+                }
+                // 页面缩放
+                FontSizeSetting(
+                    contentColor = contentColor,
+                    value = fontSizeScale,
+                    onValueChange = onFontSizeScaleChanged
+                )
             }
         }
     }
@@ -786,6 +828,96 @@ private fun SettingClickItem(
                     text = description,
                     style = MaterialTheme.typography.bodySmall,
                     color = contentColor.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * 字体大小（页面缩放）设置：整数 80~110，默认 100。
+ * 松手后才提交全局缩放。滑块下方带实时预览框。
+ */
+@Composable
+private fun FontSizeSetting(
+    contentColor: Color,
+    value: Int,
+    onValueChange: (Int) -> Unit
+) {
+    var sliderValue by remember { mutableStateOf(value.toFloat()) }
+    LaunchedEffect(value) {
+        sliderValue = value.toFloat()
+    }
+    val current = sliderValue.roundToInt().coerceIn(AppSettingsManager.FONT_SIZE_SCALE_MIN, AppSettingsManager.FONT_SIZE_SCALE_MAX)
+
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.settings_font_size_title),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = contentColor
+                )
+                Text(
+                    text = stringResource(R.string.settings_font_size_summary),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = contentColor.copy(alpha = 0.6f)
+                )
+            }
+            Text(
+                text = current.toString(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = contentColor
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Slider(
+            value = sliderValue,
+            onValueChange = { sliderValue = it },
+            onValueChangeFinished = {
+                onValueChange(sliderValue.roundToInt().coerceIn(
+                    AppSettingsManager.FONT_SIZE_SCALE_MIN,
+                    AppSettingsManager.FONT_SIZE_SCALE_MAX
+                ))
+            },
+            valueRange = AppSettingsManager.FONT_SIZE_SCALE_MIN.toFloat()..AppSettingsManager.FONT_SIZE_SCALE_MAX.toFloat(),
+            steps = 0,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            listOf(AppSettingsManager.FONT_SIZE_SCALE_MIN, 90, 100, AppSettingsManager.FONT_SIZE_SCALE_MAX).forEach { kp ->
+                Text(
+                    text = kp.toString(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = contentColor.copy(alpha = 0.5f)
+                )
+            }
+        }
+        // 实时预览框：用 sliderValue 实时缩放，不等待松手
+        val previewDensity = LocalDensity.current
+        CompositionLocalProvider(
+            LocalDensity provides Density(
+                density = previewDensity.density * current / 100f,
+                fontScale = previewDensity.fontScale
+            )
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                shape = RoundedCornerShape(12.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+            ) {
+                Text(
+                    text = "你是谁？请支持牛牛！('- ' )",
+                    modifier = Modifier.padding(16.dp),
+                    color = contentColor
                 )
             }
         }
@@ -1103,6 +1235,7 @@ private fun SettingRemoteBackendItem(
         }
     }
 }
+
 
 private data class ShizukuLaunchAppOption(
     val label: String,

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -266,4 +266,12 @@ class SettingsViewModel(
             appSettingsManager.setUseSystemMonetColor(enabled)
         }
     }
+
+    // ============ Font Size Scale ============
+    val fontSizeScale: StateFlow<Int> = appSettingsManager.fontSizeScale
+    fun setFontSizeScale(scale: Int) {
+        viewModelScope.launch {
+            appSettingsManager.setFontSizeScale(scale)
+        }
+    }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -48,7 +48,6 @@
     <string name="settings_startup_backend_desc">Choose how the app obtains system permissions</string>
     <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
     <string name="settings_monet_color_title">Monet Theme Color</string>
-    <string name="settings_monet_color_desc">Use Material You dynamic color on Android 12+. Off uses the built-in blue theme.</string>
 
     <string name="settings_achievement_title">Achievements</string>
     <string name="settings_achievement_desc">View MaaMeow milestones and hidden easter eggs</string>
@@ -59,6 +58,8 @@
     <string name="settings_theme_white">Light</string>
     <string name="settings_theme_dark">Dark</string>
     <string name="settings_theme_pure_dark">Pure Black</string>
+    <string name="settings_font_size_title">Page Scale</string>
+    <string name="settings_font_size_summary">Adjust page content size (80-110)</string>
     <string name="settings_language_title">Language</string>
     <string name="settings_language_system">Follow System</string>
     <string name="settings_language_zh">中文</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,7 +246,6 @@
     <string name="settings_startup_backend_desc">选择应用获取系统权限的方式</string>
     <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
     <string name="settings_monet_color_title">莫奈主题色</string>
-    <string name="settings_monet_color_desc">Android 12+ 启用 Material You 动态取色；关闭则使用内置蓝色主题</string>
 
     <string name="settings_achievement_title">成就</string>
     <string name="settings_achievement_desc">查看 MaaMeow 使用记录与隐藏彩蛋</string>
@@ -257,6 +256,8 @@
     <string name="settings_theme_white">白色</string>
     <string name="settings_theme_dark">暗色</string>
     <string name="settings_theme_pure_dark">纯黑</string>
+    <string name="settings_font_size_title">页面缩放</string>
+    <string name="settings_font_size_summary">调整页面内容大小 (80-110)</string>
     <string name="settings_language_title">语言</string>
     <string name="settings_language_system">跟随系统</string>
     <string name="settings_language_zh">中文</string>


### PR DESCRIPTION
添加字体缩放设置，支持用户自定义界面字体大小。

- 设置页新增字体大小滑块（0.8x~1.5x）
- 全局 TextStyle 层级统一应用缩放
- 资源文件（中英文 strings.xml）支持

## Summary by Sourcery

添加一个用户可配置的页面缩放设置，并全局应用以调整 UI 字体和内容大小。

新功能：
- 引入一个持久化的页面缩放（字体大小）偏好设置，带可配置的范围和默认值。
- 在设置中的主题部分新增字体大小缩放滑块，并提供实时预览，位置与主题和 Monet 配色选项并列。

增强改进：
- 通过在 MainActivity 中使用全局密度包装器应用配置好的页面缩放，使所有 composable 都遵循用户选择的大小。
- 将主题设置区域重构为可展开的分区，将主题模式、Monet 颜色开关和页面缩放控件进行分组。
- 简化 Monet 主题颜色文案，移除中英文资源中详细的描述字符串。

文档：
- 为新的页面缩放设置说明在中英文资源中添加本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a user-configurable page scale setting and apply it globally to adjust UI font and content size.

New Features:
- Introduce a persistent page scale (font size) preference with configurable range and default value.
- Expose a font size scale slider with live preview in the settings theme section, alongside theme and Monet color options.

Enhancements:
- Apply the configured page scale via a global density wrapper in MainActivity so all composables respect the user-selected size.
- Refactor the theme settings area into an expandable section that groups theme mode, Monet color toggle, and page scale controls.
- Simplify Monet theme color copy by removing the detailed description string in both Chinese and English resources.

Documentation:
- Add localized strings for the new page scale setting description in Chinese and English resources.

</details>