### PR TITLE
feat: 设置页面改造与成就系统

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/MainActivity.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/MainActivity.kt
@@ -8,7 +8,10 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -68,9 +71,18 @@ class MainActivity : AppCompatActivity() {
         setContent {
             val themeMode by appSettingsManager.themeMode.collectAsStateWithLifecycle()
             val useSystemMonetColor by appSettingsManager.useSystemMonetColor.collectAsStateWithLifecycle()
+            val fontSizeScale by appSettingsManager.fontSizeScale.collectAsStateWithLifecycle()
 
             MaaMeowTheme(themeMode = themeMode, useSystemMonetColor = useSystemMonetColor) {
-                AppNavigation(backgroundTaskViewModel = backgroundTaskViewModel)
+                val baseDensity = LocalDensity.current
+                CompositionLocalProvider(
+                    LocalDensity provides Density(
+                        density = baseDensity.density * fontSizeScale / 100f,
+                        fontScale = baseDensity.fontScale
+                    )
+                ) {
+                    AppNavigation(backgroundTaskViewModel = backgroundTaskViewModel)
+                }
             }
         }
     }

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -553,6 +553,15 @@ class AppSettingsManager(
         }
     }
 
+    // 是否显示成就解锁时的 Snackbar 提示
+    val showAchievementSnackbar: StateFlow<Boolean> = settings
+        .map { it.showAchievementSnackbar.toBooleanStrictOrNull() ?: true }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.showAchievementSnackbar.toBooleanStrictOrNull() ?: true)
+
+    suspend fun setShowAchievementSnackbar(enabled: Boolean) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[showAchievementSnackbar] = enabled.toString() }
         }
     }
 

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -40,6 +40,16 @@ class AppSettingsManager(
 
     companion object {
         val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "app_settings")
+
+        /** 页面缩放范围 */
+        const val FONT_SIZE_SCALE_MIN = 80
+        const val FONT_SIZE_SCALE_MAX = 110
+        const val FONT_SIZE_SCALE_DEFAULT = 100
+
+        /** 从存储原始值解析为合法的 font size scale */
+        fun parseFontSizeScale(raw: String): Int =
+            raw.toIntOrNull()?.coerceIn(FONT_SIZE_SCALE_MIN, FONT_SIZE_SCALE_MAX)
+                ?: FONT_SIZE_SCALE_DEFAULT
     }
 
     val settings: Flow<AppSettings> = with(AppSettingsSchema) { context.dataStore.flow }
@@ -528,6 +538,21 @@ class AppSettingsManager(
     suspend fun setUseSystemMonetColor(enabled: Boolean) {
         with(AppSettingsSchema) {
             context.dataStore.edit { it[useSystemMonetColor] = enabled.toString() }
+        }
+    }
+
+    // 页面缩放比例（80~110，默认 100）
+    val fontSizeScale: StateFlow<Int> = settings
+        .map { parseFontSizeScale(it.fontSizeScale) }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, parseFontSizeScale(initialSettings.fontSizeScale))
+
+    suspend fun setFontSizeScale(scale: Int) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[fontSizeScale] = scale.coerceIn(FONT_SIZE_SCALE_MIN, FONT_SIZE_SCALE_MAX).toString() }
+        }
+    }
+
         }
     }
 

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -80,4 +80,7 @@ data class AppSettings(
 
     /** 页面缩放比例（80~110，默认 100 = 1.0x） */
     @PrefKey(default = "100") val fontSizeScale: String = "100",
+
+    /** 是否显示成就解锁时的 Snackbar 提示 */
+    @PrefKey(default = "true") val showAchievementSnackbar: String = "true",
 )

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -77,4 +77,7 @@ data class AppSettings(
      * Android 12 以下设备只能使用内置蓝色主题
      */
     @PrefKey(default = "false") val useSystemMonetColor: String = "false",
+
+    /** 页面缩放比例（80~110，默认 100 = 1.0x） */
+    @PrefKey(default = "100") val fontSizeScale: String = "100",
 )

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -81,13 +81,14 @@ fun AppNavigation(
     // 执行模式状态 - 用于底部导航拦截
     val runMode by appSettings.runMode.collectAsStateWithLifecycle()
     val announcementReadVersion by appSettings.announcementReadVersion.collectAsStateWithLifecycle()
+    val showAchievementSnackbar by appSettings.showAchievementSnackbar.collectAsStateWithLifecycle()
     val language by appSettings.language.collectAsStateWithLifecycle()
     val overlayControlMode by appSettings.overlayControlMode.collectAsStateWithLifecycle()
     val pendingScheduledExecution by backgroundTaskViewModel.coordinator.pendingExecution.collectAsStateWithLifecycle()
     val scheduledCountdownState by backgroundTaskViewModel.coordinator.countdownState.collectAsStateWithLifecycle()
 
     // 定义哪些页面属于主 Tab
-    val mainTabs = listOf(Routes.HOME, Routes.BACKGROUND_TASK, Routes.SCHEDULE, Routes.NOTIFICATION)
+    val mainTabs = listOf(Routes.HOME, Routes.BACKGROUND_TASK, Routes.SCHEDULE, Routes.SETTINGS)
     
     // 判断是否处于主 Tab 页面
     val isOnMainTab = currentNavRoute in mainTabs || currentNavRoute == null
@@ -131,16 +132,18 @@ fun AppNavigation(
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         }
     }
