### PR TITLE
feat: 允许自定义壁纸

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -579,4 +579,68 @@ class AppSettingsManager(
         }
     }
 
+    // ============ 自定义图片背景（仅四个主 Tab 生效）============
+
+    /** 将 0~100 的原始字符串解析为合法百分比 */
+    private fun parsePercent(raw: String, default: Int): Int =
+        raw.toIntOrNull()?.coerceIn(0, 100) ?: default
+
+    val customBackgroundEnabled: StateFlow<Boolean> = settings
+        .map { it.customBackgroundEnabled.toBooleanStrictOrNull() ?: false }
+        .distinctUntilChanged()
+        .stateIn(
+            scope, SharingStarted.Eagerly,
+            initialSettings.customBackgroundEnabled.toBooleanStrictOrNull() ?: false
+        )
+
+    suspend fun setCustomBackgroundEnabled(enabled: Boolean) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[customBackgroundEnabled] = enabled.toString() }
+        }
+    }
+
+    val customBackgroundToken: StateFlow<String> = settings
+        .map { it.customBackgroundToken }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.customBackgroundToken)
+
+    suspend fun setCustomBackgroundToken(token: String) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[customBackgroundToken] = token }
+        }
+    }
+
+    val customBackgroundImageAlpha: StateFlow<Int> = settings
+        .map { parsePercent(it.customBackgroundImageAlpha, 80) }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, parsePercent(initialSettings.customBackgroundImageAlpha, 80))
+
+    suspend fun setCustomBackgroundImageAlpha(value: Int) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[customBackgroundImageAlpha] = value.coerceIn(0, 100).toString() }
+        }
+    }
+
+    val customBackgroundScrim: StateFlow<Int> = settings
+        .map { parsePercent(it.customBackgroundScrim, 25) }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, parsePercent(initialSettings.customBackgroundScrim, 25))
+
+    suspend fun setCustomBackgroundScrim(value: Int) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[customBackgroundScrim] = value.coerceIn(0, 100).toString() }
+        }
+    }
+
+    val customBackgroundBlur: StateFlow<Int> = settings
+        .map { parsePercent(it.customBackgroundBlur, 0) }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, parsePercent(initialSettings.customBackgroundBlur, 0))
+
+    suspend fun setCustomBackgroundBlur(value: Int) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[customBackgroundBlur] = value.coerceIn(0, 100).toString() }
+        }
+    }
+
 }

