### PR TITLE
feat: HorizontalPager tab switching with spring animations

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -1,16 +1,10 @@
 package com.aliothmoon.maameow.presentation.navigation
 
 import android.widget.Toast
-import androidx.activity.compose.BackHandler
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -21,9 +15,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -40,21 +32,18 @@ import com.aliothmoon.maameow.domain.service.ExternalNotificationService
 import com.aliothmoon.maameow.overlay.OverlayController
 import com.aliothmoon.maameow.presentation.components.AnnouncementDialog
 import com.aliothmoon.maameow.presentation.components.ResourceLoadingOverlay
-import com.aliothmoon.maameow.presentation.view.background.BackgroundTaskView
-import com.aliothmoon.maameow.presentation.view.home.HomeView
 import com.aliothmoon.maameow.presentation.view.notification.NotificationSettingsView
 import com.aliothmoon.maameow.presentation.view.settings.AchievementDebugView
 import com.aliothmoon.maameow.presentation.view.settings.AchievementView
 import com.aliothmoon.maameow.presentation.view.settings.ErrorLogView
 import com.aliothmoon.maameow.presentation.view.settings.LogHistoryView
-import com.aliothmoon.maameow.presentation.view.settings.SettingsView
 import com.aliothmoon.maameow.presentation.view.settings.TaskOverrideEditorView
 import com.aliothmoon.maameow.presentation.viewmodel.BackgroundTaskViewModel
 import com.aliothmoon.maameow.schedule.model.CountdownState
 import com.aliothmoon.maameow.schedule.ui.CountdownDialog
 import com.aliothmoon.maameow.schedule.ui.ScheduleEditView
-import com.aliothmoon.maameow.schedule.ui.ScheduleListView
 import com.aliothmoon.maameow.schedule.ui.ScheduleTriggerLogView