-    LaunchedEffect(achievementRepository) {
-        achievementRepository.unlockEvents.collect { id ->
-            val title = context.achievementText(id, "title")
-            snackbarHostState.showSnackbar(
-                message = context.getString(
-                    R.string.achievement_unlocked_message,
-                    title,
-                ),
-                duration = SnackbarDuration.Short,
-            )
+    LaunchedEffect(achievementRepository, showAchievementSnackbar) {
+        if (showAchievementSnackbar) {
+            achievementRepository.unlockEvents.collect { id ->
+                val title = context.achievementText(id, "title")
+                snackbarHostState.showSnackbar(
+                    message = context.getString(
+                        R.string.achievement_unlocked_message,
+                        title,
+                    ),
+                    duration = SnackbarDuration.Short,
+                )
+            }
         }
     }
 
@@ -225,17 +228,6 @@ fun AppNavigation(
 
                     composable(
                         route = Routes.NOTIFICATION,
-                        enterTransition = { tabEnterTransition },
-                        exitTransition = { tabExitTransition },
-                        popEnterTransition = { tabEnterTransition },
-                        popExitTransition = { tabExitTransition }
-                    ) {
-                        BackHandler { navController.popBackStack() }
-                        NotificationSettingsView()
-                    }
-
-                    composable(
-                        route = Routes.SETTINGS,
                         enterTransition = {
                             slideInHorizontally(initialOffsetX = { it }, animationSpec = tween(350))
                         },
@@ -249,6 +241,17 @@ fun AppNavigation(
                             slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
                         }
                     ) {
+                        NotificationSettingsView(navController = navController)
+                    }
+
+                    composable(
+                        route = Routes.SETTINGS,
+                        enterTransition = { tabEnterTransition },
+                        exitTransition = { tabExitTransition },
+                        popEnterTransition = { tabEnterTransition },
+                        popExitTransition = { tabExitTransition }
+                    ) {
+                        BackHandler { navController.popBackStack() }
                         SettingsView(
                             navController = navController,
                             onViewAnnouncement = { forceShowAnnouncement = true },
@@ -270,7 +273,9 @@ fun AppNavigation(
                             slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
                         }
                     ) {
-                        AchievementView(navController = navController)
+                        AchievementView(
+                            navController = navController,
+                        )
                     }
 
                     composable(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/BottomNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/BottomNavigation.kt
@@ -16,7 +16,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -57,14 +57,14 @@ sealed class BottomNavTab(
         icon = Icons.Default.DateRange
     )
 
-    data object NOTIFICATION : BottomNavTab(
-        route = Routes.NOTIFICATION,
-        labelRes = R.string.bottom_nav_notification,
-        icon = Icons.Default.Notifications
+    data object SETTINGS : BottomNavTab(
+        route = Routes.SETTINGS,
+        labelRes = R.string.bottom_nav_settings,
+        icon = Icons.Default.Settings
     )
 
     companion object {
-        val all = listOf(HOME, BACKGROUND, SCHEDULE, NOTIFICATION)
+        val all = listOf(HOME, BACKGROUND, SCHEDULE, SETTINGS)
     }
 }
 

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.rounded.Build
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
@@ -65,7 +64,6 @@ import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.aliothmoon.maameow.R
-import com.aliothmoon.maameow.constant.Routes
 import com.aliothmoon.maameow.data.datasource.ResourceDownloader
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
 import com.aliothmoon.maameow.data.permission.PermissionState
@@ -220,16 +218,6 @@ fun HomeView(
                         fontWeight = FontWeight.SemiBold,
                         style = MaterialTheme.typography.headlineMedium
                     )
-                },
-                actions = {
-                    IconButton(onClick = {
-                        navController.navigate(Routes.SETTINGS)
-                    }) {
-                        Icon(
-                            imageVector = Icons.Default.Settings,
-                            contentDescription = stringResource(R.string.home_cd_open_settings)
-                        )
-                    }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.background,

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/notification/NotificationSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/notification/NotificationSettingsView.kt
@@ -1,6 +1,9 @@
 package com.aliothmoon.maameow.presentation.view.notification
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.navigation.NavController
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -61,6 +64,7 @@ private val PROVIDERS: List<Pair<String, Int>> = listOf(
 
 @Composable
 fun NotificationSettingsView(
+    navController: NavController,
     viewModel: NotificationSettingsViewModel = koinViewModel()
 ) {
     val settings by viewModel.settings.collectAsStateWithLifecycle()
@@ -77,7 +81,11 @@ fun NotificationSettingsView(
 
     Scaffold(
         topBar = {
-            TopAppBar(title = stringResource(R.string.notification_settings_title))
+            TopAppBar(
+                title = stringResource(R.string.notification_settings_title),
+                navigationIcon = Icons.AutoMirrored.Filled.ArrowBack,
+                onNavigationClick = { navController.navigateUp() }
+            )
         }
     ) { paddingValues ->
     val contentColor = MaterialTheme.colorScheme.onSurface

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -524,16 +524,6 @@ fun SettingsView(
                             }
                         }
                     }
-                    if (BuildConfig.DEBUG) {
-                        SettingsDivider(contentColor)
-                        SettingClickItem(
-                            title = stringResource(R.string.settings_achievement_debug_title),
-                            description = stringResource(R.string.settings_achievement_debug_desc),
-                            contentColor = contentColor
-                        ) {
-                            navController.navigate(Routes.ACHIEVEMENT_DEBUG)
-                        }
-                    }
                     SettingsDivider(contentColor)
                     SettingThemeSection(
                         contentColor = contentColor,
@@ -690,6 +680,16 @@ fun SettingsView(
                         checked = showAchievementSnackbar,
                         onCheckedChange = { viewModel.setShowAchievementSnackbar(it) }
                     )
+                    if (BuildConfig.DEBUG) {
+                        SettingsDivider(contentColor)
+                        SettingClickItem(
+                            title = stringResource(R.string.settings_achievement_debug_title),
+                            description = stringResource(R.string.settings_achievement_debug_desc),
+                            contentColor = contentColor
+                        ) {
+                            navController.navigate(Routes.ACHIEVEMENT_DEBUG)
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -670,6 +670,7 @@ fun SettingsView(
                     SettingsDivider(contentColor)
                     SettingSwitchItem(
                         title = stringResource(R.string.settings_achievement_snackbar_title),
+                        description = stringResource(R.string.settings_achievement_snackbar_desc),
                         contentColor = contentColor,
                         checked = showAchievementSnackbar,
                         onCheckedChange = { viewModel.setShowAchievementSnackbar(it) }
@@ -813,12 +814,18 @@ private fun SettingThemeSection(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(
-                    text = stringResource(R.string.settings_monet_color_title),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = contentColor,
-                    modifier = Modifier.weight(1f)
-                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.settings_monet_color_title),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = contentColor
+                    )
+                    Text(
+                        text = stringResource(R.string.settings_monet_color_desc),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = contentColor.copy(alpha = 0.6f)
+                    )
+                }
                 Switch(checked = useSystemMonetColor, onCheckedChange = onMonetColorChanged)
             }
         }
@@ -927,11 +934,12 @@ private fun FontSizeSetting(
                 )
             }
         }
-        // 实时预览框：用 sliderValue 实时缩放，不等待松手
+        // 实时预览框：previewDensity 已被全局缩放（D0 * value/100），
+        // 故按 current/value 还原到 D0 * current/100，避免与全局缩放叠加造成重复缩放。
         val previewDensity = LocalDensity.current
         CompositionLocalProvider(
             LocalDensity provides Density(
-                density = previewDensity.density * current / 100f,
+                density = previewDensity.density * current / value.toFloat(),
                 fontScale = previewDensity.fontScale
             )
         ) {

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -441,6 +441,36 @@ fun SettingsView(
                 }
             }
 
+            // 显示设置
+            item {
+                SectionHeader(stringResource(R.string.settings_section_display))
+                InfoCard(
+                    title = "",
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    contentColor = contentColor,
+                    contentPadding = PaddingValues(
+                        horizontal = MaaDesignTokens.Card.innerPadding,
+                        vertical = MaaDesignTokens.Spacing.listItemVertical
+                    )
+                ) {
+                    SettingLanguageItem(
+                        contentColor = contentColor,
+                        selectedLanguage = language,
+                        onLanguageSelected = { viewModel.setLanguage(it) }
+                    )
+                    SettingsDivider(contentColor)
+                    SettingThemeSection(
+                        contentColor = contentColor,
+                        selectedMode = themeMode,
+                        onModeSelected = { viewModel.setThemeMode(it) },
+                        useSystemMonetColor = useSystemMonetColor,
+                        onMonetColorChanged = { viewModel.setUseSystemMonetColor(it) },
+                        fontSizeScale = fontSizeScale,
+                        onFontSizeScaleChanged = { viewModel.setFontSizeScale(it) }
+                    )
+                }
+            }
+
             // 其他设置
             item {
                 SectionHeader(stringResource(R.string.settings_section_other))
@@ -518,22 +548,6 @@ fun SettingsView(
                             }
                         }
                     }
-                    SettingsDivider(contentColor)
-                    SettingThemeSection(
-                        contentColor = contentColor,
-                        selectedMode = themeMode,
-                        onModeSelected = { viewModel.setThemeMode(it) },
-                        useSystemMonetColor = useSystemMonetColor,
-                        onMonetColorChanged = { viewModel.setUseSystemMonetColor(it) },
-                        fontSizeScale = fontSizeScale,
-                        onFontSizeScaleChanged = { viewModel.setFontSizeScale(it) }
-                    )
-                    SettingsDivider(contentColor)
-                    SettingLanguageItem(
-                        contentColor = contentColor,
-                        selectedLanguage = language,
-                        onLanguageSelected = { viewModel.setLanguage(it) }
-                    )
                     SettingsDivider(contentColor)
                     SettingBackgroundResolutionItem(
                         contentColor = contentColor,
@@ -765,7 +779,7 @@ private fun SettingThemeSection(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = MaaDesignTokens.Spacing.listItemVertical),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         // 标题
         Text(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -22,14 +22,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.rounded.Build
 import androidx.compose.material3.CircularProgressIndicator
 import android.os.Build
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
@@ -330,9 +326,7 @@ fun SettingsView(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = stringResource(R.string.settings_title),
-                navigationIcon = Icons.AutoMirrored.Filled.ArrowBack,
-                onNavigationClick = { navController.navigateUp() }
+                title = stringResource(R.string.settings_title)
             )
         }
     ) { paddingValues ->
@@ -766,92 +760,74 @@ private fun SettingThemeSection(
     fontSizeScale: Int,
     onFontSizeScaleChanged: (Int) -> Unit
 ) {
-    var expanded by remember { mutableStateOf(false) }
-    Column(modifier = Modifier.fillMaxWidth()) {
-        // 标题行：点击展开/收起
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { expanded = !expanded }
-                .padding(vertical = MaaDesignTokens.Spacing.listItemVertical),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(R.string.settings_theme_title),
-                style = MaterialTheme.typography.bodyLarge,
-                color = contentColor,
-                modifier = Modifier.weight(1f)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = MaaDesignTokens.Spacing.listItemVertical),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        // 标题
+        Text(
+            text = stringResource(R.string.settings_theme_title),
+            style = MaterialTheme.typography.bodyLarge,
+            color = contentColor
+        )
+        // 主题模式选择
+        Row(modifier = Modifier.fillMaxWidth()) {
+            val modes = listOf(
+                AppSettingsManager.ThemeMode.SYSTEM to stringResource(R.string.settings_theme_system),
+                AppSettingsManager.ThemeMode.WHITE to stringResource(R.string.settings_theme_white),
+                AppSettingsManager.ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
+                AppSettingsManager.ThemeMode.PURE_DARK to stringResource(R.string.settings_theme_pure_dark)
             )
-            Icon(
-                imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                contentDescription = null,
-                tint = contentColor.copy(alpha = 0.6f)
-            )
-        }
-        // 展开内容：主题模式 + 莫奈色 + 页面缩放
-        AnimatedVisibility(visible = expanded) {
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // 主题模式选择
-                Row(modifier = Modifier.fillMaxWidth()) {
-                    val modes = listOf(
-                        AppSettingsManager.ThemeMode.SYSTEM to stringResource(R.string.settings_theme_system),
-                        AppSettingsManager.ThemeMode.WHITE to stringResource(R.string.settings_theme_white),
-                        AppSettingsManager.ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
-                        AppSettingsManager.ThemeMode.PURE_DARK to stringResource(R.string.settings_theme_pure_dark)
-                    )
-                    modes.forEach { (mode, label) ->
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Center,
-                            modifier = Modifier
-                                .weight(1f)
-                                .clip(RoundedCornerShape(8.dp))
-                                .selectable(
-                                    selected = mode == selectedMode,
-                                    onClick = { onModeSelected(mode) },
-                                    role = Role.RadioButton
-                                )
-                        ) {
-                            RadioButton(
-                                selected = mode == selectedMode,
-                                onClick = null
-                            )
-                            Spacer(modifier = Modifier.width(4.dp))
-                            Text(
-                                text = label,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = contentColor,
-                                maxLines = 1
-                            )
-                        }
-                    }
-                }
-                // 莫奈主题色（SDK >= S）
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = stringResource(R.string.settings_monet_color_title),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = contentColor,
-                            modifier = Modifier.weight(1f)
+            modes.forEach { (mode, label) ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                    modifier = Modifier
+                        .weight(1f)
+                        .clip(RoundedCornerShape(8.dp))
+                        .selectable(
+                            selected = mode == selectedMode,
+                            onClick = { onModeSelected(mode) },
+                            role = Role.RadioButton
                         )
-                        Switch(checked = useSystemMonetColor, onCheckedChange = onMonetColorChanged)
-                    }
+                ) {
+                    RadioButton(
+                        selected = mode == selectedMode,
+                        onClick = null
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = label,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = contentColor,
+                        maxLines = 1
+                    )
                 }
-                // 页面缩放
-                FontSizeSetting(
-                    contentColor = contentColor,
-                    value = fontSizeScale,
-                    onValueChange = onFontSizeScaleChanged
-                )
             }
         }
+        // 莫奈主题色（SDK >= S）
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_monet_color_title),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = contentColor,
+                    modifier = Modifier.weight(1f)
+                )
+                Switch(checked = useSystemMonetColor, onCheckedChange = onMonetColorChanged)
+            }
+        }
+        // 页面缩放
+        FontSizeSetting(
+            contentColor = contentColor,
+            value = fontSizeScale,
+            onValueChange = onFontSizeScaleChanged
+        )
     }
 }
 

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -119,6 +119,7 @@ fun SettingsView(
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
     val useSystemMonetColor by viewModel.useSystemMonetColor.collectAsStateWithLifecycle()
     val fontSizeScale by viewModel.fontSizeScale.collectAsStateWithLifecycle()
+    val showAchievementSnackbar by viewModel.showAchievementSnackbar.collectAsStateWithLifecycle()
     val backgroundResolution by viewModel.backgroundResolution.collectAsStateWithLifecycle()
     val language by viewModel.language.collectAsStateWithLifecycle()
     val backupMessage by viewModel.backupMessage.collectAsStateWithLifecycle()
@@ -638,6 +639,57 @@ fun SettingsView(
                     ) {
                         importLauncher.launch(arrayOf("application/json"))
                     }
+                }
+            }
+
+            // 通知
+            item {
+                SectionHeader(stringResource(R.string.settings_section_notification))
+                InfoCard(
+                    title = "",
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    contentColor = contentColor,
+                    contentPadding = PaddingValues(
+                        horizontal = MaaDesignTokens.Card.innerPadding,
+                        vertical = MaaDesignTokens.Spacing.listItemVertical
+                    )
+                ) {
+                    SettingClickItem(
+                        title = stringResource(R.string.settings_notification_title),
+                        description = stringResource(R.string.settings_notification_desc),
+                        contentColor = contentColor
+                    ) {
+                        navController.navigate(Routes.NOTIFICATION)
+                    }
+                }
+            }
+
+            // 成就
+            item {
+                SectionHeader(stringResource(R.string.settings_section_achievement))
+                InfoCard(
+                    title = "",
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    contentColor = contentColor,
+                    contentPadding = PaddingValues(
+                        horizontal = MaaDesignTokens.Card.innerPadding,
+                        vertical = MaaDesignTokens.Spacing.listItemVertical
+                    )
+                ) {
+                    SettingClickItem(
+                        title = stringResource(R.string.settings_achievement_title),
+                        description = stringResource(R.string.settings_achievement_desc),
+                        contentColor = contentColor
+                    ) {
+                        navController.navigate(Routes.ACHIEVEMENT)
+                    }
+                    SettingsDivider(contentColor)
+                    SettingSwitchItem(
+                        title = stringResource(R.string.settings_achievement_snackbar_title),
+                        contentColor = contentColor,
+                        checked = showAchievementSnackbar,
+                        onCheckedChange = { viewModel.setShowAchievementSnackbar(it) }
+                    )
                 }
             }
 

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -23,16 +23,24 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.rounded.Build
 import androidx.compose.material3.CircularProgressIndicator
 import android.os.Build
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,6 +60,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.aliothmoon.maameow.BuildConfig
@@ -109,6 +118,7 @@ fun SettingsView(
     val updateChannel by viewModel.updateChannel.collectAsStateWithLifecycle()
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
     val useSystemMonetColor by viewModel.useSystemMonetColor.collectAsStateWithLifecycle()
+    val fontSizeScale by viewModel.fontSizeScale.collectAsStateWithLifecycle()
     val backgroundResolution by viewModel.backgroundResolution.collectAsStateWithLifecycle()
     val language by viewModel.language.collectAsStateWithLifecycle()
     val backupMessage by viewModel.backupMessage.collectAsStateWithLifecycle()
@@ -513,23 +523,6 @@ fun SettingsView(
                             }
                         }
                     }
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                        SettingSwitchItem(
-                            title = stringResource(R.string.settings_monet_color_title),
-                            description = stringResource(R.string.settings_monet_color_desc),
-                            contentColor = contentColor,
-                            checked = useSystemMonetColor,
-                            onCheckedChange = { viewModel.setUseSystemMonetColor(it) }
-                        )
-                        SettingsDivider(contentColor)
-                    }
-                    SettingClickItem(
-                        title = stringResource(R.string.settings_achievement_title),
-                        description = stringResource(R.string.settings_achievement_desc),
-                        contentColor = contentColor
-                    ) {
-                        navController.navigate(Routes.ACHIEVEMENT)
-                    }
                     if (BuildConfig.DEBUG) {
                         SettingsDivider(contentColor)
                         SettingClickItem(
@@ -541,10 +534,14 @@ fun SettingsView(
                         }
                     }
                     SettingsDivider(contentColor)
-                    SettingThemeModeItem(
+                    SettingThemeSection(
                         contentColor = contentColor,
                         selectedMode = themeMode,
-                        onModeSelected = { viewModel.setThemeMode(it) }
+                        onModeSelected = { viewModel.setThemeMode(it) },
+                        useSystemMonetColor = useSystemMonetColor,
+                        onMonetColorChanged = { viewModel.setUseSystemMonetColor(it) },
+                        fontSizeScale = fontSizeScale,
+                        onFontSizeScaleChanged = { viewModel.setFontSizeScale(it) }
                     )
                     SettingsDivider(contentColor)
                     SettingLanguageItem(
@@ -708,54 +705,99 @@ fun SettingsView(
 }
 
 @Composable
-private fun SettingThemeModeItem(
+private fun SettingThemeSection(
     contentColor: Color,
     selectedMode: AppSettingsManager.ThemeMode,
-    onModeSelected: (AppSettingsManager.ThemeMode) -> Unit
+    onModeSelected: (AppSettingsManager.ThemeMode) -> Unit,
+    useSystemMonetColor: Boolean,
+    onMonetColorChanged: (Boolean) -> Unit,
+    fontSizeScale: Int,
+    onFontSizeScaleChanged: (Int) -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = MaaDesignTokens.Spacing.listItemVertical),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        Text(
-            text = stringResource(R.string.settings_theme_title),
-            style = MaterialTheme.typography.bodyLarge,
-            color = contentColor
-        )
-        Row(modifier = Modifier.fillMaxWidth()) {
-            val modes = listOf(
-                AppSettingsManager.ThemeMode.SYSTEM to stringResource(R.string.settings_theme_system),
-                AppSettingsManager.ThemeMode.WHITE to stringResource(R.string.settings_theme_white),
-                AppSettingsManager.ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
-                AppSettingsManager.ThemeMode.PURE_DARK to stringResource(R.string.settings_theme_pure_dark)
+    var expanded by remember { mutableStateOf(false) }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // 标题行：点击展开/收起
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { expanded = !expanded }
+                .padding(vertical = MaaDesignTokens.Spacing.listItemVertical),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.settings_theme_title),
+                style = MaterialTheme.typography.bodyLarge,
+                color = contentColor,
+                modifier = Modifier.weight(1f)
             )
-            modes.forEach { (mode, label) ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
-                    modifier = Modifier
-                        .weight(1f)
-                        .clip(RoundedCornerShape(8.dp))
-                        .selectable(
-                            selected = mode == selectedMode,
-                            onClick = { onModeSelected(mode) },
-                            role = Role.RadioButton
-                        )
-                ) {
-                    RadioButton(
-                        selected = mode == selectedMode,
-                        onClick = null
+            Icon(
+                imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = null,
+                tint = contentColor.copy(alpha = 0.6f)
+            )
+        }
+        // 展开内容：主题模式 + 莫奈色 + 页面缩放
+        AnimatedVisibility(visible = expanded) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // 主题模式选择
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    val modes = listOf(
+                        AppSettingsManager.ThemeMode.SYSTEM to stringResource(R.string.settings_theme_system),
+                        AppSettingsManager.ThemeMode.WHITE to stringResource(R.string.settings_theme_white),
+                        AppSettingsManager.ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
+                        AppSettingsManager.ThemeMode.PURE_DARK to stringResource(R.string.settings_theme_pure_dark)
                     )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = label,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = contentColor,
-                        maxLines = 1
-                    )
+                    modes.forEach { (mode, label) ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center,
+                            modifier = Modifier
+                                .weight(1f)
+                                .clip(RoundedCornerShape(8.dp))
+                                .selectable(
+                                    selected = mode == selectedMode,
+                                    onClick = { onModeSelected(mode) },
+                                    role = Role.RadioButton
+                                )
+                        ) {
+                            RadioButton(
+                                selected = mode == selectedMode,
+                                onClick = null
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                text = label,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = contentColor,
+                                maxLines = 1
+                            )
+                        }
+                    }
                 }
+                // 莫奈主题色（SDK >= S）
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(R.string.settings_monet_color_title),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = contentColor,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Switch(checked = useSystemMonetColor, onCheckedChange = onMonetColorChanged)
+                    }
+                }
+                // 页面缩放
+                FontSizeSetting(
+                    contentColor = contentColor,
+                    value = fontSizeScale,
+                    onValueChange = onFontSizeScaleChanged
+                )
             }
         }
     }
