### PR TITLE
feat: MAA-Meow启动时清理缓存 APK

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/MaaApplication.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/MaaApplication.kt
@@ -29,6 +29,8 @@ import org.koin.core.logger.Level
 
 class MaaApplication : Application() {
 
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     private val appSettingsManager: AppSettingsManager by inject()
     private val crashHandler: CrashHandler by inject()
     private val unifiedStateDispatcher: UnifiedStateDispatcher by inject()
@@ -62,8 +64,8 @@ class MaaApplication : Application() {
     }
 
     private fun cleanCachedUpdateApks() {
-        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
-            appDownloader.cleanCachedApks()
+        applicationScope.launch {
+            appDownloader.cleanCachedInstalledApks()
         }
     }
 
@@ -71,7 +73,7 @@ class MaaApplication : Application() {
     // 但国产 ROM 在自启动未开启时会拦截该广播，导致闹钟丢失后无法恢复。
     // 每次应用启动时执行一次幂等同步，作为兜底保障。
     private fun doSyncScheduleAlarms() {
-        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+        applicationScope.launch {
             scheduleRepository.isLoaded.filter { it }.first()
             scheduleAlarmManager.rescheduleAll(scheduleRepository.strategies.value)
         }

--- a/app/src/main/java/com/aliothmoon/maameow/MaaApplication.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/MaaApplication.kt
@@ -65,7 +65,7 @@ class MaaApplication : Application() {
 
     private fun cleanCachedUpdateApks() {
         applicationScope.launch {
-            appDownloader.cleanCachedInstalledApks()
+            appDownloader.cleanInstalledApks()
         }
     }
 

--- a/app/src/main/java/com/aliothmoon/maameow/MaaApplication.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/MaaApplication.kt
@@ -1,6 +1,7 @@
 package com.aliothmoon.maameow
 
 import android.app.Application
+import com.aliothmoon.maameow.data.datasource.AppDownloader
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
 import com.aliothmoon.maameow.domain.service.UnifiedStateDispatcher
 import com.aliothmoon.maameow.koin.appModule
@@ -32,6 +33,7 @@ class MaaApplication : Application() {
     private val crashHandler: CrashHandler by inject()
     private val unifiedStateDispatcher: UnifiedStateDispatcher by inject()
     private val overlayController: OverlayController by inject()
+    private val appDownloader: AppDownloader by inject()
     private val treeHolder: LogTreeHolder by inject()
     private val scheduleRepository: ScheduleStrategyRepository by inject()
     private val scheduleAlarmManager: ScheduleAlarmManager by inject()
@@ -55,7 +57,14 @@ class MaaApplication : Application() {
         crashHandler.init(this)
         overlayController.setup()
         unifiedStateDispatcher.start()
+        cleanCachedUpdateApks()
         doSyncScheduleAlarms()
+    }
+
+    private fun cleanCachedUpdateApks() {
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            appDownloader.cleanCachedApks()
+        }
     }
 
     // BootReceiver 依赖 ACTION_MY_PACKAGE_REPLACED / BOOT_COMPLETED 恢复闹钟，

--- a/app/src/main/java/com/aliothmoon/maameow/data/datasource/AppDownloader.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/datasource/AppDownloader.kt
@@ -92,11 +92,11 @@ class AppDownloader(
      */
     fun cleanOldApks(keepVersion: String) {
         val keepName = apkFileName(keepVersion)
-        context.cacheDir.listFiles()?.filter {
-                it.name.startsWith("MaaMeow-") && (it.name.endsWith(".apk") || it.name.endsWith(
-                    ".apk.dl"
-                ))
-            }?.filter { it.name != keepName }?.forEach { it.delete() }
+        listCachedApks()?.filter { it.name != keepName }?.forEach { it.delete() }
+    }
+
+    fun cleanCachedApks() {
+        listCachedApks()?.forEach { it.delete() }
     }
 
     suspend fun downloadToTempFile(
@@ -172,4 +172,10 @@ class AppDownloader(
     }
 
     private fun apkFileName(version: String): String = "MaaMeow-${version}.apk"
+
+    private fun listCachedApks(): List<File>? {
+        return context.cacheDir.listFiles()?.filter {
+            it.name.startsWith("MaaMeow-") && (it.name.endsWith(".apk") || it.name.endsWith(".apk.dl"))
+        }
+    }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/data/datasource/AppDownloader.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/datasource/AppDownloader.kt
@@ -95,8 +95,8 @@ class AppDownloader(
         listCachedApks()?.filter { it.name != keepName }?.forEach { it.delete() }
     }
 
-    fun cleanCachedApks() {
-        listCachedApks()?.forEach { it.delete() }
+    fun cleanCachedInstalledApks() {
+        listCachedApks(includeDownloading = false)?.forEach { it.delete() }
     }
 
     suspend fun downloadToTempFile(
@@ -173,9 +173,9 @@ class AppDownloader(
 
     private fun apkFileName(version: String): String = "MaaMeow-${version}.apk"
 
-    private fun listCachedApks(): List<File>? {
+    private fun listCachedApks(includeDownloading: Boolean = true): List<File>? {
         return context.cacheDir.listFiles()?.filter {
-            it.name.startsWith("MaaMeow-") && (it.name.endsWith(".apk") || it.name.endsWith(".apk.dl"))
+            it.name.startsWith("MaaMeow-") && (it.name.endsWith(".apk") || (includeDownloading && it.name.endsWith(".apk.dl")))
         }
     }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/data/datasource/AppDownloader.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/datasource/AppDownloader.kt
@@ -1,6 +1,7 @@
 package com.aliothmoon.maameow.data.datasource
 
 import android.content.Context
+import com.aliothmoon.maameow.BuildConfig
 import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.data.api.HttpClientHelper
 import com.aliothmoon.maameow.data.api.await
@@ -92,11 +93,25 @@ class AppDownloader(
      */
     fun cleanOldApks(keepVersion: String) {
         val keepName = apkFileName(keepVersion)
-        listCachedApks()?.filter { it.name != keepName }?.forEach { it.delete() }
+        context.cacheDir.listFiles()?.filter {
+            it.name.startsWith("MaaMeow-") && (it.name.endsWith(".apk") || it.name.endsWith(
+                ".apk.dl"
+            ))
+        }?.filter { it.name != keepName }?.forEach { it.delete() }
     }
 
-    fun cleanCachedInstalledApks() {
-        listCachedApks(includeDownloading = false)?.forEach { it.delete() }
+
+    fun cleanInstalledApks() {
+        val current = BuildConfig.VERSION_NAME
+        context.cacheDir.listFiles()
+            ?.filter {
+                if (!it.name.startsWith("MaaMeow-") || !it.name.endsWith(".apk")) {
+                    return@filter false
+                }
+                val version = it.name.removePrefix("MaaMeow-").removeSuffix(".apk")
+                compareVersions(version, current) <= 0
+            }
+            ?.forEach { it.delete() }
     }
 
     suspend fun downloadToTempFile(
@@ -172,10 +187,4 @@ class AppDownloader(
     }
 
     private fun apkFileName(version: String): String = "MaaMeow-${version}.apk"
-
-    private fun listCachedApks(includeDownloading: Boolean = true): List<File>? {
-        return context.cacheDir.listFiles()?.filter {
-            it.name.startsWith("MaaMeow-") && (it.name.endsWith(".apk") || (includeDownloading && it.name.endsWith(".apk.dl")))
-        }
-    }
 }


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)。

## 关联 Issue

群友反馈更新后不及时清理apk文件导致存储空间额外占用

## 变更摘要

应用启动时异步清理缓存目录中的更新 APK 文件，避免旧安装包长期占用空间。
AppDownloader 新增统一的缓存 APK 列表方法，用于匹配 MaaMeow-*.apk 和 MaaMeow-*.apk.dl。
原有 cleanOldApks(keepVersion) 复用统一列表逻辑，仍保留指定版本并删除其它缓存更新包。
## 验证

<!-- 请写清楚设备、系统版本、权限方案、执行命令或操作路径。不要只写“已测试”。 -->

## 截图 / 日志 / 说明

<!-- 涉及 UI、权限、后台服务、任务执行或 Bug 修复时，请提供截图、Logcat、Actions 链接或复现步骤。 -->

## Checklist

- [ ] 我已阅读并遵守 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)

## Summary by Sourcery

在应用启动时以异步方式清理缓存的 MaaMeow 更新 APK，以防止过时的安装包占用存储空间。

新功能：
- 在应用程序启动时触发异步清理缓存的 MaaMeow 更新 APK 文件。

改进：
- 引入共享的应用级协程作用域，用于执行 APK 缓存清理、定时闹钟重同步等后台任务。
- 优化 APK 缓存清理逻辑，根据当前应用版本移除已安装或更旧的 MaaMeow APK。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up cached MaaMeow update APKs asynchronously on app startup to prevent outdated installers from occupying storage.

New Features:
- Trigger asynchronous cleanup of cached MaaMeow update APK files when the application starts.

Enhancements:
- Introduce a shared application-level coroutine scope for background tasks such as APK cache cleanup and schedule alarm resynchronization.
- Refine APK cache cleanup logic to remove installed or older MaaMeow APKs based on the current app version.

</details>

新功能：
- 在应用启动时触发异步清理已缓存的 MaaMeow 更新 APK 文件。

改进：
- 重构 APK 缓存处理逻辑，引入共享的辅助工具，用于列出已缓存的 MaaMeow APK 和下载文件，并在现有的清理逻辑中复用该工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在应用启动时以异步方式清理缓存的 MaaMeow 更新 APK，以防止过时的安装包占用存储空间。

新功能：
- 在应用程序启动时触发异步清理缓存的 MaaMeow 更新 APK 文件。

改进：
- 引入共享的应用级协程作用域，用于执行 APK 缓存清理、定时闹钟重同步等后台任务。
- 优化 APK 缓存清理逻辑，根据当前应用版本移除已安装或更旧的 MaaMeow APK。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up cached MaaMeow update APKs asynchronously on app startup to prevent outdated installers from occupying storage.

New Features:
- Trigger asynchronous cleanup of cached MaaMeow update APK files when the application starts.

Enhancements:
- Introduce a shared application-level coroutine scope for background tasks such as APK cache cleanup and schedule alarm resynchronization.
- Refine APK cache cleanup logic to remove installed or older MaaMeow APKs based on the current app version.

</details>

</details>