### PR TITLE
fix(log-panel): replace useless scroll button with functional arrow-down icon

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/LogPanel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/LogPanel.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,7 +54,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlinx.coroutines.launch
 import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.data.model.LogColorRole
 import com.aliothmoon.maameow.data.model.LogItem
@@ -76,7 +74,6 @@ fun LogPanel(
     val listState = rememberLazyListState()
     var isAutoScroll by remember { mutableStateOf(true) }
     var selectedLog by remember { mutableStateOf<LogItem?>(null) }
-    val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(logs.size, isAutoScroll) {
         if (isAutoScroll && logs.isNotEmpty()) {
@@ -150,11 +147,7 @@ fun LogPanel(
 
             if (listState.canScrollForward && logs.isNotEmpty()) {
                 IconButton(
-                    onClick = {
-                        coroutineScope.launch {
-                            listState.scrollToItem(logs.size - 1)
-                        }
-                    },
+                    onClick = { isAutoScroll = true },
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
                         .padding(16.dp)

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/LogPanel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/LogPanel.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.List
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Delete
@@ -38,6 +39,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,6 +55,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
 import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.data.model.LogColorRole
 import com.aliothmoon.maameow.data.model.LogItem
@@ -73,10 +76,11 @@ fun LogPanel(
     val listState = rememberLazyListState()
     var isAutoScroll by remember { mutableStateOf(true) }
     var selectedLog by remember { mutableStateOf<LogItem?>(null) }
+    val coroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(logs.size) {
+    LaunchedEffect(logs.size, isAutoScroll) {
         if (isAutoScroll && logs.isNotEmpty()) {
-            listState.animateScrollToItem(logs.size - 1)
+            listState.scrollToItem(logs.size - 1)
         }
     }
 
@@ -144,9 +148,13 @@ fun LogPanel(
                 }
             }
 
-            if (!isAutoScroll && logs.isNotEmpty()) {
+            if (listState.canScrollForward && logs.isNotEmpty()) {
                 IconButton(
-                    onClick = { isAutoScroll = true },
+                    onClick = {
+                        coroutineScope.launch {
+                            listState.scrollToItem(logs.size - 1)
+                        }
+                    },
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
                         .padding(16.dp)
@@ -157,7 +165,7 @@ fun LogPanel(
                         )
                 ) {
                     Icon(
-                        imageVector = Icons.Outlined.Info,
+                        imageVector = Icons.Filled.KeyboardArrowDown,
                         contentDescription = stringResource(R.string.panel_log_resume_auto_scroll),
                         tint = MaterialTheme.colorScheme.onPrimaryContainer,
                         modifier = Modifier.size(20.dp)


### PR DESCRIPTION
## 改动说明

日志面板右下角的滚动恢复按钮之前基本无用（点击后不会立即滚动），本次做了以下改进：

- **图标**：感叹号改为向下箭头，语义更清晰
- **显示条件**：基于 listState.canScrollForward 实时判断，页面在底部时自动隐藏
- **点击行为**：点击后立即执行 animateScrollToItem 跳转到底部
- **修复反应性**：LaunchedEffect key 增加 isAutoScroll，确保状态变化能正确触发滚动

## Summary by Sourcery

改进日志面板的自动滚动行为和滚动控制提示。

Bug 修复：
- 确保当自动滚动状态改变时，日志面板的自动滚动会重新触发，从而让新的日志条目可靠地滚动到视图中。

增强功能：
- 仅在可以继续向下滚动时在右下角显示“滚动到最新”按钮，点击后会立即滚动到最新日志并重新启用自动滚动，同时使用更清晰的向下箭头图标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the log panel’s auto-scroll behavior and scroll control affordance.

Bug Fixes:
- Ensure log panel auto-scroll re-triggers when the auto-scroll state changes so new logs reliably scroll into view.

Enhancements:
- Show a bottom-right scroll-to-latest button only when further scrolling is possible and clicking it immediately scrolls to the newest log while re-enabling auto-scroll, using a clearer downward arrow icon.

</details>