--- a/app/src/main/java/com/aliothmoon/maameow/data/resource/BackgroundImageStore.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/resource/BackgroundImageStore.kt
@@ -1,0 +1,142 @@
+package com.aliothmoon.maameow.data.resource
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import com.aliothmoon.maameow.data.preferences.AppSettingsManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+
+/**
+ * 自定义主界面背景图的单一数据源。
+ *
+ * 职责：
+ * - [importFromUri]：把用户选中的图片降采样后复制到 filesDir/backgrounds/bg.jpg，并更新令牌触发重载；
+ * - [clear]：删除文件并关闭背景；
+ * - [imageBitmap]：监听「启用状态 + 令牌」，在 IO 线程解码并缓存为 [ImageBitmap]，供主界面绘制。
+ *
+ * 只负责数据与解码，不含任何 UI；玻璃主题与遮罩绘制在 presentation/theme 层完成。
+ */
+class BackgroundImageStore(
+    private val context: Context,
+    private val appSettingsManager: AppSettingsManager,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val backgroundsDir: File
+        get() = File(context.filesDir, DIR_NAME)
+
+    private val backgroundFile: File
+        get() = File(backgroundsDir, BG_FILE_NAME)
+
+    /** 当前生效的背景位图；未启用或无文件时为 null。 */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val imageBitmap: StateFlow<ImageBitmap?> =
+        combine(
+            appSettingsManager.customBackgroundEnabled,
+            appSettingsManager.customBackgroundToken,
+        ) { enabled, token -> enabled to token }
+            .distinctUntilChanged()
+            .mapLatest { (enabled, _) -> if (enabled) loadBitmap() else null }
+            .flowOn(Dispatchers.IO)
+            .stateIn(scope, SharingStarted.Eagerly, null)
+
+    /** 背景图不透明度 0f~1f。 */
+    val imageAlpha: StateFlow<Float> = appSettingsManager.customBackgroundImageAlpha
+        .map { it / 100f }
+        .stateIn(scope, SharingStarted.Eagerly, appSettingsManager.customBackgroundImageAlpha.value / 100f)
+
+    /** 遮罩强度 0f~1f。 */
+    val scrimAlpha: StateFlow<Float> = appSettingsManager.customBackgroundScrim
+        .map { it / 100f }
+        .stateIn(scope, SharingStarted.Eagerly, appSettingsManager.customBackgroundScrim.value / 100f)
+
+    /** 模糊强度 0f~1f（由 UI 层换算为 dp，仅 API 31+ 生效）。 */
+    val blurFraction: StateFlow<Float> = appSettingsManager.customBackgroundBlur
+        .map { it / 100f }
+        .stateIn(scope, SharingStarted.Eagerly, appSettingsManager.customBackgroundBlur.value / 100f)
+
+    /**
+     * 从相册选中的 [uri] 导入背景图：降采样到屏幕分辨率后另存为 JPEG，成功后更新令牌并启用。
+     */
+    suspend fun importFromUri(uri: Uri): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val dir = backgroundsDir.apply { mkdirs() }
+            val tmp = File(dir, "bg_tmp")
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                tmp.outputStream().use { output -> input.copyTo(output) }
+            } ?: error("无法读取所选图片")
+
+            val dm = context.resources.displayMetrics
+            val scaled = decodeScaled(tmp, dm.widthPixels, dm.heightPixels)
+                ?: run { tmp.delete(); error("图片解码失败") }
+
+            backgroundFile.outputStream().use { out ->
+                scaled.compress(Bitmap.CompressFormat.JPEG, 90, out)
+            }
+            scaled.recycle()
+            tmp.delete()
+
+            appSettingsManager.setCustomBackgroundToken(System.currentTimeMillis().toString())
+            appSettingsManager.setCustomBackgroundEnabled(true)
+        }.onFailure { Timber.e(it, "importFromUri failed") }
+    }
+
+    /** 关闭并清除自定义背景。 */
+    suspend fun clear() = withContext(Dispatchers.IO) {
+        appSettingsManager.setCustomBackgroundEnabled(false)
+        runCatching { backgroundFile.delete() }
+        appSettingsManager.setCustomBackgroundToken("")
+    }
+
+    private fun loadBitmap(): ImageBitmap? {
+        val dm = context.resources.displayMetrics
+        val bmp = decodeScaled(backgroundFile, dm.widthPixels, dm.heightPixels) ?: return null
+        return bmp.asImageBitmap()
+    }
+
+    private fun decodeScaled(file: File, reqWidth: Int, reqHeight: Int): Bitmap? {
+        if (!file.exists() || file.length() == 0L) return null
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(file.absolutePath, bounds)
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+
+        val opts = BitmapFactory.Options().apply {
+            inSampleSize = calcInSampleSize(bounds.outWidth, bounds.outHeight, reqWidth, reqHeight)
+            inPreferredConfig = Bitmap.Config.ARGB_8888
+        }
+        return BitmapFactory.decodeFile(file.absolutePath, opts)
+    }
+
+    private fun calcInSampleSize(width: Int, height: Int, reqWidth: Int, reqHeight: Int): Int {
+        if (reqWidth <= 0 || reqHeight <= 0) return 1
+        var sample = 1
+        var halfW = width / 2
+        var halfH = height / 2
+        while (halfW / sample >= reqWidth && halfH / sample >= reqHeight) {
+            sample *= 2
+        }
+        return sample.coerceAtLeast(1)
+    }
+
+    companion object {
+        private const val DIR_NAME = "backgrounds"
+        private const val BG_FILE_NAME = "bg.jpg"
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -88,4 +88,22 @@ data class AppSettings(
 
     /** 是否显示成就解锁时的 Snackbar 提示 */
     @PrefKey(default = "true") val showAchievementSnackbar: String = "true",
+
+    /** 是否启用主界面自定义图片背景（仅四个主 Tab 生效） */
+    @PrefKey(default = "false") val customBackgroundEnabled: String = "false",
+
+    /**
+     * 自定义背景图变更令牌（时间戳）。换图即变，用于触发 BackgroundImageStore 重新解码；
+     * 图片文件固定存放在 filesDir/backgrounds/bg.jpg，路径本身无需持久化。
+     */
+    @PrefKey(default = "") val customBackgroundToken: String = "",
+
+    /** 背景图不透明度 0~100（默认 80） */
+    @PrefKey(default = "80") val customBackgroundImageAlpha: String = "80",
+
+    /** 背景遮罩强度 0~100（默认 25，用于保证前景文字可读性） */
+    @PrefKey(default = "25") val customBackgroundScrim: String = "25",
+
+    /** 背景模糊强度 0~100（默认 0，仅 API 31+ 生效） */
+    @PrefKey(default = "0") val customBackgroundBlur: String = "0",
 )

--- a/app/src/main/java/com/aliothmoon/maameow/koin/AppModule.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/koin/AppModule.kt
@@ -31,6 +31,7 @@ import com.aliothmoon.maameow.data.preferences.ConfigBackupManager
 import com.aliothmoon.maameow.data.preferences.TaskChainState
 import com.aliothmoon.maameow.data.repository.CopilotRepository
 import com.aliothmoon.maameow.data.resource.ActivityManager
+import com.aliothmoon.maameow.data.resource.BackgroundImageStore
 import com.aliothmoon.maameow.data.resource.CopilotResourceProvider
 import com.aliothmoon.maameow.data.resource.ItemHelper
 import com.aliothmoon.maameow.data.resource.ItemIconLoader
@@ -99,6 +100,7 @@ val appModule = module {
 
 
     singleOf(::AppSettingsManager)
+    singleOf(::BackgroundImageStore)
     singleOf(::AchievementRepository)
     singleOf(::AchievementReporter)
     singleOf(::ScheduleStrategyRepository)

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/AdaptiveTaskPromptDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/AdaptiveTaskPromptDialog.kt
@@ -1,18 +1,19 @@
 package com.aliothmoon.maameow.presentation.components
 
+import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
-import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -21,7 +22,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
@@ -45,19 +45,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
-import com.aliothmoon.maameow.R
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.presentation.LocalFloatingWindowContext
+import com.aliothmoon.maameow.theme.OpaqueTheme
 
 /** 普通提示弹窗的最大宽度上限（手机按比例、平板/宽屏封顶） */
 private val DialogMaxWidth = 400.dp
@@ -101,47 +102,50 @@ fun AdaptiveTaskPromptDialog(
 ) {
     if (!visible) return
 
-    val resolvedConfirmColor = confirmColor ?: MaterialTheme.colorScheme.primary
-    val resolvedIconTint = iconTint ?: resolvedConfirmColor
-    val resolvedConfirmText = confirmText ?: stringResource(R.string.common_confirm)
-    val resolvedDismissText = dismissText ?: stringResource(R.string.common_cancel)
+    // 弹窗在独立窗口内呈现，不应透出主界面自定义背景图：在玻璃作用域内恢复不透明配色。
+    OpaqueTheme {
+        val resolvedConfirmColor = confirmColor ?: MaterialTheme.colorScheme.primary
+        val resolvedIconTint = iconTint ?: resolvedConfirmColor
+        val resolvedConfirmText = confirmText ?: stringResource(R.string.common_confirm)
+        val resolvedDismissText = dismissText ?: stringResource(R.string.common_cancel)
 
-    if (LocalFloatingWindowContext.current) {
-        FloatingTaskPromptDialog(
-            title = title,
-            message = message,
-            onDismissRequest = onDismissRequest,
-            onConfirm = onConfirm,
-            confirmText = resolvedConfirmText,
-            dismissText = resolvedDismissText,
-            neutralText = neutralText,
-            onNeutralClick = onNeutralClick,
-            icon = icon,
-            iconTint = resolvedIconTint,
-            confirmColor = resolvedConfirmColor,
-            buttonLayout = buttonLayout,
-            dismissOnOutsideClick = dismissOnOutsideClick,
-            landscapeAdaptive = landscapeAdaptive,
-            content = content
-        )
-    } else {
-        MaterialTaskPromptDialog(
-            title = title,
-            message = message,
-            onDismissRequest = onDismissRequest,
-            onConfirm = onConfirm,
-            confirmText = resolvedConfirmText,
-            dismissText = resolvedDismissText,
-            neutralText = neutralText,
-            onNeutralClick = onNeutralClick,
-            icon = icon,
-            iconTint = resolvedIconTint,
-            confirmColor = resolvedConfirmColor,
-            buttonLayout = buttonLayout,
-            dismissOnOutsideClick = dismissOnOutsideClick,
-            landscapeAdaptive = landscapeAdaptive,
-            content = content
-        )
+        if (LocalFloatingWindowContext.current) {
+            FloatingTaskPromptDialog(
+                title = title,
+                message = message,
+                onDismissRequest = onDismissRequest,
+                onConfirm = onConfirm,
+                confirmText = resolvedConfirmText,
+                dismissText = resolvedDismissText,
+                neutralText = neutralText,
+                onNeutralClick = onNeutralClick,
+                icon = icon,
+                iconTint = resolvedIconTint,
+                confirmColor = resolvedConfirmColor,
+                buttonLayout = buttonLayout,
+                dismissOnOutsideClick = dismissOnOutsideClick,
+                landscapeAdaptive = landscapeAdaptive,
+                content = content
+            )
+        } else {
+            MaterialTaskPromptDialog(
+                title = title,
+                message = message,
+                onDismissRequest = onDismissRequest,
+                onConfirm = onConfirm,
+                confirmText = resolvedConfirmText,
+                dismissText = resolvedDismissText,
+                neutralText = neutralText,
+                onNeutralClick = onNeutralClick,
+                icon = icon,
+                iconTint = resolvedIconTint,
+                confirmColor = resolvedConfirmColor,
+                buttonLayout = buttonLayout,
+                dismissOnOutsideClick = dismissOnOutsideClick,
+                landscapeAdaptive = landscapeAdaptive,
+                content = content
+            )
+        }
     }
 }
 
@@ -304,7 +308,10 @@ private fun TaskPromptCard(
     val scrollState = rememberScrollState()
 
     Surface(
-        modifier = modifier.fillMaxWidth().wrapContentHeight().heightIn(max = screenHeight * 0.85f),
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .heightIn(max = screenHeight * 0.85f),
         shape = RoundedCornerShape(8.dp),
         color = MaterialTheme.colorScheme.surface,
         contentColor = MaterialTheme.colorScheme.onSurface,
@@ -361,7 +368,11 @@ private fun TaskPromptCard(
                             onClick = onConfirm,
                             contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
                         ) {
-                            Text(confirmText, maxLines = 1, style = MaterialTheme.typography.bodySmall)
+                            Text(
+                                confirmText,
+                                maxLines = 1,
+                                style = MaterialTheme.typography.bodySmall
+                            )
                         }
                         dismissText?.takeIf { it.isNotBlank() }?.let {
                             TextButton(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/ResourceInitDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/ResourceInitDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.domain.state.ResourceInitState
+import com.aliothmoon.maameow.theme.OpaqueTheme
 import com.aliothmoon.maameow.utils.i18n.asString
 
 /**
@@ -38,65 +39,67 @@ fun ResourceInitDialog(
 
     when (state) {
         is ResourceInitState.Extracting -> {
-            // 解压进度弹窗（不可关闭）
-            Dialog(
-                onDismissRequest = {},
-                properties = DialogProperties(
-                    dismissOnBackPress = false,
-                    dismissOnClickOutside = false
-                )
-            ) {
-                Surface(
-                    shape = RoundedCornerShape(8.dp),
-                    color = MaterialTheme.colorScheme.surface,
-                    tonalElevation = 6.dp
+            // 解压进度弹窗（不可关闭）——恢复不透明配色，避免透出主界面自定义背景图
+            OpaqueTheme {
+                Dialog(
+                    onDismissRequest = {},
+                    properties = DialogProperties(
+                        dismissOnBackPress = false,
+                        dismissOnClickOutside = false
+                    )
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(24.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
+                    Surface(
+                        shape = RoundedCornerShape(8.dp),
+                        color = MaterialTheme.colorScheme.surface,
+                        tonalElevation = 6.dp
                     ) {
-                        Text(
-                            text = stringResource(R.string.resource_init_in_progress_title),
-                            style = MaterialTheme.typography.titleMedium
-                        )
-
-                        Spacer(modifier = Modifier.height(24.dp))
-
-                        // 进度条
-                        LinearProgressIndicator(
-                            progress = { state.progress / 100f },
-                            modifier = Modifier.fillMaxWidth()
-                        )
-
-                        Spacer(modifier = Modifier.height(12.dp))
-
-                        // 进度文本
-                        Text(
-                            text = "${state.extractedCount} / ${state.totalCount} (${state.progress}%)",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-
-                        if (state.currentFile.isNotEmpty()) {
-                            Spacer(modifier = Modifier.height(4.dp))
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(24.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
                             Text(
-                                text = state.currentFile,
+                                text = stringResource(R.string.resource_init_in_progress_title),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+
+                            Spacer(modifier = Modifier.height(24.dp))
+
+                            // 进度条
+                            LinearProgressIndicator(
+                                progress = { state.progress / 100f },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+
+                            Spacer(modifier = Modifier.height(12.dp))
+
+                            // 进度文本
+                            Text(
+                                text = "${state.extractedCount} / ${state.totalCount} (${state.progress}%)",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+
+                            if (state.currentFile.isNotEmpty()) {
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = state.currentFile,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                                    maxLines = 1
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            Text(
+                                text = stringResource(R.string.resource_init_in_progress_message),
                                 style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-                                maxLines = 1
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                textAlign = TextAlign.Center
                             )
                         }
-
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        Text(
-                            text = stringResource(R.string.resource_init_in_progress_message),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            textAlign = TextAlign.Center
-                        )
                     }
                 }
             }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/MainScreen.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/MainScreen.kt
@@ -7,10 +7,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
@@ -18,13 +22,18 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.aliothmoon.maameow.constant.Routes
+import com.aliothmoon.maameow.data.resource.BackgroundImageStore
 import com.aliothmoon.maameow.presentation.view.background.BackgroundTaskView
 import com.aliothmoon.maameow.presentation.view.home.HomeView
 import com.aliothmoon.maameow.presentation.view.settings.SettingsView
 import com.aliothmoon.maameow.presentation.viewmodel.BackgroundTaskViewModel
 import com.aliothmoon.maameow.schedule.ui.ScheduleListView
 import com.aliothmoon.maameow.theme.MaaAnimations
+import com.aliothmoon.maameow.theme.MaaBackgroundHost
+import com.aliothmoon.maameow.theme.MaxBackgroundBlur
+import com.aliothmoon.maameow.theme.toGlass
 import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
 import kotlin.math.abs
 
 
@@ -71,59 +80,92 @@ fun MainScreen(
         }
     }
 
-    Scaffold(
-        modifier = modifier,
-        bottomBar = {
-            if (visible && !fullscreen) {
-                AppBottomNavigation(
-                    currentRoute = BottomNavTab.all[pagerState.targetPage].route,
-                    onTabSelected = { tab -> goToPage(BottomNavTab.all.indexOf(tab)) },
-                )
-            }
-        },
-    ) { paddingValues ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = paddingValues.calculateBottomPadding())
-                .graphicsLayer {
-                    // 隐藏时跳过绘制但保留组合树，避免 HorizontalPager 状态丢失
-                    alpha = if (visible) 1f else 0f
-                },
-        ) {
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier.fillMaxSize(),
-                key = { BottomNavTab.all[it].route },
-                userScrollEnabled = visible && !fullscreen,
-            ) { page ->
-                when (BottomNavTab.all[page]) {
-                    BottomNavTab.HOME -> HomeView(navController = navController)
-                    BottomNavTab.BACKGROUND -> BackgroundTaskView(
-                        viewModel = backgroundTaskViewModel,
-                    )
+    // 自定义图片背景（仅四个主 Tab 生效）：启用时切换玻璃配色并在 Scaffold 之下绘制背景图。
+    val backgroundStore: BackgroundImageStore = koinInject()
+    val bgImage by backgroundStore.imageBitmap.collectAsStateWithLifecycle()
+    val bgImageAlpha by backgroundStore.imageAlpha.collectAsStateWithLifecycle()
+    val bgScrimAlpha by backgroundStore.scrimAlpha.collectAsStateWithLifecycle()
+    val bgBlurFraction by backgroundStore.blurFraction.collectAsStateWithLifecycle()
 
-                    BottomNavTab.SCHEDULE -> ScheduleListView(navController = navController)
-                    BottomNavTab.SETTINGS -> SettingsView(
-                        navController = navController,
-                        onViewAnnouncement = onViewAnnouncement,
+    val mainContent: @Composable () -> Unit = {
+        Scaffold(
+            modifier = modifier,
+            bottomBar = {
+                if (visible && !fullscreen) {
+                    AppBottomNavigation(
+                        currentRoute = BottomNavTab.all[pagerState.targetPage].route,
+                        onTabSelected = { tab -> goToPage(BottomNavTab.all.indexOf(tab)) },
                     )
                 }
-            }
+            },
+        ) { paddingValues ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = paddingValues.calculateBottomPadding())
+                    .graphicsLayer {
+                        // 隐藏时跳过绘制但保留组合树，避免 HorizontalPager 状态丢失
+                        alpha = if (visible) 1f else 0f
+                    },
+            ) {
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = Modifier.fillMaxSize(),
+                    key = { BottomNavTab.all[it].route },
+                    userScrollEnabled = visible && !fullscreen,
+                ) { page ->
+                    when (BottomNavTab.all[page]) {
+                        BottomNavTab.HOME -> HomeView(navController = navController)
+                        BottomNavTab.BACKGROUND -> BackgroundTaskView(
+                            viewModel = backgroundTaskViewModel,
+                        )
 
-            // 隐藏（子页面叠加其上）时吞掉所有指针，防止横滑切走主 Tab / 点击穿透到底层页。
-            if (!visible) {
-                Box(
-                    Modifier
-                        .matchParentSize()
-                        .pointerInput(Unit) {
-                            awaitPointerEventScope {
-                                while (true) {
-                                    awaitPointerEvent().changes.forEach { it.consume() }
+                        BottomNavTab.SCHEDULE -> ScheduleListView(navController = navController)
+                        BottomNavTab.SETTINGS -> SettingsView(
+                            navController = navController,
+                            onViewAnnouncement = onViewAnnouncement,
+                        )
+                    }
+                }
+
+                // 隐藏（子页面叠加其上）时吞掉所有指针，防止横滑切走主 Tab / 点击穿透到底层页。
+                if (!visible) {
+                    Box(
+                        Modifier
+                            .matchParentSize()
+                            .pointerInput(Unit) {
+                                awaitPointerEventScope {
+                                    while (true) {
+                                        awaitPointerEvent().changes.forEach { it.consume() }
+                                    }
                                 }
-                            }
-                        })
+                            })
+                }
             }
         }
+    }
+
+    val image = bgImage
+    if (image != null) {
+        val baseScheme = MaterialTheme.colorScheme
+        val glassScheme = remember(baseScheme) { baseScheme.toGlass() }
+        MaterialTheme(
+            colorScheme = glassScheme,
+            typography = MaterialTheme.typography,
+            shapes = MaterialTheme.shapes,
+        ) {
+            CompositionLocalProvider(LocalContentColor provides glassScheme.onSurface) {
+                MaaBackgroundHost(
+                    image = image,
+                    imageAlpha = bgImageAlpha,
+                    scrimColor = baseScheme.background,
+                    scrimAlpha = bgScrimAlpha,
+                    blurRadius = MaxBackgroundBlur * bgBlurFraction,
+                    content = mainContent,
+                )
+            }
+        }
+    } else {
+        mainContent()
     }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -5,10 +5,12 @@ import android.content.Intent
 import android.os.Build
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -28,8 +30,10 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Build
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
@@ -48,6 +52,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -121,11 +127,20 @@ fun SettingsView(
     val fontSizeScale by viewModel.fontSizeScale.collectAsStateWithLifecycle()
     val showAchievementSnackbar by viewModel.showAchievementSnackbar.collectAsStateWithLifecycle()
     val backgroundResolution by viewModel.backgroundResolution.collectAsStateWithLifecycle()
+    val customBackgroundEnabled by viewModel.customBackgroundEnabled.collectAsStateWithLifecycle()
+    val customBackgroundImageAlpha by viewModel.customBackgroundImageAlpha.collectAsStateWithLifecycle()
+    val customBackgroundScrim by viewModel.customBackgroundScrim.collectAsStateWithLifecycle()
+    val customBackgroundBlur by viewModel.customBackgroundBlur.collectAsStateWithLifecycle()
+    val backgroundImage by viewModel.backgroundImage.collectAsStateWithLifecycle()
     val language by viewModel.language.collectAsStateWithLifecycle()
     val backupMessage by viewModel.backupMessage.collectAsStateWithLifecycle()
     val showRestartDialog by viewModel.showRestartDialog.collectAsStateWithLifecycle()
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
+
+    val pickBackgroundLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri -> uri?.let { viewModel.onPickBackgroundImage(it) } }
 
     val exportLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.CreateDocument("application/json")
@@ -421,7 +436,8 @@ fun SettingsView(
                         navController.navigate("error_log")
                     }
                     ListItemDivider()
-                    val logExportChooserTitle = stringResource(R.string.settings_log_export_chooser_title)
+                    val logExportChooserTitle =
+                        stringResource(R.string.settings_log_export_chooser_title)
                     SettingClickItem(
                         title = stringResource(R.string.settings_log_export_title),
                         description = stringResource(R.string.settings_log_export_desc),
@@ -430,7 +446,12 @@ fun SettingsView(
                         coroutineScope.launch {
                             val intent = logExportService.exportAllLogs()
                             if (intent != null) {
-                                context.startActivity(Intent.createChooser(intent, logExportChooserTitle))
+                                context.startActivity(
+                                    Intent.createChooser(
+                                        intent,
+                                        logExportChooserTitle
+                                    )
+                                )
                             }
                         }
                     }
@@ -470,6 +491,25 @@ fun SettingsView(
                         fontSizeScale = fontSizeScale,
                         onFontSizeScaleChanged = { viewModel.setFontSizeScale(it) }
                     )
+                    ListItemDivider()
+                    SettingCustomBackgroundSection(
+                        contentColor = contentColor,
+                        enabled = customBackgroundEnabled,
+                        previewImage = backgroundImage,
+                        imageAlpha = customBackgroundImageAlpha,
+                        scrim = customBackgroundScrim,
+                        blur = customBackgroundBlur,
+                        onEnabledChange = { viewModel.setCustomBackgroundEnabled(it) },
+                        onPickImage = {
+                            pickBackgroundLauncher.launch(
+                                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                            )
+                        },
+                        onRemoveImage = { viewModel.removeBackgroundImage() },
+                        onImageAlphaChange = { viewModel.setCustomBackgroundImageAlpha(it) },
+                        onScrimChange = { viewModel.setCustomBackgroundScrim(it) },
+                        onBlurChange = { viewModel.setCustomBackgroundBlur(it) },
+                    )
                 }
             }
 
@@ -502,14 +542,15 @@ fun SettingsView(
                                     context,
                                     shizukuLaunchPackage
                                 )
-                                val shizukuLaunchAppDescription = if (shizukuLaunchPackage == OFFICIAL_SHIZUKU_PACKAGE) {
-                                    stringResource(R.string.settings_shizuku_launch_app_default_desc)
-                                } else {
-                                    stringResource(
-                                        R.string.settings_shizuku_launch_app_selected_desc,
-                                        shizukuLaunchAppName ?: shizukuLaunchPackage
-                                    )
-                                }
+                                val shizukuLaunchAppDescription =
+                                    if (shizukuLaunchPackage == OFFICIAL_SHIZUKU_PACKAGE) {
+                                        stringResource(R.string.settings_shizuku_launch_app_default_desc)
+                                    } else {
+                                        stringResource(
+                                            R.string.settings_shizuku_launch_app_selected_desc,
+                                            shizukuLaunchAppName ?: shizukuLaunchPackage
+                                        )
+                                    }
                                 SettingClickItem(
                                     title = stringResource(R.string.settings_shizuku_launch_app_title),
                                     description = shizukuLaunchAppDescription,
@@ -715,7 +756,10 @@ fun SettingsView(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
-                                Misc.openUriSafely(context, "https://github.com/Aliothmoon/MAA-Meow")
+                                Misc.openUriSafely(
+                                    context,
+                                    "https://github.com/Aliothmoon/MAA-Meow"
+                                )
                             }
                             .padding(vertical = MaaDesignTokens.Spacing.listItemVertical),
                         textAlign = TextAlign.Center
@@ -838,6 +882,145 @@ private fun SettingClickItem(
  * 松手后才提交全局缩放。滑块下方带实时预览框。
  */
 @Composable
+private fun SettingCustomBackgroundSection(
+    contentColor: Color,
+    enabled: Boolean,
+    previewImage: ImageBitmap?,
+    imageAlpha: Int,
+    scrim: Int,
+    blur: Int,
+    onEnabledChange: (Boolean) -> Unit,
+    onPickImage: () -> Unit,
+    onRemoveImage: () -> Unit,
+    onImageAlphaChange: (Int) -> Unit,
+    onScrimChange: (Int) -> Unit,
+    onBlurChange: (Int) -> Unit,
+) {
+    val hasImage = previewImage != null
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = MaaDesignTokens.Spacing.listItemVertical),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.settings_background_title),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = contentColor
+                )
+                Text(
+                    text = stringResource(R.string.settings_background_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = contentColor.copy(alpha = 0.6f)
+                )
+            }
+            Switch(checked = enabled, onCheckedChange = onEnabledChange)
+        }
+
+        AnimatedVisibility(
+            visible = enabled,
+            enter = expandVertically(),
+            exit = shrinkVertically()
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                if (previewImage != null) {
+                    Image(
+                        bitmap = previewImage,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(120.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                    )
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = onPickImage, modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(
+                                if (hasImage) R.string.settings_background_replace
+                                else R.string.settings_background_pick
+                            )
+                        )
+                    }
+                    if (hasImage) {
+                        OutlinedButton(onClick = onRemoveImage, modifier = Modifier.weight(1f)) {
+                            Text(text = stringResource(R.string.settings_background_remove))
+                        }
+                    }
+                }
+                if (hasImage) {
+                    BackgroundPercentSlider(
+                        label = stringResource(R.string.settings_background_image_alpha),
+                        value = imageAlpha,
+                        contentColor = contentColor,
+                        onValueChange = onImageAlphaChange
+                    )
+                    BackgroundPercentSlider(
+                        label = stringResource(R.string.settings_background_scrim),
+                        value = scrim,
+                        contentColor = contentColor,
+                        onValueChange = onScrimChange
+                    )
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        BackgroundPercentSlider(
+                            label = stringResource(R.string.settings_background_blur),
+                            value = blur,
+                            contentColor = contentColor,
+                            onValueChange = onBlurChange
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BackgroundPercentSlider(
+    label: String,
+    value: Int,
+    contentColor: Color,
+    onValueChange: (Int) -> Unit,
+) {
+    var sliderValue by remember { mutableStateOf(value.toFloat()) }
+    LaunchedEffect(value) { sliderValue = value.toFloat() }
+    val current = sliderValue.roundToInt().coerceIn(0, 100)
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = contentColor,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = "$current%",
+                style = MaterialTheme.typography.bodyMedium,
+                color = contentColor
+            )
+        }
+        Slider(
+            value = sliderValue,
+            onValueChange = { sliderValue = it },
+            onValueChangeFinished = {
+                onValueChange(sliderValue.roundToInt().coerceIn(0, 100))
+            },
+            valueRange = 0f..100f,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
 private fun FontSizeSetting(
     contentColor: Color,
     value: Int,
@@ -847,9 +1030,14 @@ private fun FontSizeSetting(
     LaunchedEffect(value) {
         sliderValue = value.toFloat()
     }
-    val current = sliderValue.roundToInt().coerceIn(AppSettingsManager.FONT_SIZE_SCALE_MIN, AppSettingsManager.FONT_SIZE_SCALE_MAX)
+    val current = sliderValue.roundToInt()
+        .coerceIn(AppSettingsManager.FONT_SIZE_SCALE_MIN, AppSettingsManager.FONT_SIZE_SCALE_MAX)
 
-    Column(modifier = Modifier.fillMaxWidth().padding(vertical = MaaDesignTokens.Spacing.listItemVertical)) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = MaaDesignTokens.Spacing.listItemVertical)
+    ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
@@ -877,10 +1065,12 @@ private fun FontSizeSetting(
             value = sliderValue,
             onValueChange = { sliderValue = it },
             onValueChangeFinished = {
-                onValueChange(sliderValue.roundToInt().coerceIn(
-                    AppSettingsManager.FONT_SIZE_SCALE_MIN,
-                    AppSettingsManager.FONT_SIZE_SCALE_MAX
-                ))
+                onValueChange(
+                    sliderValue.roundToInt().coerceIn(
+                        AppSettingsManager.FONT_SIZE_SCALE_MIN,
+                        AppSettingsManager.FONT_SIZE_SCALE_MAX
+                    )
+                )
             },
             valueRange = AppSettingsManager.FONT_SIZE_SCALE_MIN.toFloat()..AppSettingsManager.FONT_SIZE_SCALE_MAX.toFloat(),
             steps = 0,
@@ -890,7 +1080,12 @@ private fun FontSizeSetting(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            listOf(AppSettingsManager.FONT_SIZE_SCALE_MIN, 90, 100, AppSettingsManager.FONT_SIZE_SCALE_MAX).forEach { kp ->
+            listOf(
+                AppSettingsManager.FONT_SIZE_SCALE_MIN,
+                90,
+                100,
+                AppSettingsManager.FONT_SIZE_SCALE_MAX
+            ).forEach { kp ->
                 Text(
                     text = kp.toString(),
                     style = MaterialTheme.typography.labelSmall,
@@ -983,7 +1178,10 @@ private fun SettingChannelItem(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.rowTitleGap)) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.rowTitleGap)
+        ) {
             Text(
                 text = stringResource(R.string.settings_update_channel_title),
                 style = MaterialTheme.typography.bodyLarge,
@@ -1040,7 +1238,10 @@ private fun SettingBackgroundResolutionItem(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.rowTitleGap)) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.rowTitleGap)
+        ) {
             Text(
                 text = stringResource(R.string.settings_background_resolution_title),
                 style = MaterialTheme.typography.bodyLarge,
@@ -1152,7 +1353,10 @@ private fun SettingRemoteBackendItem(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.rowTitleGap)) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.rowTitleGap)
+        ) {
             Text(
                 text = stringResource(R.string.settings_startup_backend_title),
                 style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -1,7 +1,9 @@
 package com.aliothmoon.maameow.presentation.viewmodel
 
 import android.app.Application
+import android.net.Uri
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.aliothmoon.maameow.BuildConfig
@@ -12,6 +14,7 @@ import com.aliothmoon.maameow.data.model.update.UpdateChannel
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
 import com.aliothmoon.maameow.data.preferences.ConfigBackupManager
 import com.aliothmoon.maameow.data.preferences.TaskChainState
+import com.aliothmoon.maameow.data.resource.BackgroundImageStore
 import com.aliothmoon.maameow.data.resource.ResourceDataManager
 import com.aliothmoon.maameow.domain.models.RemoteBackend
 import com.aliothmoon.maameow.domain.service.AchievementReporter
@@ -42,6 +45,7 @@ class SettingsViewModel(
     private val resourceDataManager: ResourceDataManager,
     private val resourceLoader: MaaResourceLoader,
     private val achievementReporter: AchievementReporter,
+    private val backgroundImageStore: BackgroundImageStore,
 ) : ViewModel() {
 
     // ========== 导入导出 ==========
@@ -288,5 +292,40 @@ class SettingsViewModel(
         viewModelScope.launch {
             appSettingsManager.setShowAchievementSnackbar(enabled)
         }
+    }
+
+    // ============ 自定义图片背景 ============
+    val customBackgroundEnabled: StateFlow<Boolean> = appSettingsManager.customBackgroundEnabled
+    val customBackgroundImageAlpha: StateFlow<Int> = appSettingsManager.customBackgroundImageAlpha
+    val customBackgroundScrim: StateFlow<Int> = appSettingsManager.customBackgroundScrim
+    val customBackgroundBlur: StateFlow<Int> = appSettingsManager.customBackgroundBlur
+    val backgroundImage: StateFlow<ImageBitmap?> = backgroundImageStore.imageBitmap
+
+    fun setCustomBackgroundEnabled(enabled: Boolean) {
+        viewModelScope.launch { appSettingsManager.setCustomBackgroundEnabled(enabled) }
+    }
+
+    fun onPickBackgroundImage(uri: Uri) {
+        viewModelScope.launch {
+            backgroundImageStore.importFromUri(uri).onFailure {
+                _backupMessage.value = uiTextOf(R.string.settings_background_import_failed)
+            }
+        }
+    }
+
+    fun removeBackgroundImage() {
+        viewModelScope.launch { backgroundImageStore.clear() }
+    }
+
+    fun setCustomBackgroundImageAlpha(value: Int) {
+        viewModelScope.launch { appSettingsManager.setCustomBackgroundImageAlpha(value) }
+    }
+
+    fun setCustomBackgroundScrim(value: Int) {
+        viewModelScope.launch { appSettingsManager.setCustomBackgroundScrim(value) }
+    }
+
+    fun setCustomBackgroundBlur(value: Int) {
+        viewModelScope.launch { appSettingsManager.setCustomBackgroundBlur(value) }
     }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/theme/MaaBackground.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/theme/MaaBackground.kt
@@ -1,0 +1,59 @@
+package com.aliothmoon.maameow.theme
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/** 模糊滑块 100% 对应的最大模糊半径。 */
+val MaxBackgroundBlur: Dp = 24.dp
+
+/**
+ * 主界面自定义背景绘制层：全屏铺满背景图 → 遮罩 → 内容。
+ *
+ * 纯 UI，不含状态获取；由 MainScreen 注入位图与参数并包裹四个 Tab 的 Scaffold。
+ * [image] 为空时退化为直接渲染 [content]，无任何额外绘制。
+ *
+ * @param scrimColor 遮罩基色（一般取原始不透明 background），配合 [scrimAlpha] 提升前景可读性。
+ * @param blurRadius 模糊半径；仅 API 31+ 实际生效，低版本自动忽略。
+ */
+@Composable
+fun MaaBackgroundHost(
+    image: ImageBitmap?,
+    imageAlpha: Float,
+    scrimColor: Color,
+    scrimAlpha: Float,
+    blurRadius: Dp,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        if (image != null) {
+            Image(
+                bitmap = image,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                alpha = imageAlpha.coerceIn(0f, 1f),
+                modifier = Modifier
+                    .matchParentSize()
+                    .then(if (blurRadius > 0.dp) Modifier.blur(blurRadius) else Modifier),
+            )
+            if (scrimAlpha > 0f) {
+                Box(
+                    Modifier
+                        .matchParentSize()
+                        .background(scrimColor.copy(alpha = scrimAlpha.coerceIn(0f, 1f)))
+                )
+            }
+        }
+        content()
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/theme/Theme.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/theme/Theme.kt
@@ -2,11 +2,12 @@ package com.aliothmoon.maameow.theme
 
 import android.os.Build
 import androidx.compose.foundation.IndicationNodeFactory
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.darkColorScheme
@@ -16,11 +17,12 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
-import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.node.DelegatableNode
 import androidx.compose.ui.node.DrawModifierNode
-import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.platform.LocalContext
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
 
@@ -159,6 +161,55 @@ object MaaThemeAlphas {
     const val Medium = 0.74f
 }
 
+/**
+ * 保存启用玻璃背景前的「原始不透明」ColorScheme，供 [OpaqueTheme] 在弹窗中恢复。
+ * 由 [MaaMeowTheme] 统一下发；未进入 App 主题时为 null。
+ */
+val LocalOpaqueColorScheme = staticCompositionLocalOf<ColorScheme?> { null }
+
+/** 主界面自定义背景启用时，卡片/表面的默认不透明度（玻璃拟态）。 */
+const val GLASS_SURFACE_ALPHA = 0.82f
+
+/**
+ * 生成玻璃版配色：背景置透明（露出背景图），各 surface 族加透明度让卡片透出背景，
+ * 前景 on* 色保持不透明以保证文字清晰。
+ */
+fun ColorScheme.toGlass(surfaceAlpha: Float = GLASS_SURFACE_ALPHA): ColorScheme = copy(
+    background = Color.Transparent,
+    surface = surface.copy(alpha = surfaceAlpha),
+    surfaceVariant = surfaceVariant.copy(alpha = surfaceAlpha),
+    surfaceBright = surfaceBright.copy(alpha = surfaceAlpha),
+    surfaceDim = surfaceDim.copy(alpha = surfaceAlpha),
+    surfaceContainer = surfaceContainer.copy(alpha = surfaceAlpha),
+    surfaceContainerLowest = surfaceContainerLowest.copy(alpha = surfaceAlpha),
+    surfaceContainerLow = surfaceContainerLow.copy(alpha = surfaceAlpha),
+    surfaceContainerHigh = surfaceContainerHigh.copy(alpha = surfaceAlpha),
+    surfaceContainerHighest = surfaceContainerHighest.copy(alpha = surfaceAlpha),
+)
+
+/**
+ * 在玻璃背景作用域内恢复不透明配色的包装器。
+ *
+ * 用于弹窗（[com.aliothmoon.maameow.presentation.components.AdaptiveTaskPromptDialog] 等）——
+ * 它们在自身独立窗口内呈现，不应透出主界面背景图。若当前不处于玻璃作用域（[LocalOpaqueColorScheme] 为
+ * 空或与当前配色一致），则为无副作用的透传。
+ */
+@Composable
+fun OpaqueTheme(content: @Composable () -> Unit) {
+    val opaque = LocalOpaqueColorScheme.current
+    if (opaque == null || opaque === MaterialTheme.colorScheme) {
+        content()
+    } else {
+        MaterialTheme(
+            colorScheme = opaque,
+            typography = MaterialTheme.typography,
+            shapes = MaterialTheme.shapes,
+        ) {
+            CompositionLocalProvider(LocalContentColor provides opaque.onSurface, content = content)
+        }
+    }
+}
+
 @Composable
 fun MaaMeowTheme(
     themeMode: AppSettingsManager.ThemeMode = AppSettingsManager.ThemeMode.SYSTEM,
@@ -201,7 +252,8 @@ fun MaaMeowTheme(
     }
 
     CompositionLocalProvider(
-        LocalIndication provides NoIndication
+        LocalIndication provides NoIndication,
+        LocalOpaqueColorScheme provides colorScheme,
     ) {
         MaterialTheme(
             colorScheme = colorScheme,

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -63,6 +63,15 @@
     <string name="settings_font_size_title">Page Scale</string>
     <string name="settings_font_size_summary">Adjust page content size (80-110)</string>
     <string name="settings_font_size_preview_text">Who are you? Please support Pallas! (\'- \' )</string>
+    <string name="settings_background_title">Custom Background</string>
+    <string name="settings_background_desc">Set an image background for the four main tabs</string>
+    <string name="settings_background_pick">Choose Image</string>
+    <string name="settings_background_replace">Replace Image</string>
+    <string name="settings_background_remove">Remove</string>
+    <string name="settings_background_image_alpha">Image Opacity</string>
+    <string name="settings_background_scrim">Scrim</string>
+    <string name="settings_background_blur">Blur</string>
+    <string name="settings_background_import_failed">Failed to import background image</string>
     <string name="settings_language_title">Language</string>
     <string name="settings_language_system">Follow System</string>
     <string name="settings_language_zh">中文</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -261,6 +261,15 @@
     <string name="settings_font_size_title">页面缩放</string>
     <string name="settings_font_size_summary">调整页面内容大小 (80-110)</string>
     <string name="settings_font_size_preview_text">你是谁？请支持牛牛！(\'- \' )</string>
+    <string name="settings_background_title">自定义背景</string>
+    <string name="settings_background_desc">为主界面四个标签页设置图片背景</string>
+    <string name="settings_background_pick">选择图片</string>
+    <string name="settings_background_replace">更换图片</string>
+    <string name="settings_background_remove">移除</string>
+    <string name="settings_background_image_alpha">图片不透明度</string>
+    <string name="settings_background_scrim">遮罩强度</string>
+    <string name="settings_background_blur">模糊</string>
+    <string name="settings_background_import_failed">背景图片导入失败</string>
     <string name="settings_language_title">语言</string>
     <string name="settings_language_system">跟随系统</string>
     <string name="settings_language_zh">中文</string>


### PR DESCRIPTION
## Summary by Sourcery

为主标签页添加可配置的图片背景支持，并确保对话框使用与新背景无关的不透明主题。

新特性：
- 引入自定义背景设置区域，使用户可以为四个主标签页启用照片背景，选择/替换/移除图片，并调节不透明度、遮罩（scrim）和模糊效果。
- 通过新的偏好设置和 `BackgroundImageStore` 持久化自定义背景配置和图片，并使用玻璃风格的配色方案将其渲染在主标签页框架后方。

错误修复：
- 通过将任务提示和资源初始化对话框包裹在不透明主题中，防止它们意外显示自定义背景。

优化改进：
- 通过添加玻璃和不透明主题变体来优化主题处理，使主界面可以采用半透明效果，同时让对话框保持不透明且易于阅读。
- 整理若干现有的 composable，以提升布局的可读性，而不改变行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable image background support for the main tabs and ensure dialogs use an opaque theme independent of the new background.

New Features:
- Introduce a custom background setting section that lets users enable a photo background for the four main tabs, pick/replace/remove the image, and adjust opacity, scrim, and blur.
- Persist custom background configuration and image via new preferences and a BackgroundImageStore, and render it behind the main tab scaffold with a glass-styled color scheme.

Bug Fixes:
- Prevent task prompt and resource initialization dialogs from unintentionally showing the custom background by wrapping them in an opaque theme.

Enhancements:
- Refine theme handling by adding glass and opaque variants so the main UI can adopt a translucent look while dialogs remain opaque and readable.
- Tidy several existing composables for better layout readability without changing behavior.

</details>