+import com.aliothmoon.maameow.theme.MaaAnimations
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
@@ -69,64 +58,39 @@ fun AppNavigation(
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentNavRoute = navBackStackEntry?.destination?.route
-
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
-
     var isFullscreen by remember { mutableStateOf(false) }
     var forceShowAnnouncement by remember { mutableStateOf(false) }
     var announcementDismissedOnce by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
 
-    // 执行模式状态 - 用于底部导航拦截
     val runMode by appSettings.runMode.collectAsStateWithLifecycle()
     val announcementReadVersion by appSettings.announcementReadVersion.collectAsStateWithLifecycle()
     val showAchievementSnackbar by appSettings.showAchievementSnackbar.collectAsStateWithLifecycle()
     val language by appSettings.language.collectAsStateWithLifecycle()
-    val overlayControlMode by appSettings.overlayControlMode.collectAsStateWithLifecycle()
-    val pendingScheduledExecution by backgroundTaskViewModel.coordinator.pendingExecution.collectAsStateWithLifecycle()
     val scheduledCountdownState by backgroundTaskViewModel.coordinator.countdownState.collectAsStateWithLifecycle()
 
-    // 定义哪些页面属于主 Tab
-    val mainTabs = listOf(Routes.HOME, Routes.BACKGROUND_TASK, Routes.SCHEDULE, Routes.SETTINGS)
-    
-    // 判断是否处于主 Tab 页面
-    val isOnMainTab = currentNavRoute in mainTabs || currentNavRoute == null
-
-    // 判断是否显示底部导航
-    val showBottomBar = !isFullscreen && isOnMainTab
-    val switchBackgroundModeMessage = stringResource(R.string.navigation_toast_switch_background_mode)
-
-    LaunchedEffect(pendingScheduledExecution?.requestId) {
-        if (pendingScheduledExecution != null && currentNavRoute != Routes.BACKGROUND_TASK) {
-            navController.navigate(Routes.BACKGROUND_TASK) {
-                popUpTo(Routes.HOME) {
-                    saveState = true
-                }
-                launchSingleTop = true
-                restoreState = true
-            }
-        }
-    }
+    // 判断是否处于主 Tab 页面（由 MainScreen HorizontalPager 处理）
+    val isOnMainTab = currentNavRoute in listOf(
+        Routes.HOME, Routes.BACKGROUND_TASK, Routes.SCHEDULE, Routes.SETTINGS
+    ) || currentNavRoute == null
 
     LaunchedEffect(backgroundTaskViewModel) {
         backgroundTaskViewModel.coordinator.feedbackMessages.collect { message ->
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         }
     }
-
     LaunchedEffect(backgroundTaskViewModel) {
         backgroundTaskViewModel.coordinator.countdownState.collect { state ->
             overlayController.updateCountdownState(state)
         }
     }
-
     LaunchedEffect(backgroundTaskViewModel) {
         overlayController.onCountdownClick = {
             backgroundTaskViewModel.onScheduledStartNow()
         }
     }
-
     LaunchedEffect(notificationService) {
         notificationService.feedbackMessages.collect { message ->
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
@@ -147,252 +111,118 @@ fun AppNavigation(
         }
     }
 
-    // 主 Tab 切换动画定义 - 使用极短的渐变色来平滑过渡，防止重叠感
-    val tabEnterTransition = fadeIn(animationSpec = tween(150))
-    val tabExitTransition = fadeOut(animationSpec = tween(150))
+    // Shared axis transitions for sub-pages
+    val forwardEnterTransition = MaaAnimations.sharedAxisForwardEnter()
+    val forwardExitTransition = MaaAnimations.sharedAxisForwardExit()
+    val popEnterTransition = MaaAnimations.sharedAxisPopEnter()
+    val popExitTransition = MaaAnimations.sharedAxisPopExit()
 
     Box(modifier = Modifier.fillMaxSize()) {
-        Scaffold(
-            snackbarHost = { SnackbarHost(snackbarHostState) },
-            bottomBar = {
-                if (showBottomBar) {
-                    AppBottomNavigation(
-                        currentRoute = currentNavRoute ?: Routes.HOME,
-                        onTabSelected = { tab ->
-                            if (tab.route == currentNavRoute) return@AppBottomNavigation
+        // MainScreen with HorizontalPager for smooth tab switching
+        MainScreen(
+            navController = navController,
+            backgroundTaskViewModel = backgroundTaskViewModel,
+            onFullscreenChanged = { isFullscreen = it },
+            onViewAnnouncement = { forceShowAnnouncement = true },
+            visible = isOnMainTab,
+        )
 
-                            if (tab.route == Routes.BACKGROUND_TASK && runMode == RunMode.FOREGROUND) {
-                                Toast.makeText(
-                                    context,
-                                    switchBackgroundModeMessage,
-                                    Toast.LENGTH_SHORT
-                                ).show()
-                                return@AppBottomNavigation
-                            }
+        // NavHost for sub-pages only (notifications, achievement, logs, etc.)
+        // Tab switching is handled entirely by MainScreen's HorizontalPager.
+        NavHost(
+            navController = navController,
+            startDestination = Routes.HOME,
+        ) {
+            // Main tab routes - MainScreen handles rendering via HorizontalPager
+            composable(route = Routes.HOME) {}
+            composable(route = Routes.BACKGROUND_TASK) {}
+            composable(route = Routes.SCHEDULE) {}
+            composable(route = Routes.SETTINGS) {}
 
-                            navController.navigate(tab.route) {
-                                popUpTo(Routes.HOME) {
-                                    saveState = true
-                                }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        }
-                    )
-                }
-            }
-        ) { paddingValues ->
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(bottom = paddingValues.calculateBottomPadding())
+            // ── Sub-pages with forward navigation transitions ──
+            composable(
+                route = Routes.NOTIFICATION,
+                enterTransition = { forwardEnterTransition },
+                exitTransition = { forwardExitTransition },
+                popEnterTransition = { popEnterTransition },
+                popExitTransition = { popExitTransition }
             ) {
-                NavHost(
+                NotificationSettingsView(navController = navController)
+            }
+            composable(
+                route = Routes.ACHIEVEMENT,
+                enterTransition = { forwardEnterTransition },
+                exitTransition = { forwardExitTransition },
+                popEnterTransition = { popEnterTransition },
+                popExitTransition = { popExitTransition }
+            ) {
+                AchievementView(
                     navController = navController,
-                    startDestination = Routes.HOME,
-                ) {
-                    composable(
-                        route = Routes.HOME,
-                        enterTransition = { tabEnterTransition },
-                        exitTransition = { tabExitTransition },
-                        popEnterTransition = { tabEnterTransition },
-                        popExitTransition = { tabExitTransition }
-                    ) {
-                        HomeView(navController = navController)
-                    }
-
-                    composable(
-                        route = Routes.BACKGROUND_TASK,
-                        enterTransition = { tabEnterTransition },
-                        exitTransition = { tabExitTransition },
-                        popEnterTransition = { tabEnterTransition },
-                        popExitTransition = { tabExitTransition }
-                    ) {
-                        BackHandler { navController.popBackStack() }
-                        BackgroundTaskView(
-                            onFullscreenChanged = { isFullscreen = it },
-                            viewModel = backgroundTaskViewModel,
-                        )
-                    }
-
-                    composable(
-                        route = Routes.SCHEDULE,
-                        enterTransition = { tabEnterTransition },
-                        exitTransition = { tabExitTransition },
-                        popEnterTransition = { tabEnterTransition },
-                        popExitTransition = { tabExitTransition }
-                    ) {
-                        BackHandler { navController.popBackStack() }
-                        ScheduleListView(navController = navController)
-                    }
-
-                    composable(
-                        route = Routes.NOTIFICATION,
-                        enterTransition = {
-                            slideInHorizontally(initialOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        exitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        popEnterTransition = {
-                            slideInHorizontally(initialOffsetX = { -it / 3 }, animationSpec = tween(350))
-                        },
-                        popExitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        }
-                    ) {
-                        NotificationSettingsView(navController = navController)
-                    }
-
-                    composable(
-                        route = Routes.SETTINGS,
-                        enterTransition = { tabEnterTransition },
-                        exitTransition = { tabExitTransition },
-                        popEnterTransition = { tabEnterTransition },
-                        popExitTransition = { tabExitTransition }
-                    ) {
-                        BackHandler { navController.popBackStack() }
-                        SettingsView(
-                            navController = navController,
-                            onViewAnnouncement = { forceShowAnnouncement = true },
-                        )
-                    }
-
-                    composable(
-                        route = Routes.ACHIEVEMENT,
-                        enterTransition = {
-                            slideInHorizontally(initialOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        exitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        popEnterTransition = {
-                            slideInHorizontally(initialOffsetX = { -it / 3 }, animationSpec = tween(350))
-                        },
-                        popExitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        }
-                    ) {
-                        AchievementView(
-                            navController = navController,
-                        )
-                    }
-
-                    composable(
-                        route = Routes.ACHIEVEMENT_DEBUG,
-                        enterTransition = {
-                            slideInHorizontally(initialOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        exitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        popEnterTransition = {
-                            slideInHorizontally(initialOffsetX = { -it / 3 }, animationSpec = tween(350))
-                        },
-                        popExitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        }
-                    ) {
-                        AchievementDebugView(navController = navController)
-                    }
-
-                    composable(
-                        route = Routes.LOG_HISTORY,
-                        enterTransition = {
-                            slideInHorizontally(initialOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        exitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        popEnterTransition = {
-                            slideInHorizontally(initialOffsetX = { -it / 3 }, animationSpec = tween(350))
-                        },
-                        popExitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        }
-                    ) {
-                        LogHistoryView(navController = navController)
-                    }
-
-                    composable(
-                        route = Routes.ERROR_LOG,
-                        enterTransition = {
-                            slideInHorizontally(initialOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        exitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        popEnterTransition = {
-                            slideInHorizontally(initialOffsetX = { -it / 3 }, animationSpec = tween(350))
-                        },
-                        popExitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        }
-                    ) {
-                        ErrorLogView(navController = navController)
-                    }
-
-                    composable(
-                        route = Routes.SCHEDULE_EDIT,
-                        enterTransition = {
-                            slideInHorizontally(initialOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        exitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        popEnterTransition = {
-                            slideInHorizontally(initialOffsetX = { -it / 3 }, animationSpec = tween(350))
-                        },
-                        popExitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        }
-                    ) { backStackEntry ->
-                        val strategyId = backStackEntry.arguments?.getString("strategyId")
-                            .let { if (it == "new") null else it }
-                        ScheduleEditView(navController = navController, strategyId = strategyId)
-                    }
-
-                    composable(
-                        route = Routes.SCHEDULE_TRIGGER_LOG,
-                        enterTransition = {
-                            slideInHorizontally(initialOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        exitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        popEnterTransition = {
-                            slideInHorizontally(initialOffsetX = { -it / 3 }, animationSpec = tween(350))
-                        },
-                        popExitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        }
-                    ) {
-                        ScheduleTriggerLogView(navController = navController)
-                    }
-
-                    composable(
-                        route = Routes.TASK_OVERRIDE_EDITOR,
-                        enterTransition = {
-                            slideInHorizontally(initialOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        exitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        },
-                        popEnterTransition = {
-                            slideInHorizontally(initialOffsetX = { -it / 3 }, animationSpec = tween(350))
-                        },
-                        popExitTransition = {
-                            slideOutHorizontally(targetOffsetX = { it }, animationSpec = tween(350))
-                        }
-                    ) {
-                        TaskOverrideEditorView(navController = navController)
-                    }
-                }
+                )
+            }
+            composable(
+                route = Routes.ACHIEVEMENT_DEBUG,
+                enterTransition = { forwardEnterTransition },
+                exitTransition = { forwardExitTransition },
+                popEnterTransition = { popEnterTransition },
+                popExitTransition = { popExitTransition }
+            ) {
+                AchievementDebugView(navController = navController)
+            }
+            composable(
+                route = Routes.LOG_HISTORY,
+                enterTransition = { forwardEnterTransition },
+                exitTransition = { forwardExitTransition },
+                popEnterTransition = { popEnterTransition },
+                popExitTransition = { popExitTransition }
+            ) {
+                LogHistoryView(navController = navController)
+            }
+            composable(
+                route = Routes.ERROR_LOG,
+                enterTransition = { forwardEnterTransition },
+                exitTransition = { forwardExitTransition },
+                popEnterTransition = { popEnterTransition },
+                popExitTransition = { popExitTransition }
+            ) {
+                ErrorLogView(navController = navController)
+            }
+            composable(
+                route = Routes.SCHEDULE_EDIT,
+                enterTransition = { forwardEnterTransition },
+                exitTransition = { forwardExitTransition },
+                popEnterTransition = { popEnterTransition },
+                popExitTransition = { popExitTransition }
+            ) { backStackEntry ->
+                val strategyId = backStackEntry.arguments?.getString("strategyId")
+                    .let { if (it == "new") null else it }
+                ScheduleEditView(navController = navController, strategyId = strategyId)
+            }
+            composable(
+                route = Routes.SCHEDULE_TRIGGER_LOG,
+                enterTransition = { forwardEnterTransition },
+                exitTransition = { forwardExitTransition },
+                popEnterTransition = { popEnterTransition },
+                popExitTransition = { popExitTransition }
+            ) {
+                ScheduleTriggerLogView(navController = navController)
+            }
+            composable(
+                route = Routes.TASK_OVERRIDE_EDITOR,
+                enterTransition = { forwardEnterTransition },
+                exitTransition = { forwardExitTransition },
+                popEnterTransition = { popEnterTransition },
+                popExitTransition = { popExitTransition }
+            ) {
+                TaskOverrideEditorView(navController = navController)
             }
         }
-
         ResourceLoadingOverlay()
-
+        // SnackbarHost overlaid on top
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
         // 全局定时任务倒计时弹窗（前台所有控制模式均不弹出对话框，静默处理）
         val countdown = scheduledCountdownState
         val hideCountdownDialog = runMode == RunMode.FOREGROUND
@@ -403,7 +233,6 @@ fun AppNavigation(
                 onStartNow = { backgroundTaskViewModel.onScheduledStartNow() },
             )
         }
-
         // 长期公告弹窗：每次公告版本变更后首次启动自动弹出，或从设置中手动打开
         val needsToShow = announcementReadVersion != AnnouncementConfig.CURRENT_VERSION
         val showAnnouncement = forceShowAnnouncement || (needsToShow && !announcementDismissedOnce)

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -3,11 +3,12 @@ package com.aliothmoon.maameow.presentation.navigation
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -44,8 +45,13 @@ import com.aliothmoon.maameow.schedule.ui.CountdownDialog
 import com.aliothmoon.maameow.schedule.ui.ScheduleEditView
 import com.aliothmoon.maameow.schedule.ui.ScheduleTriggerLogView
 import com.aliothmoon.maameow.theme.MaaAnimations
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+
+/** 主 Tab 路由集合（与 [BottomNavTab.all] 单一真源），用于判断是否处于主界面。 */
+private val MAIN_TAB_ROUTES: Set<String> = BottomNavTab.all.mapTo(HashSet()) { it.route }
 
 @Composable
 fun AppNavigation(
@@ -60,7 +66,11 @@ fun AppNavigation(
     val currentNavRoute = navBackStackEntry?.destination?.route
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
-    var isFullscreen by remember { mutableStateOf(false) }
+    val isFullscreen by remember(backgroundTaskViewModel) {
+        backgroundTaskViewModel.state
+            .map { it.isFullscreenMonitor }
+            .distinctUntilChanged()
+    }.collectAsStateWithLifecycle(initialValue = false)
     var forceShowAnnouncement by remember { mutableStateOf(false) }
     var announcementDismissedOnce by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
@@ -71,10 +81,8 @@ fun AppNavigation(
     val language by appSettings.language.collectAsStateWithLifecycle()
     val scheduledCountdownState by backgroundTaskViewModel.coordinator.countdownState.collectAsStateWithLifecycle()
 
-    // 判断是否处于主 Tab 页面（由 MainScreen HorizontalPager 处理）
-    val isOnMainTab = currentNavRoute in listOf(
-        Routes.HOME, Routes.BACKGROUND_TASK, Routes.SCHEDULE, Routes.SETTINGS
-    ) || currentNavRoute == null
+    // 判断是否处于主 Tab 页面
+    val isOnMainTab = currentNavRoute == null || currentNavRoute in MAIN_TAB_ROUTES
 
     LaunchedEffect(backgroundTaskViewModel) {
         backgroundTaskViewModel.coordinator.feedbackMessages.collect { message ->
@@ -111,109 +119,52 @@ fun AppNavigation(
         }
     }
 
-    // Shared axis transitions for sub-pages
-    val forwardEnterTransition = MaaAnimations.sharedAxisForwardEnter()
-    val forwardExitTransition = MaaAnimations.sharedAxisForwardExit()
-    val popEnterTransition = MaaAnimations.sharedAxisPopEnter()
-    val popExitTransition = MaaAnimations.sharedAxisPopExit()
-
     Box(modifier = Modifier.fillMaxSize()) {
         // MainScreen with HorizontalPager for smooth tab switching
         MainScreen(
             navController = navController,
             backgroundTaskViewModel = backgroundTaskViewModel,
-            onFullscreenChanged = { isFullscreen = it },
             onViewAnnouncement = { forceShowAnnouncement = true },
             visible = isOnMainTab,
+            fullscreen = isFullscreen,
         )
 
-        // NavHost for sub-pages only (notifications, achievement, logs, etc.)
-        // Tab switching is handled entirely by MainScreen's HorizontalPager.
+        // NavHost 只承载子页面；主 Tab 切换完全由 MainScreen 的 HorizontalPager 处理。
         NavHost(
             navController = navController,
             startDestination = Routes.HOME,
+            enterTransition = { MaaAnimations.sharedAxisForwardEnter },
+            exitTransition = { MaaAnimations.sharedAxisForwardExit },
+            popEnterTransition = { MaaAnimations.sharedAxisPopEnter },
+            popExitTransition = { MaaAnimations.sharedAxisPopExit },
         ) {
-            // Main tab routes - MainScreen handles rendering via HorizontalPager
-            composable(route = Routes.HOME) {}
-            composable(route = Routes.BACKGROUND_TASK) {}
-            composable(route = Routes.SCHEDULE) {}
-            composable(route = Routes.SETTINGS) {}
+            // 主 Tab 路由仅作占位，真实内容由 MainScreen 的 HorizontalPager 渲染
+            BottomNavTab.all.forEach { tab -> composable(tab.route) {} }
 
-            // ── Sub-pages with forward navigation transitions ──
-            composable(
-                route = Routes.NOTIFICATION,
-                enterTransition = { forwardEnterTransition },
-                exitTransition = { forwardExitTransition },
-                popEnterTransition = { popEnterTransition },
-                popExitTransition = { popExitTransition }
-            ) {
+            composable(Routes.NOTIFICATION) {
                 NotificationSettingsView(navController = navController)
             }
-            composable(
-                route = Routes.ACHIEVEMENT,
-                enterTransition = { forwardEnterTransition },
-                exitTransition = { forwardExitTransition },
-                popEnterTransition = { popEnterTransition },
-                popExitTransition = { popExitTransition }
-            ) {
-                AchievementView(
-                    navController = navController,
-                )
+            composable(Routes.ACHIEVEMENT) {
+                AchievementView(navController = navController)
             }
-            composable(
-                route = Routes.ACHIEVEMENT_DEBUG,
-                enterTransition = { forwardEnterTransition },
-                exitTransition = { forwardExitTransition },
-                popEnterTransition = { popEnterTransition },
-                popExitTransition = { popExitTransition }
-            ) {
+            composable(Routes.ACHIEVEMENT_DEBUG) {
                 AchievementDebugView(navController = navController)
             }
-            composable(
-                route = Routes.LOG_HISTORY,
-                enterTransition = { forwardEnterTransition },
-                exitTransition = { forwardExitTransition },
-                popEnterTransition = { popEnterTransition },
-                popExitTransition = { popExitTransition }
-            ) {
+            composable(Routes.LOG_HISTORY) {
                 LogHistoryView(navController = navController)
             }
-            composable(
-                route = Routes.ERROR_LOG,
-                enterTransition = { forwardEnterTransition },
-                exitTransition = { forwardExitTransition },
-                popEnterTransition = { popEnterTransition },
-                popExitTransition = { popExitTransition }
-            ) {
+            composable(Routes.ERROR_LOG) {
                 ErrorLogView(navController = navController)
             }
-            composable(
-                route = Routes.SCHEDULE_EDIT,
-                enterTransition = { forwardEnterTransition },
-                exitTransition = { forwardExitTransition },
-                popEnterTransition = { popEnterTransition },
-                popExitTransition = { popExitTransition }
-            ) { backStackEntry ->
+            composable(Routes.SCHEDULE_EDIT) { backStackEntry ->
                 val strategyId = backStackEntry.arguments?.getString("strategyId")
                     .let { if (it == "new") null else it }
                 ScheduleEditView(navController = navController, strategyId = strategyId)
             }
-            composable(
-                route = Routes.SCHEDULE_TRIGGER_LOG,
-                enterTransition = { forwardEnterTransition },
-                exitTransition = { forwardExitTransition },
-                popEnterTransition = { popEnterTransition },
-                popExitTransition = { popExitTransition }
-            ) {
+            composable(Routes.SCHEDULE_TRIGGER_LOG) {
                 ScheduleTriggerLogView(navController = navController)
             }
-            composable(
-                route = Routes.TASK_OVERRIDE_EDITOR,
-                enterTransition = { forwardEnterTransition },
-                exitTransition = { forwardExitTransition },
-                popEnterTransition = { popEnterTransition },
-                popExitTransition = { popExitTransition }
-            ) {
+            composable(Routes.TASK_OVERRIDE_EDITOR) {
                 TaskOverrideEditorView(navController = navController)
             }
         }
@@ -221,7 +172,9 @@ fun AppNavigation(
         // SnackbarHost overlaid on top
         SnackbarHost(
             hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter)
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
         )
         // 全局定时任务倒计时弹窗（前台所有控制模式均不弹出对话框，静默处理）
         val countdown = scheduledCountdownState

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/BottomNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/BottomNavigation.kt
@@ -35,14 +35,10 @@ import com.aliothmoon.maameow.constant.Routes
 import com.aliothmoon.maameow.theme.MaaDesignTokens
 
 sealed class BottomNavTab(
-    val route: String,
-    @param:StringRes val labelRes: Int,
-    val icon: ImageVector
+    val route: String, @param:StringRes val labelRes: Int, val icon: ImageVector
 ) {
     data object HOME : BottomNavTab(
-        route = Routes.HOME,
-        labelRes = R.string.bottom_nav_home,
-        icon = Icons.Default.Home
+        route = Routes.HOME, labelRes = R.string.bottom_nav_home, icon = Icons.Default.Home
     )
 
     data object BACKGROUND : BottomNavTab(
@@ -71,14 +67,17 @@ sealed class BottomNavTab(
 @Composable
 fun AppBottomNavigation(
     currentRoute: String,
-    onTabSelected: (BottomNavTab) -> Unit
+    onTabSelected: (BottomNavTab) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Surface(
-        color = MaterialTheme.colorScheme.surface,
-        shadowElevation = 0.dp
+        modifier = modifier, color = MaterialTheme.colorScheme.surface, shadowElevation = 0.dp
     ) {
         Column {
-            HorizontalDivider(thickness = MaaDesignTokens.Separator.thickness, color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+            HorizontalDivider(
+                thickness = MaaDesignTokens.Separator.thickness,
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+            )
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -90,10 +89,8 @@ fun AppBottomNavigation(
                 BottomNavTab.all.forEach { tab ->
                     val label = stringResource(tab.labelRes)
                     val selected = currentRoute == tab.route
-                    val contentColor = if (selected)
-                        MaterialTheme.colorScheme.primary
-                    else
-                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    val contentColor = if (selected) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
 
                     Column(
                         modifier = Modifier
@@ -103,8 +100,7 @@ fun AppBottomNavigation(
                             ) { onTabSelected(tab) }
                             .heightIn(min = 48.dp)
                             .padding(horizontal = 20.dp, vertical = 2.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
+                        horizontalAlignment = Alignment.CenterHorizontally) {
                         Icon(
                             imageVector = tab.icon,
                             contentDescription = label,

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/MainScreen.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/MainScreen.kt
@@ -1,133 +1,86 @@
 package com.aliothmoon.maameow.presentation.navigation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.aliothmoon.maameow.data.preferences.AppSettingsManager
+import androidx.navigation.NavController
+import com.aliothmoon.maameow.constant.Routes
 import com.aliothmoon.maameow.presentation.view.background.BackgroundTaskView
 import com.aliothmoon.maameow.presentation.view.home.HomeView
 import com.aliothmoon.maameow.presentation.view.settings.SettingsView
 import com.aliothmoon.maameow.presentation.viewmodel.BackgroundTaskViewModel
 import com.aliothmoon.maameow.schedule.ui.ScheduleListView
 import com.aliothmoon.maameow.theme.MaaAnimations
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import org.koin.compose.koinInject
 import kotlin.math.abs
 
-const val MAIN_PAGE_COUNT = 4
-
-val LocalMainPagerState = staticCompositionLocalOf<MainPagerState?> { null }
-
-class MainPagerState(
-    val pagerState: PagerState,
-    private val coroutineScope: kotlinx.coroutines.CoroutineScope
-) {
-    var selectedPage by mutableIntStateOf(pagerState.currentPage)
-        private set
-    var isNavigating by mutableStateOf(false)
-        private set
-    private var navJob: Job? = null
-
-    fun animateToPage(targetIndex: Int) {
-        if (targetIndex == selectedPage) return
-        navJob?.cancel()
-        selectedPage = targetIndex
-        isNavigating = true
-        val distance = abs(targetIndex - pagerState.currentPage).coerceAtLeast(2)
-        val duration = 100 * distance + 100
-
-        navJob = coroutineScope.launch {
-            try {
-                pagerState.animateScrollToPage(
-                    page = targetIndex,
-                    animationSpec = tween(easing = MaaAnimations.springEasing, durationMillis = duration)
-                )
-            } finally {
-                isNavigating = false
-                if (pagerState.currentPage != targetIndex) {
-                    selectedPage = pagerState.currentPage
-                }
-            }
-        }
-    }
-
-    fun syncPage() {
-        if (!isNavigating && selectedPage != pagerState.currentPage) {
-            selectedPage = pagerState.currentPage
-        }
-    }
-}
-
-@Composable
-fun rememberMainPagerState(
-    pagerState: PagerState,
-    coroutineScope: kotlinx.coroutines.CoroutineScope = rememberCoroutineScope()
-): MainPagerState {
-    return remember(pagerState, coroutineScope) {
-        MainPagerState(pagerState, coroutineScope)
-    }
-}
 
 @Composable
 fun MainScreen(
-    navController: androidx.navigation.NavController,
+    modifier: Modifier = Modifier,
+    navController: NavController,
     backgroundTaskViewModel: BackgroundTaskViewModel,
-    onFullscreenChanged: (Boolean) -> Unit,
     onViewAnnouncement: () -> Unit = {},
     visible: Boolean = true,
-    appSettings: AppSettingsManager = koinInject()
+    fullscreen: Boolean = false,
 ) {
-    val pagerState = rememberPagerState(pageCount = { MAIN_PAGE_COUNT })
-    val mainPagerState = rememberMainPagerState(pagerState)
+    val pagerState = rememberPagerState(pageCount = { BottomNavTab.all.size })
+    val scope = rememberCoroutineScope()
 
-    val settledPage = mainPagerState.pagerState.settledPage
-    LaunchedEffect(settledPage) { mainPagerState.syncPage() }
-    val currentPage = mainPagerState.pagerState.currentPage
-    LaunchedEffect(currentPage) { mainPagerState.syncPage() }
-
-    val currentNavRoute = BottomNavTab.all[mainPagerState.selectedPage].route
-    val showBottomBar = visible
-
-    // 定时任务自动跳转 - 通过 LocalMainPagerState 滑到任务页
-    val pendingScheduledExecution by backgroundTaskViewModel.coordinator.pendingExecution.collectAsStateWithLifecycle()
-    LaunchedEffect(pendingScheduledExecution?.requestId) {
-        if (pendingScheduledExecution != null) {
-            mainPagerState.animateToPage(1) // BACKGROUND_TASK = index 1
+    // targetPage：点击/滑动一旦确定目标即生效，停稳后等于 currentPage。
+    // animateScrollToPage 内部走 MutatorMutex，连续调用时后者自动接管，无需手动取消。
+    fun goToPage(index: Int) {
+        if (index !in BottomNavTab.all.indices || index == pagerState.targetPage) return
+        scope.launch {
+            val distance = abs(index - pagerState.currentPage).coerceAtLeast(1)
+            pagerState.animateScrollToPage(
+                page = index,
+                animationSpec = tween(
+                    durationMillis = 100 * distance + 100,
+                    easing = MaaAnimations.springEasing,
+                ),
+            )
         }
     }
 
-    CompositionLocalProvider(LocalMainPagerState provides mainPagerState) {
+    // 非首页 Tab 按返回键先回到首页；全屏由 BackgroundTaskView 自行处理。
+    BackHandler(enabled = visible && !fullscreen && pagerState.targetPage != 0) {
+        goToPage(0)
+    }
+
+    // 定时任务触发时：若正处于子页面，先弹回主 Tab 浮出主界面，再滑到后台任务页
+    // （恢复旧导航 navigate(BACKGROUND){popUpTo(HOME)} 的“自动浮出后台页”语义）。
+    val pendingScheduledExecution by backgroundTaskViewModel.coordinator.pendingExecution.collectAsStateWithLifecycle()
+    LaunchedEffect(pendingScheduledExecution?.requestId) {
+        if (pendingScheduledExecution != null) {
+            navController.popBackStack(Routes.HOME, false)
+            goToPage(BottomNavTab.all.indexOf(BottomNavTab.BACKGROUND))
+        }
+    }
+
     Scaffold(
+        modifier = modifier,
         bottomBar = {
-            if (showBottomBar) {
+            if (visible && !fullscreen) {
                 AppBottomNavigation(
-                    currentRoute = currentNavRoute,
-                    onTabSelected = { tab ->
-                        val index = BottomNavTab.all.indexOf(tab)
-                        if (index >= 0) mainPagerState.animateToPage(index)
-                    }
+                    currentRoute = BottomNavTab.all[pagerState.targetPage].route,
+                    onTabSelected = { tab -> goToPage(BottomNavTab.all.indexOf(tab)) },
                 )
             }
-        }
+        },
     ) { paddingValues ->
         Box(
             modifier = Modifier
@@ -136,28 +89,41 @@ fun MainScreen(
                 .graphicsLayer {
                     // 隐藏时跳过绘制但保留组合树，避免 HorizontalPager 状态丢失
                     alpha = if (visible) 1f else 0f
-                }
+                },
         ) {
             HorizontalPager(
-                state = mainPagerState.pagerState,
+                state = pagerState,
                 modifier = Modifier.fillMaxSize(),
-                beyondViewportPageCount = 3,
-                userScrollEnabled = true
+                key = { BottomNavTab.all[it].route },
+                userScrollEnabled = visible && !fullscreen,
             ) { page ->
-                when (page) {
-                    0 -> HomeView(navController = navController)
-                    1 -> BackgroundTaskView(
-                        onFullscreenChanged = onFullscreenChanged,
+                when (BottomNavTab.all[page]) {
+                    BottomNavTab.HOME -> HomeView(navController = navController)
+                    BottomNavTab.BACKGROUND -> BackgroundTaskView(
                         viewModel = backgroundTaskViewModel,
                     )
-                    2 -> ScheduleListView(navController = navController)
-                    3 -> SettingsView(
+
+                    BottomNavTab.SCHEDULE -> ScheduleListView(navController = navController)
+                    BottomNavTab.SETTINGS -> SettingsView(
                         navController = navController,
                         onViewAnnouncement = onViewAnnouncement,
                     )
                 }
             }
+
+            // 隐藏（子页面叠加其上）时吞掉所有指针，防止横滑切走主 Tab / 点击穿透到底层页。
+            if (!visible) {
+                Box(
+                    Modifier
+                        .matchParentSize()
+                        .pointerInput(Unit) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    awaitPointerEvent().changes.forEach { it.consume() }
+                                }
+                            }
+                        })
+            }
         }
-    }
     }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/MainScreen.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/MainScreen.kt
@@ -1,0 +1,163 @@
+package com.aliothmoon.maameow.presentation.navigation
+
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.aliothmoon.maameow.data.preferences.AppSettingsManager
+import com.aliothmoon.maameow.presentation.view.background.BackgroundTaskView
+import com.aliothmoon.maameow.presentation.view.home.HomeView
+import com.aliothmoon.maameow.presentation.view.settings.SettingsView
+import com.aliothmoon.maameow.presentation.viewmodel.BackgroundTaskViewModel
+import com.aliothmoon.maameow.schedule.ui.ScheduleListView
+import com.aliothmoon.maameow.theme.MaaAnimations
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+import kotlin.math.abs
+
+const val MAIN_PAGE_COUNT = 4
+
+val LocalMainPagerState = staticCompositionLocalOf<MainPagerState?> { null }
+
+class MainPagerState(
+    val pagerState: PagerState,
+    private val coroutineScope: kotlinx.coroutines.CoroutineScope
+) {
+    var selectedPage by mutableIntStateOf(pagerState.currentPage)
+        private set
+    var isNavigating by mutableStateOf(false)
+        private set
+    private var navJob: Job? = null
+
+    fun animateToPage(targetIndex: Int) {
+        if (targetIndex == selectedPage) return
+        navJob?.cancel()
+        selectedPage = targetIndex
+        isNavigating = true
+        val distance = abs(targetIndex - pagerState.currentPage).coerceAtLeast(2)
+        val duration = 100 * distance + 100
+
+        navJob = coroutineScope.launch {
+            try {
+                pagerState.animateScrollToPage(
+                    page = targetIndex,
+                    animationSpec = tween(easing = MaaAnimations.springEasing, durationMillis = duration)
+                )
+            } finally {
+                isNavigating = false
+                if (pagerState.currentPage != targetIndex) {
+                    selectedPage = pagerState.currentPage
+                }
+            }
+        }
+    }
+
+    fun syncPage() {
+        if (!isNavigating && selectedPage != pagerState.currentPage) {
+            selectedPage = pagerState.currentPage
+        }
+    }
+}
+
+@Composable
+fun rememberMainPagerState(
+    pagerState: PagerState,
+    coroutineScope: kotlinx.coroutines.CoroutineScope = rememberCoroutineScope()
+): MainPagerState {
+    return remember(pagerState, coroutineScope) {
+        MainPagerState(pagerState, coroutineScope)
+    }
+}
+
+@Composable
+fun MainScreen(
+    navController: androidx.navigation.NavController,
+    backgroundTaskViewModel: BackgroundTaskViewModel,
+    onFullscreenChanged: (Boolean) -> Unit,
+    onViewAnnouncement: () -> Unit = {},
+    visible: Boolean = true,
+    appSettings: AppSettingsManager = koinInject()
+) {
+    val pagerState = rememberPagerState(pageCount = { MAIN_PAGE_COUNT })
+    val mainPagerState = rememberMainPagerState(pagerState)
+
+    val settledPage = mainPagerState.pagerState.settledPage
+    LaunchedEffect(settledPage) { mainPagerState.syncPage() }
+    val currentPage = mainPagerState.pagerState.currentPage
+    LaunchedEffect(currentPage) { mainPagerState.syncPage() }
+
+    val currentNavRoute = BottomNavTab.all[mainPagerState.selectedPage].route
+    val showBottomBar = visible
+
+    // 定时任务自动跳转 - 通过 LocalMainPagerState 滑到任务页
+    val pendingScheduledExecution by backgroundTaskViewModel.coordinator.pendingExecution.collectAsStateWithLifecycle()
+    LaunchedEffect(pendingScheduledExecution?.requestId) {
+        if (pendingScheduledExecution != null) {
+            mainPagerState.animateToPage(1) // BACKGROUND_TASK = index 1
+        }
+    }
+
+    CompositionLocalProvider(LocalMainPagerState provides mainPagerState) {
+    Scaffold(
+        bottomBar = {
+            if (showBottomBar) {
+                AppBottomNavigation(
+                    currentRoute = currentNavRoute,
+                    onTabSelected = { tab ->
+                        val index = BottomNavTab.all.indexOf(tab)
+                        if (index >= 0) mainPagerState.animateToPage(index)
+                    }
+                )
+            }
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = paddingValues.calculateBottomPadding())
+                .graphicsLayer {
+                    // 隐藏时跳过绘制但保留组合树，避免 HorizontalPager 状态丢失
+                    alpha = if (visible) 1f else 0f
+                }
+        ) {
+            HorizontalPager(
+                state = mainPagerState.pagerState,
+                modifier = Modifier.fillMaxSize(),
+                beyondViewportPageCount = 3,
+                userScrollEnabled = true
+            ) { page ->
+                when (page) {
+                    0 -> HomeView(navController = navController)
+                    1 -> BackgroundTaskView(
+                        onFullscreenChanged = onFullscreenChanged,
+                        viewModel = backgroundTaskViewModel,
+                    )
+                    2 -> ScheduleListView(navController = navController)
+                    3 -> SettingsView(
+                        navController = navController,
+                        onViewAnnouncement = onViewAnnouncement,
+                    )
+                }
+            }
+        }
+    }
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
@@ -84,6 +84,7 @@ import com.aliothmoon.maameow.constant.DefaultDisplayConfig
 import com.aliothmoon.maameow.domain.models.RemoteBackend
 import com.aliothmoon.maameow.domain.service.MaaCompositionService
 import com.aliothmoon.maameow.domain.service.UnifiedStateDispatcher
+import com.aliothmoon.maameow.domain.models.RunMode
 import com.aliothmoon.maameow.domain.state.MaaExecutionState
 import com.aliothmoon.maameow.manager.PermissionManager
 import com.aliothmoon.maameow.manager.ShizukuInstallHelper
@@ -126,11 +127,11 @@ import com.aliothmoon.maameow.presentation.view.panel.ToolboxPanel
 import com.aliothmoon.maameow.presentation.view.panel.LocalToolboxFileExporter
 import com.aliothmoon.maameow.presentation.view.panel.rememberSafToolboxFileExporter
 import com.aliothmoon.maameow.theme.MaaAnimations
+import com.aliothmoon.maameow.theme.MaaThemeAlphas
 import androidx.compose.animation.core.tween
 
 @Composable
 fun BackgroundTaskView(
-    onFullscreenChanged: (Boolean) -> Unit = {},
     viewModel: BackgroundTaskViewModel,
     copilotViewModel: CopilotViewModel = koinInject(),
     toolboxViewModel: ToolboxViewModel = koinInject(),
@@ -145,6 +146,7 @@ fun BackgroundTaskView(
     val coroutineScope = rememberCoroutineScope()
     val state by viewModel.state.collectAsStateWithLifecycle()
     val maaState by compositionService.state.collectAsStateWithLifecycle()
+    val runMode by appSettingsManager.runMode.collectAsStateWithLifecycle()
     val markers by viewModel.markers.collectAsStateWithLifecycle()
     val displayResolution by compositionService.displayResolution.collectAsStateWithLifecycle()
     val permissions by permissionManager.state.collectAsStateWithLifecycle()
@@ -169,9 +171,7 @@ fun BackgroundTaskView(
     val canShowTaskActions = PanelTab.canShowTaskActions(state.current)
 
     val pagerState = rememberPagerState(
-        initialPage = state.current.ordinal,
-        pageCount = { PanelTab.entries.size }
-    )
+        initialPage = state.current.ordinal, pageCount = { PanelTab.entries.size })
 
     LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.settledPage }.collect { page ->
@@ -185,10 +185,8 @@ fun BackgroundTaskView(
     LaunchedEffect(state.current) {
         if (pagerState.currentPage != state.current.ordinal) {
             pagerState.animateScrollToPage(
-                state.current.ordinal,
-                animationSpec = tween(
-                    easing = MaaAnimations.springEasing,
-                    durationMillis = 250
+                state.current.ordinal, animationSpec = tween(
+                    easing = MaaAnimations.springEasing, durationMillis = 250
                 )
             )
         }
@@ -212,18 +210,17 @@ fun BackgroundTaskView(
 
     if (!permissions.remoteAccessGranted && showRemoteAccessDialog) {
         var isRequestingRemoteAccess by remember { mutableStateOf(false) }
-        val canOpenShizukuShortcut = permissions.startupBackend == RemoteBackend.SHIZUKU &&
-                !permissions.isStartupBackendAvailable(permissions.startupBackend) &&
-                shizukuShortcutEnabled
+        val canOpenShizukuShortcut =
+            permissions.startupBackend == RemoteBackend.SHIZUKU && !permissions.isStartupBackendAvailable(
+                permissions.startupBackend
+            ) && shizukuShortcutEnabled
         ShizukuPermissionDialog(
             title = stringResource(
-                R.string.bg_shizuku_permission_title,
-                permissions.startupBackend.display
-            ),
+            R.string.bg_shizuku_permission_title, permissions.startupBackend.display
+        ),
             message = if (canOpenShizukuShortcut) {
                 stringResource(
-                    R.string.bg_shizuku_permission_message,
-                    permissions.startupBackend.display
+                    R.string.bg_shizuku_permission_message, permissions.startupBackend.display
                 )
             } else {
                 stringResource(
@@ -250,18 +247,17 @@ fun BackgroundTaskView(
                     val granted = permissionManager.requestRemoteAccess()
                     isRequestingRemoteAccess = false
                     if (!granted) {
-                        val message = if (!permissions.isStartupBackendAvailable(permissions.startupBackend)) {
-                            context.getString(
-                                R.string.bg_toast_remote_access_unavailable,
-                                permissions.startupBackend.display
-                            )
-                        } else {
-                            permissionNotAcquiredFormat.format(currentPermissionLabel)
-                        }
+                        val message =
+                            if (!permissions.isStartupBackendAvailable(permissions.startupBackend)) {
+                                context.getString(
+                                    R.string.bg_toast_remote_access_unavailable,
+                                    permissions.startupBackend.display
+                                )
+                            } else {
+                                permissionNotAcquiredFormat.format(currentPermissionLabel)
+                            }
                         Toast.makeText(
-                            context,
-                            message,
-                            Toast.LENGTH_SHORT
+                            context, message, Toast.LENGTH_SHORT
                         ).show()
                     }
                 }
@@ -282,10 +278,6 @@ fun BackgroundTaskView(
     }
 
 
-    LaunchedEffect(state.isFullscreenMonitor) {
-        onFullscreenChanged(state.isFullscreenMonitor)
-    }
-
     val pendingExecution by viewModel.coordinator.pendingExecution.collectAsStateWithLifecycle()
 
     LaunchedEffect(pendingExecution?.requestId) {
@@ -297,9 +289,7 @@ fun BackgroundTaskView(
     LaunchedEffect(Unit) {
         dispatcher.serviceDiedEvent.collect {
             Toast.makeText(
-                context,
-                serviceDiedMessage,
-                Toast.LENGTH_SHORT
+                context, serviceDiedMessage, Toast.LENGTH_SHORT
             ).show()
         }
     }
@@ -307,9 +297,7 @@ fun BackgroundTaskView(
     LaunchedEffect(Unit) {
         appWatchdog.appDiedEvent.collect {
             Toast.makeText(
-                context,
-                appDiedMessage,
-                Toast.LENGTH_SHORT
+                context, appDiedMessage, Toast.LENGTH_SHORT
             ).show()
         }
     }
@@ -375,8 +363,7 @@ fun BackgroundTaskView(
                                     }
                                 })
                             }
-                        },
-                        modifier = Modifier.fillMaxSize()
+                        }, modifier = Modifier.fillMaxSize()
                     )
                     if (markers.isNotEmpty()) TouchPreviewOverlay(
                         markers = markers,
@@ -408,8 +395,7 @@ fun BackgroundTaskView(
                         modifier = Modifier.fillMaxSize(),
                         isRunning = maaState == MaaExecutionState.RUNNING,
                         isSurfaceAvailable = isSurfaceAvailable,
-                        onClick = { viewModel.onToggleFullscreenMonitor() }
-                    ) {
+                        onClick = { viewModel.onToggleFullscreenMonitor() }) {
                         previewContent()
                     }
                 } else {
@@ -482,12 +468,10 @@ fun BackgroundTaskView(
                                                     profiles = profiles,
                                                     activeProfileId = activeProfileId,
                                                     onConfigChange = { config ->
-                                                        val nodeId =
-                                                            selectedNode?.id
-                                                                ?: return@TaskConfigPanel
+                                                        val nodeId = selectedNode?.id
+                                                            ?: return@TaskConfigPanel
                                                         viewModel.onNodeConfigChange(
-                                                            nodeId,
-                                                            config
+                                                            nodeId, config
                                                         )
                                                     },
                                                     onAddNode = { viewModel.onAddNode(it) },
@@ -495,8 +479,7 @@ fun BackgroundTaskView(
                                                     onDuplicateNode = { viewModel.onDuplicateNode(it) },
                                                     onRenameNode = { id, name ->
                                                         viewModel.onRenameNode(
-                                                            id,
-                                                            name
+                                                            id, name
                                                         )
                                                     },
                                                     onSwitchProfile = {
@@ -506,8 +489,7 @@ fun BackgroundTaskView(
                                                     },
                                                     onRenameProfile = { id, name ->
                                                         viewModel.onRenameProfile(
-                                                            id,
-                                                            name
+                                                            id, name
                                                         )
                                                     },
                                                     onDuplicateProfile = {
@@ -523,8 +505,7 @@ fun BackgroundTaskView(
                                                     onCreateProfile = { viewModel.onCreateProfile() },
                                                     onReorderProfile = { from, to ->
                                                         viewModel.onReorderProfile(from, to)
-                                                    }
-                                                )
+                                                    })
                                             }
                                         }
                                     }
@@ -536,6 +517,7 @@ fun BackgroundTaskView(
                                 ) {
                                     ToolboxPanel(modifier = Modifier.fillMaxSize())
                                 }
+
                                 3 -> {
                                     val runtimeLogs by viewModel.logs.collectAsStateWithLifecycle()
                                     LogPanel(
@@ -549,6 +531,10 @@ fun BackgroundTaskView(
                         if (canShowTaskActions) {
                             Spacer(modifier = Modifier.height(6.dp))
                             val focusManager = LocalFocusManager.current
+                            // 前台模式不从后台任务页启动任务：按钮显示为禁用态但仍可点击，点击给出提示（防呆
+                            val foregroundBlocked = runMode == RunMode.FOREGROUND
+                            val switchBackgroundModeMessage =
+                                stringResource(R.string.navigation_toast_switch_background_mode)
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
                                 horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -557,6 +543,14 @@ fun BackgroundTaskView(
                                 Button(
                                     onClick = {
                                         focusManager.clearFocus()
+                                        if (foregroundBlocked) {
+                                            Toast.makeText(
+                                                context,
+                                                switchBackgroundModeMessage,
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                            return@Button
+                                        }
                                         if (!permissions.remoteAccessGranted) {
                                             showRemoteAccessDialog = true
                                             return@Button
@@ -569,6 +563,18 @@ fun BackgroundTaskView(
                                         }
                                     },
                                     enabled = maaState != MaaExecutionState.RUNNING && maaState != MaaExecutionState.STARTING && maaState != MaaExecutionState.STOPPING,
+                                    colors = if (foregroundBlocked) {
+                                        ButtonDefaults.buttonColors(
+                                            containerColor = MaterialTheme.colorScheme.onSurface.copy(
+                                                alpha = 0.12f
+                                            ),
+                                            contentColor = MaterialTheme.colorScheme.onSurface.copy(
+                                                alpha = MaaThemeAlphas.Disabled
+                                            ),
+                                        )
+                                    } else {
+                                        ButtonDefaults.buttonColors()
+                                    },
                                     modifier = Modifier.weight(1f),
                                     shape = RoundedCornerShape(8.dp)
                                 ) {
@@ -631,8 +637,7 @@ fun BackgroundTaskView(
                         contentAlignment = Alignment.Center
                     ) {
                         CircularProgressIndicator(
-                            modifier = Modifier.size(32.dp),
-                            strokeWidth = 2.dp
+                            modifier = Modifier.size(32.dp), strokeWidth = 2.dp
                         )
                     }
                 }
@@ -868,17 +873,13 @@ private fun BackgroundMoreActionsOverlay(
                 .fillMaxWidth()
                 .padding(start = 16.dp, end = 16.dp, bottom = 64.dp)
                 .clickable(
-                    interactionSource = cardInteractionSource,
-                    indication = null,
-                    onClick = {}
-                ),
+                    interactionSource = cardInteractionSource, indication = null, onClick = {}),
             shape = RoundedCornerShape(4.dp),
             colors = CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface
             ),
             elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-            border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
-        ) {
+            border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)) {
             Column(modifier = Modifier.padding(10.dp)) {
                 // 标题与快速操作组
                 Text(
@@ -922,10 +923,8 @@ private fun BackgroundMoreActionsOverlay(
                 ) {
                     ActionTile(
                         icon = if (isGameMuted) Icons.AutoMirrored.Filled.VolumeOff else Icons.AutoMirrored.Filled.VolumeUp,
-                        label = if (isGameMuted)
-                            stringResource(R.string.bg_action_game_muted)
-                        else
-                            stringResource(R.string.bg_action_mute_game),
+                        label = if (isGameMuted) stringResource(R.string.bg_action_game_muted)
+                        else stringResource(R.string.bg_action_mute_game),
                         onClick = onToggleGameSound,
                         modifier = Modifier.weight(1f),
                         containerColor = if (isGameMuted) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.secondary,
@@ -953,8 +952,7 @@ private fun BackgroundMoreActionsOverlay(
 
                 Spacer(modifier = Modifier.height(12.dp))
                 HorizontalDivider(
-                    color = MaterialTheme.colorScheme.outlineVariant,
-                    thickness = 0.5.dp
+                    color = MaterialTheme.colorScheme.outlineVariant, thickness = 0.5.dp
                 )
                 Spacer(modifier = Modifier.height(12.dp))
 
@@ -973,16 +971,14 @@ private fun BackgroundMoreActionsOverlay(
                     checked = muteOnGameLaunch,
                     onCheckedChange = {
                         coroutineScope.launch { appSettingsManager.setMuteOnGameLaunch(it) }
-                    }
-                )
+                    })
                 SettingSwitchRow(
                     icon = Icons.Filled.Cancel,
                     label = stringResource(R.string.bg_auto_close_on_end),
                     checked = closeAppOnTaskEnd,
                     onCheckedChange = {
                         coroutineScope.launch { appSettingsManager.setCloseAppOnTaskEnd(it) }
-                    }
-                )
+                    })
                 SettingSwitchRow(
                     icon = Icons.Filled.StayCurrentPortrait,
                     label = stringResource(R.string.bg_auto_hardware_screen_off),
@@ -997,16 +993,14 @@ private fun BackgroundMoreActionsOverlay(
                                 )
                             }
                         }
-                    }
-                )
+                    })
                 SettingSwitchRow(
                     icon = Icons.Filled.TouchApp,
                     label = stringResource(R.string.bg_auto_show_touch_preview),
                     checked = showTouchPreview,
                     onCheckedChange = {
                         coroutineScope.launch { appSettingsManager.setShowTouchPreview(it) }
-                    }
-                )
+                    })
             }
         }
     }
@@ -1071,10 +1065,7 @@ private fun ActionTile(
 
 @Composable
 private fun SettingSwitchRow(
-    icon: ImageVector,
-    label: String,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit
+    icon: ImageVector, label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit
 ) {
     Row(
         modifier = Modifier

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
@@ -125,6 +125,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import com.aliothmoon.maameow.presentation.view.panel.ToolboxPanel
 import com.aliothmoon.maameow.presentation.view.panel.LocalToolboxFileExporter
 import com.aliothmoon.maameow.presentation.view.panel.rememberSafToolboxFileExporter
+import com.aliothmoon.maameow.theme.MaaAnimations
+import androidx.compose.animation.core.tween
 
 @Composable
 fun BackgroundTaskView(
@@ -182,7 +184,13 @@ fun BackgroundTaskView(
 
     LaunchedEffect(state.current) {
         if (pagerState.currentPage != state.current.ordinal) {
-            pagerState.scrollToPage(state.current.ordinal)
+            pagerState.animateScrollToPage(
+                state.current.ordinal,
+                animationSpec = tween(
+                    easing = MaaAnimations.springEasing,
+                    durationMillis = 250
+                )
+            )
         }
     }
     val context = LocalContext.current

--- a/app/src/main/java/com/aliothmoon/maameow/theme/MaaAnimations.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/theme/MaaAnimations.kt
@@ -1,0 +1,59 @@
+package com.aliothmoon.maameow.theme
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+
+/**
+ * Shared-axis style page transitions inspired by Material motion spec.
+ * Uses spring-like cubic bezier for a subtle bounce feel.
+ */
+object MaaAnimations {
+
+    private const val PAGE_DURATION = 380
+
+    /**
+     * Spring-like cubic bezier (0.32, 0.72, 0.0, 1.0) -- produces a subtle
+     * overshoot and settle-back feel for smooth transitions.
+     */
+    val springEasing = CubicBezierEasing(0.32f, 0.72f, 0.0f, 1.0f)
+    private val pageEasing = springEasing
+
+    fun sharedAxisForwardEnter(): EnterTransition =
+        slideInHorizontally(
+            initialOffsetX = { fullWidth -> fullWidth },
+            animationSpec = tween(PAGE_DURATION, easing = pageEasing)
+        ) + fadeIn(
+            animationSpec = tween(PAGE_DURATION, easing = LinearEasing)
+        )
+
+    fun sharedAxisForwardExit(): ExitTransition =
+        slideOutHorizontally(
+            targetOffsetX = { fullWidth -> -fullWidth / 2 },
+            animationSpec = tween(PAGE_DURATION, easing = pageEasing)
+        ) + fadeOut(
+            animationSpec = tween(PAGE_DURATION, easing = LinearEasing)
+        )
+
+    fun sharedAxisPopEnter(): EnterTransition =
+        slideInHorizontally(
+            initialOffsetX = { fullWidth -> -fullWidth / 2 },
+            animationSpec = tween(PAGE_DURATION, easing = pageEasing)
+        ) + fadeIn(
+            animationSpec = tween(PAGE_DURATION, easing = LinearEasing)
+        )
+
+    fun sharedAxisPopExit(): ExitTransition =
+        slideOutHorizontally(
+            targetOffsetX = { fullWidth -> fullWidth },
+            animationSpec = tween(PAGE_DURATION, easing = pageEasing)
+        ) + fadeOut(
+            animationSpec = tween(PAGE_DURATION, easing = LinearEasing)
+        )
+}

--- a/app/src/main/java/com/aliothmoon/maameow/theme/MaaAnimations.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/theme/MaaAnimations.kt
@@ -10,50 +10,32 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 
-/**
- * Shared-axis style page transitions inspired by Material motion spec.
- * Uses spring-like cubic bezier for a subtle bounce feel.
- */
 object MaaAnimations {
 
     private const val PAGE_DURATION = 380
 
     /**
-     * Spring-like cubic bezier (0.32, 0.72, 0.0, 1.0) -- produces a subtle
-     * overshoot and settle-back feel for smooth transitions.
+     * Ease-out cubic bezier (0.32, 0.72, 0.0, 1.0): fast start, smooth settle.
+     * Control-point y stays within [0, 1], so it does not overshoot.
      */
     val springEasing = CubicBezierEasing(0.32f, 0.72f, 0.0f, 1.0f)
-    private val pageEasing = springEasing
 
-    fun sharedAxisForwardEnter(): EnterTransition =
+    private fun slideEnter(offsetX: (Int) -> Int): EnterTransition =
         slideInHorizontally(
-            initialOffsetX = { fullWidth -> fullWidth },
-            animationSpec = tween(PAGE_DURATION, easing = pageEasing)
-        ) + fadeIn(
-            animationSpec = tween(PAGE_DURATION, easing = LinearEasing)
-        )
+            initialOffsetX = offsetX,
+            animationSpec = tween(PAGE_DURATION, easing = springEasing)
+        ) +
+                fadeIn(animationSpec = tween(PAGE_DURATION, easing = LinearEasing))
 
-    fun sharedAxisForwardExit(): ExitTransition =
+    private fun slideExit(offsetX: (Int) -> Int): ExitTransition =
         slideOutHorizontally(
-            targetOffsetX = { fullWidth -> -fullWidth / 2 },
-            animationSpec = tween(PAGE_DURATION, easing = pageEasing)
-        ) + fadeOut(
-            animationSpec = tween(PAGE_DURATION, easing = LinearEasing)
-        )
+            targetOffsetX = offsetX,
+            animationSpec = tween(PAGE_DURATION, easing = springEasing)
+        ) +
+                fadeOut(animationSpec = tween(PAGE_DURATION, easing = LinearEasing))
 
-    fun sharedAxisPopEnter(): EnterTransition =
-        slideInHorizontally(
-            initialOffsetX = { fullWidth -> -fullWidth / 2 },
-            animationSpec = tween(PAGE_DURATION, easing = pageEasing)
-        ) + fadeIn(
-            animationSpec = tween(PAGE_DURATION, easing = LinearEasing)
-        )
-
-    fun sharedAxisPopExit(): ExitTransition =
-        slideOutHorizontally(
-            targetOffsetX = { fullWidth -> fullWidth },
-            animationSpec = tween(PAGE_DURATION, easing = pageEasing)
-        ) + fadeOut(
-            animationSpec = tween(PAGE_DURATION, easing = LinearEasing)
-        )
+    val sharedAxisForwardEnter: EnterTransition = slideEnter { fullWidth -> fullWidth }
+    val sharedAxisForwardExit: ExitTransition = slideExit { fullWidth -> -fullWidth / 2 }
+    val sharedAxisPopEnter: EnterTransition = slideEnter { fullWidth -> -fullWidth / 2 }
+    val sharedAxisPopExit: ExitTransition = slideExit { fullWidth -> fullWidth }
 }


### PR DESCRIPTION
## 改动说明

将主导航从 NavHost + fadeIn/fadeOut 切换改为 HorizontalPager + spring 贝塞尔动画，实现更平滑的 Tab 切换体验。

### 新增文件
- **`MaaAnimations.kt`** — 弹性贝塞尔曲线 easing (0.32, 0.72, 0, 1) + shared axis 子页面转场
- **`MainScreen.kt`** — HorizontalPager 替代 NavHost 处理 Tab 切换，支持手势滑动

### 修改文件
- **`AppNavigation.kt`** — NavHost 只保留子页面路由（通知、成就、日志等），Tab 切换委托给 MainScreen
- **`BackgroundTaskView.kt`** — Tasks/Auto Battle/Tools/Logs 子 Tab 使用 `animateScrollToPage` + spring 动画

### 架构变化
```
旧: NavHost 管 Tab + 子页面，fadeIn/fadeOut(150ms) 切 Tab
新: HorizontalPager 管 Tab（spring动画），NavHost 只管子页面（shared axis 380ms 转场）
```

### 动画参数
- Tab 切换：springEasing CubicBezier(0.32, 0.72, 0, 1)，时长按距离动态计算
- 子页面转场：shared axis 滑动 + 渐变，380ms
- BackgroundTask 子 Tab：springEasing 250ms

## Summary by Sourcery

引入一个基于 HorizontalPager 的主界面，在切换标签时使用弹簧动画，同时将子页面路由委托给带共享轴过渡效果的 NavHost 处理。

New Features:
- 添加使用 HorizontalPager 的 `MainScreen` composable，用于处理带手势支持的主标签导航。
- 添加 `MaaAnimations` 工具类，提供类弹簧的缓动效果以及共享轴页面切换预设。

Enhancements:
- 重构 `AppNavigation`，使 `NavHost` 仅负责子页面路由，并集成 `MainScreen` 以管理顶层标签。
- 更新 `BackgroundTaskView`，使用带弹簧缓动效果的动画 pager 滚动，以实现更顺滑的子标签切换。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a HorizontalPager-based main screen with spring animations for tab switching while delegating sub-page routing to NavHost with shared-axis transitions.

New Features:
- Add MainScreen composable using HorizontalPager to handle main tab navigation with gesture support.
- Add MaaAnimations utility providing spring-like easing and shared-axis page transition presets.

Enhancements:
- Refactor AppNavigation so NavHost only manages sub-page routes and integrates MainScreen for top-level tabs.
- Update BackgroundTaskView to use animated pager scrolling with spring easing for smoother sub-tab transitions.

</details>