@@ -786,6 +828,96 @@ private fun SettingClickItem(
                     text = description,
                     style = MaterialTheme.typography.bodySmall,
                     color = contentColor.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * 字体大小（页面缩放）设置：整数 80~110，默认 100。
+ * 松手后才提交全局缩放。滑块下方带实时预览框。
+ */
+@Composable
+private fun FontSizeSetting(
+    contentColor: Color,
+    value: Int,
+    onValueChange: (Int) -> Unit
+) {
+    var sliderValue by remember { mutableStateOf(value.toFloat()) }
+    LaunchedEffect(value) {
+        sliderValue = value.toFloat()
+    }
+    val current = sliderValue.roundToInt().coerceIn(AppSettingsManager.FONT_SIZE_SCALE_MIN, AppSettingsManager.FONT_SIZE_SCALE_MAX)
+
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.settings_font_size_title),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = contentColor
+                )
+                Text(
+                    text = stringResource(R.string.settings_font_size_summary),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = contentColor.copy(alpha = 0.6f)
+                )
+            }
+            Text(
+                text = current.toString(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = contentColor
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Slider(
+            value = sliderValue,
+            onValueChange = { sliderValue = it },
+            onValueChangeFinished = {
+                onValueChange(sliderValue.roundToInt().coerceIn(
+                    AppSettingsManager.FONT_SIZE_SCALE_MIN,
+                    AppSettingsManager.FONT_SIZE_SCALE_MAX
+                ))
+            },
+            valueRange = AppSettingsManager.FONT_SIZE_SCALE_MIN.toFloat()..AppSettingsManager.FONT_SIZE_SCALE_MAX.toFloat(),
+            steps = 0,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            listOf(AppSettingsManager.FONT_SIZE_SCALE_MIN, 90, 100, AppSettingsManager.FONT_SIZE_SCALE_MAX).forEach { kp ->
+                Text(
+                    text = kp.toString(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = contentColor.copy(alpha = 0.5f)
+                )
+            }
+        }
+        // 实时预览框：用 sliderValue 实时缩放，不等待松手
+        val previewDensity = LocalDensity.current
+        CompositionLocalProvider(
+            LocalDensity provides Density(
+                density = previewDensity.density * current / 100f,
+                fontScale = previewDensity.fontScale
+            )
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                shape = RoundedCornerShape(12.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+            ) {
+                Text(
+                    text = "你是谁？请支持牛牛！('- ' )",
+                    modifier = Modifier.padding(16.dp),
+                    color = contentColor
                 )
             }
         }
@@ -1103,6 +1235,7 @@ private fun SettingRemoteBackendItem(
         }
     }
 }
+
 
 private data class ShizukuLaunchAppOption(
     val label: String,

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -965,7 +965,7 @@ private fun FontSizeSetting(
                 color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
             ) {
                 Text(
-                    text = "你是谁？请支持牛牛！('- ' )",
+                    text = stringResource(R.string.settings_font_size_preview_text),
                     modifier = Modifier.padding(16.dp),
                     color = contentColor
                 )

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -266,4 +266,12 @@ class SettingsViewModel(
             appSettingsManager.setUseSystemMonetColor(enabled)
         }
     }
+
+    // ============ Font Size Scale ============
+    val fontSizeScale: StateFlow<Int> = appSettingsManager.fontSizeScale
+    fun setFontSizeScale(scale: Int) {
+        viewModelScope.launch {
+            appSettingsManager.setFontSizeScale(scale)
+        }
+    }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -274,4 +274,11 @@ class SettingsViewModel(
             appSettingsManager.setFontSizeScale(scale)
         }
     }
+    // 成就 Snackbar 提示开关
+    val showAchievementSnackbar: StateFlow<Boolean> = appSettingsManager.showAchievementSnackbar
+    fun setShowAchievementSnackbar(enabled: Boolean) {
+        viewModelScope.launch {
+            appSettingsManager.setShowAchievementSnackbar(enabled)
+        }
+    }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -48,6 +48,7 @@
     <string name="settings_startup_backend_desc">Choose how the app obtains system permissions</string>
     <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
     <string name="settings_monet_color_title">Monet Theme Color</string>
+    <string name="settings_monet_color_desc">Generate colors from your wallpaper; off uses the built-in blue theme.</string>
 
     <string name="settings_achievement_title">Achievements</string>
     <string name="settings_achievement_desc">View MaaMeow milestones and hidden easter eggs</string>
@@ -104,7 +105,6 @@
     <string name="settings_achievement_snackbar_title">Achievement Notifications</string>
     <string name="settings_achievement_snackbar_desc">Show Snackbar when achievements are unlocked</string>
 
-
     <string name="achievement_title">Achievements</string>
     <string name="achievement_unlocked_message">Achievement unlocked: %1$s</string>
     <string name="achievement_search_hint">Search achievement name</string>
@@ -156,7 +156,6 @@
     <string name="achievement_debug_clear_done">All achievement records deleted</string>
     <!-- home: top bar & app title -->
     <string name="home_app_title">MAA</string>
-    <string name="home_cd_open_settings">Settings</string>
 
     <!-- home: screen info card -->
     <string name="home_screen_resolution">Screen Resolution</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -91,11 +91,20 @@
     <string name="editor_json_valid">JSON valid</string>
     <string name="editor_json_invalid">JSON invalid</string>
     <string name="editor_save_success">Saved. Changes take effect on next task start.</string>
+    <string name="settings_section_notification">Notifications</string>
+    <string name="settings_notification_title">Notification Settings</string>
+    <string name="settings_notification_desc">Manage internal and external notification channels</string>
+
     <string name="settings_section_data">Data Management</string>
     <string name="settings_export_config_title">Export Configuration</string>
     <string name="settings_export_config_desc">Export all settings and task configurations to a file</string>
     <string name="settings_import_config_title">Import Configuration</string>
     <string name="settings_import_config_desc">Restore settings and task configurations from a file</string>
+    <string name="settings_section_achievement">Achievements</string>
+    <string name="settings_achievement_snackbar_title">Popup Notifications</string>
+    <string name="settings_achievement_snackbar_desc">Show Snackbar when achievements are unlocked</string>
+
+
     <string name="achievement_title">Achievements</string>
     <string name="achievement_unlocked_message">Achievement unlocked: %1$s</string>
     <string name="achievement_search_hint">Search achievement name</string>
@@ -823,7 +832,7 @@
     <string name="bottom_nav_home">Home</string>
     <string name="bottom_nav_background_task">Tasks</string>
     <string name="bottom_nav_schedule">Schedule</string>
-    <string name="bottom_nav_notification">Push</string>
+    <string name="bottom_nav_settings">Settings</string>
     <string name="navigation_toast_switch_background_mode">Current mode is foreground. Switch to background mode first.</string>
 
     <!-- shared panel / toolbox -->

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -48,7 +48,6 @@
     <string name="settings_startup_backend_desc">Choose how the app obtains system permissions</string>
     <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
     <string name="settings_monet_color_title">Monet Theme Color</string>
-    <string name="settings_monet_color_desc">Use Material You dynamic color on Android 12+. Off uses the built-in blue theme.</string>
 
     <string name="settings_achievement_title">Achievements</string>
     <string name="settings_achievement_desc">View MaaMeow milestones and hidden easter eggs</string>
@@ -59,6 +58,8 @@
     <string name="settings_theme_white">Light</string>
     <string name="settings_theme_dark">Dark</string>
     <string name="settings_theme_pure_dark">Pure Black</string>
+    <string name="settings_font_size_title">Page Scale</string>
+    <string name="settings_font_size_summary">Adjust page content size (80-110)</string>
     <string name="settings_language_title">Language</string>
     <string name="settings_language_system">Follow System</string>
     <string name="settings_language_zh">中文</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -101,7 +101,7 @@
     <string name="settings_import_config_title">Import Configuration</string>
     <string name="settings_import_config_desc">Restore settings and task configurations from a file</string>
     <string name="settings_section_achievement">Achievements</string>
-    <string name="settings_achievement_snackbar_title">Popup Notifications</string>
+    <string name="settings_achievement_snackbar_title">Achievement Notifications</string>
     <string name="settings_achievement_snackbar_desc">Show Snackbar when achievements are unlocked</string>
 
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -43,6 +43,7 @@
     <string name="settings_log_export_chooser_title">Export Logs</string>
     <string name="settings_debug_mode_title">Debug Mode</string>
     <string name="settings_debug_mode_desc">Record detailed log information when enabled</string>
+    <string name="settings_section_display">Display</string>
     <string name="settings_section_other">Other</string>
     <string name="settings_startup_backend_title">Startup Mode</string>
     <string name="settings_startup_backend_desc">Choose how the app obtains system permissions</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -62,6 +62,7 @@
     <string name="settings_theme_pure_dark">Pure Black</string>
     <string name="settings_font_size_title">Page Scale</string>
     <string name="settings_font_size_summary">Adjust page content size (80-110)</string>
+    <string name="settings_font_size_preview_text">Who are you? Please support Pallas! (\'- \' )</string>
     <string name="settings_language_title">Language</string>
     <string name="settings_language_system">Follow System</string>
     <string name="settings_language_zh">中文</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,6 +246,7 @@
     <string name="settings_startup_backend_desc">选择应用获取系统权限的方式</string>
     <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
     <string name="settings_monet_color_title">莫奈主题色</string>
+    <string name="settings_monet_color_desc">根据壁纸动态取色，关闭则使用内置蓝色主题</string>
 
     <string name="settings_achievement_title">成就</string>
     <string name="settings_achievement_desc">查看 MaaMeow 使用记录与隐藏彩蛋</string>
@@ -301,10 +302,10 @@
     <string name="settings_import_config_title">导入配置</string>
     <string name="settings_import_config_desc">从文件恢复设置和任务配置</string>
 
-        <string name="settings_section_achievement">成就</string>
+    <!-- settings: achievement section -->
+    <string name="settings_section_achievement">成就</string>
     <string name="settings_achievement_snackbar_title">成就提示</string>
     <string name="settings_achievement_snackbar_desc">成就解锁时弹出 Snackbar 提示</string>
-
 
     <!-- achievements -->
     <string name="achievement_title">成就</string>
@@ -359,7 +360,6 @@
 
     <!-- home: top bar & app title -->
     <string name="home_app_title">MAA</string>
-    <string name="home_cd_open_settings">设置</string>
 
     <!-- home: screen info card -->
     <string name="home_screen_resolution">屏幕分辨率</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -289,12 +289,22 @@
     <string name="editor_json_invalid">JSON 格式错误</string>
     <string name="editor_save_success">保存成功，下次任务启动生效</string>
 
+    <!-- settings: notification section -->
+    <string name="settings_section_notification">通知</string>
+    <string name="settings_notification_title">通知设置</string>
+    <string name="settings_notification_desc">管理内部和外部通知渠道</string>
+
     <!-- settings: data section -->
     <string name="settings_section_data">数据管理</string>
     <string name="settings_export_config_title">导出配置</string>
     <string name="settings_export_config_desc">将所有设置和任务配置导出为文件</string>
     <string name="settings_import_config_title">导入配置</string>
     <string name="settings_import_config_desc">从文件恢复设置和任务配置</string>
+
+        <string name="settings_section_achievement">成就</string>
+    <string name="settings_achievement_snackbar_title">弹窗提示</string>
+    <string name="settings_achievement_snackbar_desc">成就解锁时弹出 Snackbar 提示</string>
+
 
     <!-- achievements -->
     <string name="achievement_title">成就</string>
@@ -876,7 +886,7 @@
     <string name="bottom_nav_home">首页</string>
     <string name="bottom_nav_background_task">后台任务</string>
     <string name="bottom_nav_schedule">定时</string>
-    <string name="bottom_nav_notification">通知</string>
+    <string name="bottom_nav_settings">设置</string>
     <string name="navigation_toast_switch_background_mode">当前是前台模式，请先切换到后台模式</string>
 
     <!-- shared panel / toolbox -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -302,7 +302,7 @@
     <string name="settings_import_config_desc">从文件恢复设置和任务配置</string>
 
         <string name="settings_section_achievement">成就</string>
-    <string name="settings_achievement_snackbar_title">弹窗提示</string>
+    <string name="settings_achievement_snackbar_title">成就提示</string>
     <string name="settings_achievement_snackbar_desc">成就解锁时弹出 Snackbar 提示</string>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,7 @@
     <string name="settings_theme_pure_dark">纯黑</string>
     <string name="settings_font_size_title">页面缩放</string>
     <string name="settings_font_size_summary">调整页面内容大小 (80-110)</string>
+    <string name="settings_font_size_preview_text">你是谁？请支持牛牛！(\'- \' )</string>
     <string name="settings_language_title">语言</string>
     <string name="settings_language_system">跟随系统</string>
     <string name="settings_language_zh">中文</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,7 +246,6 @@
     <string name="settings_startup_backend_desc">选择应用获取系统权限的方式</string>
     <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
     <string name="settings_monet_color_title">莫奈主题色</string>
-    <string name="settings_monet_color_desc">Android 12+ 启用 Material You 动态取色；关闭则使用内置蓝色主题</string>
 
     <string name="settings_achievement_title">成就</string>
     <string name="settings_achievement_desc">查看 MaaMeow 使用记录与隐藏彩蛋</string>
@@ -257,6 +256,8 @@
     <string name="settings_theme_white">白色</string>
     <string name="settings_theme_dark">暗色</string>
     <string name="settings_theme_pure_dark">纯黑</string>
+    <string name="settings_font_size_title">页面缩放</string>
+    <string name="settings_font_size_summary">调整页面内容大小 (80-110)</string>
     <string name="settings_language_title">语言</string>
     <string name="settings_language_system">跟随系统</string>
     <string name="settings_language_zh">中文</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,6 +241,7 @@
     <string name="settings_debug_mode_desc">启用后记录详细日志信息</string>
 
     <!-- settings: other section -->
+    <string name="settings_section_display">显示设置</string>
     <string name="settings_section_other">其他设置</string>
     <string name="settings_startup_backend_title">启动模式</string>
     <string name="settings_startup_backend_desc">选择应用获取系统权限的方式</string>


### PR DESCRIPTION
重构设置页面布局，新增成就系统 UI。

- 设置页拆分为多个 section（外观、通知、成就、关于）
- 底部导航「设置」改为「更多」
- 新增成就弹窗提示开关
- 依赖 PR1（字体缩放）

## Summary by Sourcery

重构设置和导航体验，引入全局页面缩放，并新增可配置的成就通知。

新功能：
- 在设置中添加可折叠的主题部分，其中包括主题模式选择、Monet 颜色开关，以及带实时预览的新页面缩放（字体大小）滑块。
- 在设置中引入专门的通知部分，可导航到独立的通知设置页面。
- 新增用户偏好设置，用于切换成就解锁的 Snackbar 通知，并将其接入成就系统。
- 应用全局页面缩放设置，使其影响整个应用的 UI 密度。

改进：
- 重新组织设置页面为更清晰的分区，包括拥有独立控件的专用成就区域。
- 更新底部导航，将通知标签替换为设置标签，并通过设置页面来访问通知相关内容。
- 调整通知设置页面，使用带返回导航的应用内工具栏，而不是作为主标签页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the settings and navigation experience, introduce global page scaling, and add configurable achievement notifications.

New Features:
- Add a collapsible theme section in settings that includes theme mode selection, Monet color toggle, and a new page scale (font size) slider with live preview.
- Introduce a dedicated notifications section in settings with navigation to a standalone notification settings screen.
- Add a user preference to toggle achievement unlock Snackbar notifications and wire it into the achievement system.
- Apply a global page scale setting that affects UI density throughout the app.

Enhancements:
- Reorganize the settings screen into clearer sections, including a dedicated achievements section with its own controls.
- Update bottom navigation to replace the notification tab with a settings tab and route notifications via the settings screen.
- Adjust the notification settings screen to use an in-app toolbar with back navigation instead of being a main tab.

</details>