### PR TITLE
feat: add customizable wallpaper background and safer image handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -205,6 +205,8 @@ dependencies {
     implementation(libs.angus.activation)
     implementation(libs.jakarta.activation.api)
     implementation(libs.reorderable)
+    implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
     implementation(libs.compose.markdown)
 
     // sora-editor：JSON 语法高亮编辑器（TextMate + darcula 主题）

--- a/app/src/main/java/com/aliothmoon/maameow/MainActivity.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/MainActivity.kt
@@ -68,10 +68,10 @@ class MainActivity : AppCompatActivity() {
         })
         setContent {
             val themeMode by appSettingsManager.themeMode.collectAsStateWithLifecycle()
-            val useSystemMonetColor by appSettingsManager.useSystemMonetColor.collectAsStateWithLifecycle()
+            val useWallpaperColor by appSettingsManager.useWallpaperColor.collectAsStateWithLifecycle()
             val fontSizeScale by appSettingsManager.fontSizeScale.collectAsStateWithLifecycle()
 
-            MaaMeowTheme(themeMode = themeMode, useSystemMonetColor = useSystemMonetColor) {
+            MaaMeowTheme(themeMode = themeMode, useWallpaperColor = useWallpaperColor) {
                 val baseDensity = LocalDensity.current
                 CompositionLocalProvider(
                     LocalDensity provides Density(

--- a/app/src/main/java/com/aliothmoon/maameow/constant/Routes.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/constant/Routes.kt
@@ -13,4 +13,5 @@ object Routes {
     const val SCHEDULE_TRIGGER_LOG = "schedule_trigger_log"
     const val NOTIFICATION = "notification"
     const val TASK_OVERRIDE_EDITOR = "task_override_editor"
+    const val WALLPAPER_SETTINGS = "wallpaper_settings"
 }

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -40,6 +40,8 @@ class AppSettingsManager(
     companion object {
         val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "app_settings")
 
+        private val NO_WALLPAPER_CROP_SCALE = Float.NaN
+
         /** 页面缩放范围 */
         const val FONT_SIZE_SCALE_MIN = 80
         const val FONT_SIZE_SCALE_MAX = 110
@@ -624,6 +626,52 @@ class AppSettingsManager(
     suspend fun setWallpaperFrostedGlass(enabled: Boolean) {
         with(AppSettingsSchema) {
             context.dataStore.edit { it[wallpaperFrostedGlass] = enabled.toString() }
+        }
+    }
+
+    val wallpaperCropScale: StateFlow<Float> = settings
+        .map { it.wallpaperCropScale.toFloatOrNull() ?: NO_WALLPAPER_CROP_SCALE }
+        .distinctUntilChanged()
+        .stateIn(
+            scope,
+            SharingStarted.Eagerly,
+            initialSettings.wallpaperCropScale.toFloatOrNull() ?: NO_WALLPAPER_CROP_SCALE,
+        )
+
+    val wallpaperCropPanX: StateFlow<Float> = settings
+        .map { it.wallpaperCropPanX.toFloatOrNull() ?: 0f }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperCropPanX.toFloatOrNull() ?: 0f)
+
+    val wallpaperCropPanY: StateFlow<Float> = settings
+        .map { it.wallpaperCropPanY.toFloatOrNull() ?: 0f }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperCropPanY.toFloatOrNull() ?: 0f)
+
+    val wallpaperCropRotation: StateFlow<Float> = settings
+        .map { it.wallpaperCropRotation.toFloatOrNull() ?: 0f }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperCropRotation.toFloatOrNull() ?: 0f)
+
+    suspend fun setWallpaperCropState(scale: Float, panX: Float, panY: Float, rotation: Float) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit {
+                it[wallpaperCropScale] = scale.toString()
+                it[wallpaperCropPanX] = panX.toString()
+                it[wallpaperCropPanY] = panY.toString()
+                it[wallpaperCropRotation] = rotation.toString()
+            }
+        }
+    }
+
+    suspend fun clearWallpaperCropState() {
+        with(AppSettingsSchema) {
+            context.dataStore.edit {
+                it[wallpaperCropScale] = ""
+                it[wallpaperCropPanX] = "0"
+                it[wallpaperCropPanY] = "0"
+                it[wallpaperCropRotation] = "0"
+            }
         }
     }
 

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -39,9 +39,6 @@ class AppSettingsManager(
 
     companion object {
         val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "app_settings")
-
-        private val NO_WALLPAPER_CROP_SCALE = Float.NaN
-
         /** 页面缩放范围 */
         const val FONT_SIZE_SCALE_MIN = 80
         const val FONT_SIZE_SCALE_MAX = 110
@@ -628,52 +625,5 @@ class AppSettingsManager(
             context.dataStore.edit { it[wallpaperFrostedGlass] = enabled.toString() }
         }
     }
-
-    val wallpaperCropScale: StateFlow<Float> = settings
-        .map { it.wallpaperCropScale.toFloatOrNull() ?: NO_WALLPAPER_CROP_SCALE }
-        .distinctUntilChanged()
-        .stateIn(
-            scope,
-            SharingStarted.Eagerly,
-            initialSettings.wallpaperCropScale.toFloatOrNull() ?: NO_WALLPAPER_CROP_SCALE,
-        )
-
-    val wallpaperCropPanX: StateFlow<Float> = settings
-        .map { it.wallpaperCropPanX.toFloatOrNull() ?: 0f }
-        .distinctUntilChanged()
-        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperCropPanX.toFloatOrNull() ?: 0f)
-
-    val wallpaperCropPanY: StateFlow<Float> = settings
-        .map { it.wallpaperCropPanY.toFloatOrNull() ?: 0f }
-        .distinctUntilChanged()
-        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperCropPanY.toFloatOrNull() ?: 0f)
-
-    val wallpaperCropRotation: StateFlow<Float> = settings
-        .map { it.wallpaperCropRotation.toFloatOrNull() ?: 0f }
-        .distinctUntilChanged()
-        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperCropRotation.toFloatOrNull() ?: 0f)
-
-    suspend fun setWallpaperCropState(scale: Float, panX: Float, panY: Float, rotation: Float) {
-        with(AppSettingsSchema) {
-            context.dataStore.edit {
-                it[wallpaperCropScale] = scale.toString()
-                it[wallpaperCropPanX] = panX.toString()
-                it[wallpaperCropPanY] = panY.toString()
-                it[wallpaperCropRotation] = rotation.toString()
-            }
-        }
-    }
-
-    suspend fun clearWallpaperCropState() {
-        with(AppSettingsSchema) {
-            context.dataStore.edit {
-                it[wallpaperCropScale] = ""
-                it[wallpaperCropPanX] = "0"
-                it[wallpaperCropPanY] = "0"
-                it[wallpaperCropRotation] = "0"
-            }
-        }
-    }
-
 
 }

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -540,18 +540,18 @@ class AppSettingsManager(
     }
 
 
-    // 是否启用系统莫奈主题色（Android 12+ Material You）
-    private fun parseUseSystemMonetColor(raw: String): Boolean =
-        raw.toBooleanStrictOrNull() ?: true
+    // 是否启用壁纸动态取色（有自定义壁纸时从壁纸取色，无壁纸时跟随系统壁纸）
+    private fun parseUseWallpaperColor(raw: String): Boolean =
+        raw.toBooleanStrictOrNull() ?: false
 
-    val useSystemMonetColor: StateFlow<Boolean> = settings
-        .map { parseUseSystemMonetColor(it.useSystemMonetColor) }
+    val useWallpaperColor: StateFlow<Boolean> = settings
+        .map { parseUseWallpaperColor(it.useWallpaperColor) }
         .distinctUntilChanged()
-        .stateIn(scope, SharingStarted.Eagerly, parseUseSystemMonetColor(initialSettings.useSystemMonetColor))
+        .stateIn(scope, SharingStarted.Eagerly, parseUseWallpaperColor(initialSettings.useWallpaperColor))
 
-    suspend fun setUseSystemMonetColor(enabled: Boolean) {
+    suspend fun setUseWallpaperColor(enabled: Boolean) {
         with(AppSettingsSchema) {
-            context.dataStore.edit { it[useSystemMonetColor] = enabled.toString() }
+            context.dataStore.edit { it[useWallpaperColor] = enabled.toString() }
         }
     }
 
@@ -578,5 +578,54 @@ class AppSettingsManager(
             context.dataStore.edit { it[showAchievementSnackbar] = enabled.toString() }
         }
     }
+
+    // 自定义壁纸
+    val wallpaperUri: StateFlow<String> = settings
+        .map { it.wallpaperUri }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperUri)
+
+    suspend fun setWallpaperUri(uri: String) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[wallpaperUri] = uri }
+        }
+    }
+
+    // 壁纸透明度
+    val wallpaperAlpha: StateFlow<Int> = settings
+        .map { it.wallpaperAlpha.toIntOrNull() ?: 100 }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperAlpha.toIntOrNull() ?: 100)
+
+    suspend fun setWallpaperAlpha(alpha: Int) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[wallpaperAlpha] = alpha.coerceIn(0, 100).toString() }
+        }
+    }
+
+    // 壁纸模糊
+    val wallpaperBlur: StateFlow<Int> = settings
+        .map { it.wallpaperBlur.toIntOrNull() ?: 0 }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperBlur.toIntOrNull() ?: 0)
+
+    suspend fun setWallpaperBlur(blur: Int) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[wallpaperBlur] = blur.coerceIn(0, 25).toString() }
+        }
+    }
+
+    // 壁纸磨砂玻璃
+    val wallpaperFrostedGlass: StateFlow<Boolean> = settings
+        .map { it.wallpaperFrostedGlass.toBoolean() }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperFrostedGlass.toBoolean())
+
+    suspend fun setWallpaperFrostedGlass(enabled: Boolean) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[wallpaperFrostedGlass] = enabled.toString() }
+        }
+    }
+
 
 }

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -100,10 +100,4 @@ data class AppSettings(
 
     /** 壁纸磨砂玻璃效果：组件背景半透明透出壁纸，默认 false */
     @PrefKey(default = "false") val wallpaperFrostedGlass: String = "false",
-
-    /** 壁纸裁切参数，空 scale 表示没有已保存裁切状态 */
-    @PrefKey(default = "") val wallpaperCropScale: String = "",
-    @PrefKey(default = "0") val wallpaperCropPanX: String = "0",
-    @PrefKey(default = "0") val wallpaperCropPanY: String = "0",
-    @PrefKey(default = "0") val wallpaperCropRotation: String = "0",
 )

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -77,15 +77,28 @@ data class AppSettings(
     @PrefKey(default = "false") val runScheduleWhenLocked: String = "false",
 
     /**
-     * 是否启用系统莫奈主题色（Android 12+ Material You）
-     * 启用后主题跟随系统壁纸动态取色，关闭则使用内置硬编码蓝色主题
+     * 启用动态取色：有自定义壁纸时从壁纸取色，无壁纸时跟随系统壁纸取色
+     * 关闭则使用内置硬编码蓝色主题
      * Android 12 以下设备只能使用内置蓝色主题
      */
-    @PrefKey(default = "false") val useSystemMonetColor: String = "false",
+    @PrefKey(default = "false") val useWallpaperColor: String = "false",
 
     /** 页面缩放比例（80~110，默认 100 = 1.0x） */
     @PrefKey(default = "100") val fontSizeScale: String = "100",
 
     /** 是否显示成就解锁时的 Snackbar 提示 */
     @PrefKey(default = "true") val showAchievementSnackbar: String = "true",
+
+    /** 自定义壁纸 URI（content:// 或 file://），空串表示未设置 */
+    @PrefKey(default = "") val wallpaperUri: String = "",
+
+    /** 壁纸透明度 0~100，默认 100 */
+    @PrefKey(default = "100") val wallpaperAlpha: String = "100",
+
+    /** 壁纸模糊半径 0~25，默认 0 */
+    @PrefKey(default = "0") val wallpaperBlur: String = "0",
+
+    /** 壁纸磨砂玻璃效果：组件背景半透明透出壁纸，默认 false */
+    @PrefKey(default = "false") val wallpaperFrostedGlass: String = "false",
+
 )

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -101,4 +101,9 @@ data class AppSettings(
     /** 壁纸磨砂玻璃效果：组件背景半透明透出壁纸，默认 false */
     @PrefKey(default = "false") val wallpaperFrostedGlass: String = "false",
 
+    /** 壁纸裁切参数，空 scale 表示没有已保存裁切状态 */
+    @PrefKey(default = "") val wallpaperCropScale: String = "",
+    @PrefKey(default = "0") val wallpaperCropPanX: String = "0",
+    @PrefKey(default = "0") val wallpaperCropPanY: String = "0",
+    @PrefKey(default = "0") val wallpaperCropRotation: String = "0",
 )

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/AdaptiveTaskPromptDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/AdaptiveTaskPromptDialog.kt
@@ -306,10 +306,9 @@ private fun TaskPromptCard(
     Surface(
         modifier = modifier.fillMaxWidth().wrapContentHeight().heightIn(max = screenHeight * 0.85f),
         shape = RoundedCornerShape(8.dp),
-        color = MaterialTheme.colorScheme.surface,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
         contentColor = MaterialTheme.colorScheme.onSurface,
-        tonalElevation = 6.dp,
-        shadowElevation = 8.dp
+        tonalElevation = 6.dp
     ) {
         Column(
             modifier = Modifier.padding(20.dp),

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
@@ -12,14 +12,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -50,14 +47,11 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.compose.runtime.snapshotFlow
 import com.aliothmoon.maameow.R
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -118,44 +112,20 @@ fun AnnouncementDialog(
         }.getOrNull()?.asImageBitmap()
     }
 
-    Dialog(
-        onDismissRequest = {},
-        properties = DialogProperties(
-            dismissOnBackPress = false,
-            dismissOnClickOutside = false,
-            usePlatformDefaultWidth = false,
-            decorFitsSystemWindows = false
-        ),
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.45f)),
+        contentAlignment = Alignment.Center
     ) {
-        val safeInsets = WindowInsets.safeDrawing.asPaddingValues()
-        val layoutDirection = LocalLayoutDirection.current
-        val maxHorizontalInset = max(
-            safeInsets.calculateLeftPadding(layoutDirection),
-            safeInsets.calculateRightPadding(layoutDirection)
-        )
-        // 垂直安全区：避免居中弹窗底部按钮被状态栏/导航栏（手势条）遮挡
-        val maxVerticalInset = max(
-            safeInsets.calculateTopPadding(),
-            safeInsets.calculateBottomPadding()
-        )
-
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
             Surface(
                 modifier = Modifier
                     .dialogWidth(max = 600.dp, fraction = 0.95f)
-                    .heightIn(max = screenHeight * 0.85f)
-                    .padding(
-                        horizontal = maxHorizontalInset + 16.dp,
-                        vertical = maxVerticalInset,
-                    ),
+                    .heightIn(max = screenHeight * 0.85f),
                 shape = RoundedCornerShape(12.dp),
-                color = MaterialTheme.colorScheme.surface,
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
                 contentColor = MaterialTheme.colorScheme.onSurface,
                 tonalElevation = 6.dp,
-                shadowElevation = 8.dp,
             ) {
                 Column(modifier = Modifier.padding(20.dp)) {
                     val inLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
@@ -354,9 +324,8 @@ fun AnnouncementDialog(
                     ) {
                         Text(stringResource(R.string.announcement_confirm))
                     }
-                    }
-                }
             }
         }
     }
+}
 }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/InfoCard.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/InfoCard.kt
@@ -18,7 +18,7 @@ import com.aliothmoon.maameow.theme.MaaDesignTokens
 private fun BaseCard(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues,
-    containerColor: Color = MaterialTheme.colorScheme.surface,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerLow,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Card(
@@ -40,7 +40,7 @@ private fun BaseCard(
 fun InfoCard(
     modifier: Modifier = Modifier,
     title: String = "",
-    containerColor: Color = MaterialTheme.colorScheme.surface,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerLow,
     contentColor: Color = MaterialTheme.colorScheme.onSurface,
     content: @Composable ColumnScope.() -> Unit,
 ) {
@@ -64,7 +64,7 @@ fun InfoCard(
 @Composable
 fun SettingsGroupCard(
     modifier: Modifier = Modifier,
-    containerColor: Color = MaterialTheme.colorScheme.surface,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerLow,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     BaseCard(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/OverlayDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/OverlayDialog.kt
@@ -97,7 +97,7 @@ fun OverlayDialog(
                         ) { /* 消费点击事件，防止穿透到遮罩层 */ },
                     shape = RoundedCornerShape(8.dp),
                     colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surface
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
                     )
                 ) {
                     Column(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/ResourceInitDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/ResourceInitDialog.kt
@@ -1,7 +1,10 @@
 package com.aliothmoon.maameow.presentation.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -19,8 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.domain.state.ResourceInitState
 import com.aliothmoon.maameow.utils.i18n.asString
@@ -38,17 +39,17 @@ fun ResourceInitDialog(
 
     when (state) {
         is ResourceInitState.Extracting -> {
-            // 解压进度弹窗（不可关闭）
-            Dialog(
-                onDismissRequest = {},
-                properties = DialogProperties(
-                    dismissOnBackPress = false,
-                    dismissOnClickOutside = false
-                )
+            // 解压进度弹窗（不可关闭）— 使用 Box overlay 而非 Dialog，以保留壁纸可见性
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.45f)),
+                contentAlignment = Alignment.Center
             ) {
                 Surface(
+                    modifier = Modifier.fillMaxWidth(0.85f),
                     shape = RoundedCornerShape(8.dp),
-                    color = MaterialTheme.colorScheme.surface,
+                    color = MaterialTheme.colorScheme.surfaceContainerLow,
                     tonalElevation = 6.dp
                 ) {
                     Column(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/ResourceLoadingOverlay.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/ResourceLoadingOverlay.kt
@@ -62,9 +62,8 @@ fun ResourceLoadingOverlay(
         ) {
             Card(
                 colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface
-                ),
-                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                )
             ) {
                 Column(
                     modifier = Modifier.padding(32.dp),

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/UpdateCard.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/UpdateCard.kt
@@ -259,7 +259,7 @@ fun UpdateCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
         )
     ) {
         Column(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -1,6 +1,5 @@
 package com.aliothmoon.maameow.presentation.navigation
 
-import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -39,6 +38,7 @@ import com.aliothmoon.maameow.domain.service.ExternalNotificationService
 import com.aliothmoon.maameow.overlay.OverlayController
 import com.aliothmoon.maameow.presentation.LocalToaster
 import com.aliothmoon.maameow.theme.WallpaperColorScheme
+import com.aliothmoon.maameow.utils.BitmapUtils
 import com.aliothmoon.maameow.presentation.components.AnnouncementDialog
 import com.aliothmoon.maameow.presentation.components.ResourceLoadingOverlay
 import com.aliothmoon.maameow.presentation.state.UiEffect
@@ -162,20 +162,7 @@ fun AppNavigation(
         // Load full-quality bitmap for wallpaper display
         val nativeBitmap = remember(wallpaperUri, showWallpaper) {
             if (!showWallpaper || wallpaperUri.isEmpty()) null
-            else try {
-                val uri = Uri.parse(wallpaperUri)
-                // Downsample to max 2048px to avoid OOM on large images
-                val bounds = android.graphics.BitmapFactory.Options().apply { inJustDecodeBounds = true }
-                context.contentResolver.openInputStream(uri)?.use {
-                    android.graphics.BitmapFactory.decodeStream(it, null, bounds)
-                }
-                val maxDim = maxOf(bounds.outWidth, bounds.outHeight)
-                val sample = if (maxDim > 2048) (maxDim / 2048).coerceAtLeast(1) else 1
-                val opts = android.graphics.BitmapFactory.Options().apply { inSampleSize = sample }
-                context.contentResolver.openInputStream(uri)?.use {
-                    android.graphics.BitmapFactory.decodeStream(it, null, opts)
-                }
-            } catch (_: Exception) { null }
+            else BitmapUtils.loadDownsampledBitmap(context, wallpaperUri)
         }
         // Recycle bitmap when wallpaper changes or is hidden
         androidx.compose.runtime.DisposableEffect(nativeBitmap) {

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -1,5 +1,6 @@
 package com.aliothmoon.maameow.presentation.navigation
 
+import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -7,6 +8,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -16,6 +21,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -31,6 +38,7 @@ import com.aliothmoon.maameow.domain.models.RunMode
 import com.aliothmoon.maameow.domain.service.ExternalNotificationService
 import com.aliothmoon.maameow.overlay.OverlayController
 import com.aliothmoon.maameow.presentation.LocalToaster
+import com.aliothmoon.maameow.theme.WallpaperColorScheme
 import com.aliothmoon.maameow.presentation.components.AnnouncementDialog
 import com.aliothmoon.maameow.presentation.components.ResourceLoadingOverlay
 import com.aliothmoon.maameow.presentation.state.UiEffect
@@ -40,6 +48,7 @@ import com.aliothmoon.maameow.presentation.view.settings.AchievementView
 import com.aliothmoon.maameow.presentation.view.settings.ErrorLogView
 import com.aliothmoon.maameow.presentation.view.settings.LogHistoryView
 import com.aliothmoon.maameow.presentation.view.settings.TaskOverrideEditorView
+import com.aliothmoon.maameow.presentation.view.settings.WallpaperSettingsView
 import com.aliothmoon.maameow.presentation.viewmodel.AppEventsViewModel
 import com.aliothmoon.maameow.presentation.viewmodel.BackgroundTaskViewModel
 import com.aliothmoon.maameow.schedule.model.CountdownState
@@ -132,19 +141,121 @@ fun AppNavigation(
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        // MainScreen with HorizontalPager for smooth tab switching
-        MainScreen(
-            navController = navController,
-            backgroundTaskViewModel = backgroundTaskViewModel,
-            onViewAnnouncement = { forceShowAnnouncement = true },
-            visible = isOnMainTab,
-            fullscreen = isFullscreen,
-        )
+        // Full-screen wallpaper background — hide on wallpaper settings page & pure dark mode
+        val wallpaperUri by appSettings.wallpaperUri.collectAsStateWithLifecycle()
+        val wallpaperAlpha by appSettings.wallpaperAlpha.collectAsStateWithLifecycle()
+        val wallpaperBlur by appSettings.wallpaperBlur.collectAsStateWithLifecycle()
+        val wallpaperFrostedGlass by appSettings.wallpaperFrostedGlass.collectAsStateWithLifecycle()
+        val useWallpaperColor by appSettings.useWallpaperColor.collectAsStateWithLifecycle()
 
-        // NavHost 只承载子页面；主 Tab 切换完全由 MainScreen 的 HorizontalPager 处理。
-        // 在此统一下发 LocalToaster，使所有子页面都能弹出顶部提示。
-        CompositionLocalProvider(LocalToaster provides toaster) {
-            NavHost(
+        // Theme awareness for wallpaper behavior
+        val themeMode by appSettings.themeMode.collectAsStateWithLifecycle()
+        val isDarkTheme = when (themeMode) {
+            AppSettingsManager.ThemeMode.SYSTEM -> isSystemInDarkTheme()
+            AppSettingsManager.ThemeMode.WHITE -> false
+            AppSettingsManager.ThemeMode.DARK, AppSettingsManager.ThemeMode.PURE_DARK -> true
+        }
+        val showWallpaper = wallpaperUri.isNotEmpty() &&
+            currentNavRoute != Routes.WALLPAPER_SETTINGS &&
+            themeMode != AppSettingsManager.ThemeMode.PURE_DARK
+
+        // Load full-quality bitmap for wallpaper display
+        val nativeBitmap = remember(wallpaperUri, showWallpaper) {
+            if (!showWallpaper || wallpaperUri.isEmpty()) null
+            else try {
+                val uri = Uri.parse(wallpaperUri)
+                // Downsample to max 2048px to avoid OOM on large images
+                val bounds = android.graphics.BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                context.contentResolver.openInputStream(uri)?.use {
+                    android.graphics.BitmapFactory.decodeStream(it, null, bounds)
+                }
+                val maxDim = maxOf(bounds.outWidth, bounds.outHeight)
+                val sample = if (maxDim > 2048) (maxDim / 2048).coerceAtLeast(1) else 1
+                val opts = android.graphics.BitmapFactory.Options().apply { inSampleSize = sample }
+                context.contentResolver.openInputStream(uri)?.use {
+                    android.graphics.BitmapFactory.decodeStream(it, null, opts)
+                }
+            } catch (_: Exception) { null }
+        }
+        // Recycle bitmap when wallpaper changes or is hidden
+        androidx.compose.runtime.DisposableEffect(nativeBitmap) {
+            onDispose { nativeBitmap?.recycle() }
+        }
+
+        if (showWallpaper) {
+            val bitmap = remember(nativeBitmap) { nativeBitmap?.asImageBitmap() }
+            if (bitmap != null) {
+                val contentScale = ContentScale.Crop
+                // Wallpaper image
+                androidx.compose.foundation.Image(
+                    bitmap = bitmap,
+                    contentDescription = null,
+                    contentScale = contentScale,
+                    alpha = wallpaperAlpha / 100f,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .then(
+                            if (wallpaperBlur > 0) Modifier.blur(wallpaperBlur.dp) else Modifier
+                        ),
+                )
+                // Dark mode: dim the wallpaper
+                if (isDarkTheme) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.Black.copy(alpha = 0.3f)),
+                    )
+                }
+            }
+        }
+
+        // Dynamic color: when useWallpaperColor is ON:
+        // - has wallpaper → extract seed color from custom wallpaper
+        // - no wallpaper → use system dynamic color (from system wallpaper)
+        val dynamicColorScheme = remember(nativeBitmap, wallpaperUri, useWallpaperColor, isDarkTheme) {
+            if (useWallpaperColor) {
+                if (wallpaperUri.isNotEmpty() && nativeBitmap != null) {
+                    val seed = WallpaperColorScheme.extractSeedColor(nativeBitmap)
+                    WallpaperColorScheme.generateColorScheme(seed, isDarkTheme)
+                } else null // no custom wallpaper → fall through to system dynamic color in Theme.kt
+            } else null
+        }
+
+        // Adaptive color scheme: transparent Scaffold background when wallpaper is shown.
+        // Only background is transparent so wallpaper shows through the scaffold.
+        // When frosted glass is enabled, dialog/card surfaces become semi-transparent.
+        val baseScheme = dynamicColorScheme ?: MaterialTheme.colorScheme
+        val transparentColorScheme = if (showWallpaper) {
+            baseScheme.copy(
+                background = Color.Transparent,
+                surface = if (wallpaperFrostedGlass) baseScheme.surface.copy(alpha = 0.55f) else baseScheme.surface,
+                surfaceVariant = if (wallpaperFrostedGlass) baseScheme.surfaceVariant.copy(alpha = 0.55f) else baseScheme.surfaceVariant,
+                surfaceContainerLowest = if (wallpaperFrostedGlass) baseScheme.surfaceContainerLowest.copy(alpha = 0.35f) else baseScheme.surfaceContainerLowest,
+                surfaceContainerLow = if (wallpaperFrostedGlass) baseScheme.surfaceContainerLow.copy(alpha = 0.40f) else baseScheme.surfaceContainerLow,
+                surfaceContainer = if (wallpaperFrostedGlass) baseScheme.surfaceContainer.copy(alpha = 0.65f) else baseScheme.surfaceContainer,
+                surfaceContainerHigh = if (wallpaperFrostedGlass) baseScheme.surfaceContainerHigh.copy(alpha = 0.80f) else baseScheme.surfaceContainerHigh,
+                surfaceContainerHighest = if (wallpaperFrostedGlass) baseScheme.surfaceContainerHighest.copy(alpha = 0.90f) else baseScheme.surfaceContainerHighest,
+                outline = if (wallpaperFrostedGlass) baseScheme.outline.copy(alpha = 0.35f) else baseScheme.outline,
+                outlineVariant = if (wallpaperFrostedGlass) baseScheme.outlineVariant.copy(alpha = 0.30f) else baseScheme.outlineVariant,
+            )
+        } else if (dynamicColorScheme != null) {
+            dynamicColorScheme
+        } else baseScheme
+
+        // MainScreen with HorizontalPager for smooth tab switching
+        MaterialTheme(colorScheme = transparentColorScheme) {
+            MainScreen(
+                navController = navController,
+                backgroundTaskViewModel = backgroundTaskViewModel,
+                onViewAnnouncement = { forceShowAnnouncement = true },
+                visible = isOnMainTab,
+                fullscreen = isFullscreen,
+            )
+
+            // NavHost 只承载子页面；主 Tab 切换完全由 MainScreen 的 HorizontalPager 处理。
+            // 在此统一下发 LocalToaster，使所有子页面都能弹出顶部提示。
+            CompositionLocalProvider(LocalToaster provides toaster) {
+                NavHost(
                 navController = navController,
                 startDestination = Routes.HOME,
                 enterTransition = { MaaAnimations.sharedAxisForwardEnter },
@@ -181,16 +292,21 @@ fun AppNavigation(
                 composable(Routes.TASK_OVERRIDE_EDITOR) {
                     TaskOverrideEditorView(navController = navController)
                 }
+                composable(Routes.WALLPAPER_SETTINGS) {
+                    val settingsVm: com.aliothmoon.maameow.presentation.viewmodel.SettingsViewModel = koinViewModel()
+                    WallpaperSettingsView(navController = navController, viewModel = settingsVm)
+                }
+            }  // NavHost
             }
-        }
-        ResourceLoadingOverlay()
+                ResourceLoadingOverlay()
+}  // MaterialTheme
         // 顶部轻提示（sonner）：替代旧的 Material3 Snackbar，按类型上色（成功=绿、错误=红）
         Toaster(
             state = toaster,
             alignment = Alignment.TopCenter,
             richColors = true,
             showCloseButton = true,
-            darkTheme = MaterialTheme.colorScheme.background.luminance() < 0.5f,
+            darkTheme = isDarkTheme,
             containerPadding = PaddingValues(top = 8.dp),
             modifier = Modifier.statusBarsPadding(),
         )
@@ -215,6 +331,7 @@ fun AppNavigation(
             }
         }
         if (announcementMarkdown != null) {
+            androidx.compose.material3.MaterialTheme(colorScheme = baseScheme) {
             AnnouncementDialog(
                 imageAssetPath = remember(language) { AnnouncementConfig.imageAssetPath(language) },
                 markdown = announcementMarkdown,
@@ -229,6 +346,7 @@ fun AppNavigation(
                     }
                 },
             )
+            }
         }
     }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/BottomNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/BottomNavigation.kt
@@ -71,7 +71,7 @@ fun AppBottomNavigation(
     modifier: Modifier = Modifier,
 ) {
     Surface(
-        modifier = modifier, color = MaterialTheme.colorScheme.surface, shadowElevation = 0.dp
+        modifier = modifier, color = MaterialTheme.colorScheme.surfaceContainerLow, shadowElevation = 0.dp
     ) {
         Column {
             HorizontalDivider(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
@@ -371,7 +371,7 @@ fun BackgroundTaskView(
                                                 .weight(1f)
                                                 .fillMaxHeight(),
                                             colors = CardDefaults.cardColors(
-                                                containerColor = MaterialTheme.colorScheme.surface
+                                                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
                                             )
                                         ) {
                                             Column(modifier = Modifier.padding(top = 10.dp)) {
@@ -804,10 +804,8 @@ private fun BackgroundMoreActionsOverlay(
                     interactionSource = cardInteractionSource, indication = null, onClick = {}),
             shape = RoundedCornerShape(4.dp),
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface
-            ),
-            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-            border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)) {
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.96f)
+            )) {
             Column(modifier = Modifier.padding(10.dp)) {
                 // 标题与快速操作组
                 Text(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
@@ -339,7 +339,7 @@ private fun ScreenInfoCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
         )
     ) {
         Column(
@@ -564,7 +564,7 @@ private fun RunModeCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
         )
     ) {
         Row(
@@ -661,7 +661,7 @@ private fun PermissionCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
         )
     ) {
         Column(
@@ -774,7 +774,7 @@ private fun ForegroundModeSection(
             elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
             shape = MaterialTheme.shapes.medium,
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
             )
         ) {
             Column(modifier = Modifier.padding(12.dp)) {
@@ -834,7 +834,7 @@ private fun ForegroundModeSection(
             elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
             shape = MaterialTheme.shapes.medium,
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
             )
         ) {
             Row(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/ExpandedControlPanel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/ExpandedControlPanel.kt
@@ -117,7 +117,7 @@ fun ExpandedControlPanel(
                 ),
             shape = RoundedCornerShape(4.dp),
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
             )
         ) {
             Column(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/LogPanel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/LogPanel.kt
@@ -118,42 +118,49 @@ fun LogPanel(
             }
         }
 
-        Box(modifier = Modifier.weight(1f)) {
-            LazyColumn(
-                state = listState,
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                items(
-                    items = logs,
-                    key = { it.id }
-                ) { logItem ->
-                    LogLine(
-                        logItem = logItem,
-                        onClick = { selectedLog = logItem }
-                    )
-                }
-            }
-
-            if (listState.canScrollForward && logs.isNotEmpty()) {
-                IconButton(
-                    onClick = { isAutoScroll = true },
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(16.dp)
-                        .size(40.dp)
-                        .background(
-                            MaterialTheme.colorScheme.primaryContainer,
-                            CircleShape
-                        )
+        Surface(
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerLow,
+            tonalElevation = 1.dp,
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    Icon(
-                        imageVector = Icons.Filled.KeyboardArrowDown,
-                        contentDescription = stringResource(R.string.panel_log_resume_auto_scroll),
-                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                        modifier = Modifier.size(20.dp)
-                    )
+                    items(
+                        items = logs,
+                        key = { it.id }
+                    ) { logItem ->
+                        LogLine(
+                            logItem = logItem,
+                            onClick = { selectedLog = logItem }
+                        )
+                    }
+                }
+
+                if (listState.canScrollForward && logs.isNotEmpty()) {
+                    IconButton(
+                        onClick = { isAutoScroll = true },
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(16.dp)
+                            .size(40.dp)
+                            .background(
+                                MaterialTheme.colorScheme.primaryContainer,
+                                CircleShape
+                            )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.KeyboardArrowDown,
+                            contentDescription = stringResource(R.string.panel_log_resume_auto_scroll),
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -117,9 +117,10 @@ fun SettingsView(
     val tasksOverrideEnabled by viewModel.tasksOverrideEnabled.collectAsStateWithLifecycle()
     val updateChannel by viewModel.updateChannel.collectAsStateWithLifecycle()
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
-    val useSystemMonetColor by viewModel.useSystemMonetColor.collectAsStateWithLifecycle()
+    val useWallpaperColor by viewModel.useWallpaperColor.collectAsStateWithLifecycle()
     val fontSizeScale by viewModel.fontSizeScale.collectAsStateWithLifecycle()
     val showAchievementSnackbar by viewModel.showAchievementSnackbar.collectAsStateWithLifecycle()
+    val wallpaperUri by viewModel.wallpaperUri.collectAsStateWithLifecycle()
     val backgroundResolution by viewModel.backgroundResolution.collectAsStateWithLifecycle()
     val language by viewModel.language.collectAsStateWithLifecycle()
     val backupMessage by viewModel.backupMessage.collectAsStateWithLifecycle()
@@ -461,12 +462,25 @@ fun SettingsView(
                         onLanguageSelected = { viewModel.setLanguage(it) }
                     )
                     ListItemDivider()
+                    // Custom wallpaper
+                    SettingClickItem(
+                        title = stringResource(R.string.settings_wallpaper_title),
+                        description = if (wallpaperUri.isNotEmpty()) {
+                            stringResource(R.string.settings_wallpaper_set)
+                        } else {
+                            stringResource(R.string.settings_wallpaper_desc)
+                        },
+                        contentColor = contentColor
+                    ) {
+                        navController.navigate(Routes.WALLPAPER_SETTINGS)
+                    }
+                    ListItemDivider()
                     SettingThemeSection(
                         contentColor = contentColor,
                         selectedMode = themeMode,
                         onModeSelected = { viewModel.setThemeMode(it) },
-                        useSystemMonetColor = useSystemMonetColor,
-                        onMonetColorChanged = { viewModel.setUseSystemMonetColor(it) },
+useWallpaperColor = useWallpaperColor,
+                            onWallpaperColorChanged = { viewModel.setUseWallpaperColor(it) },
                         fontSizeScale = fontSizeScale,
                         onFontSizeScaleChanged = { viewModel.setFontSizeScale(it) }
                     )
@@ -735,8 +749,8 @@ private fun SettingThemeSection(
     contentColor: Color,
     selectedMode: AppSettingsManager.ThemeMode,
     onModeSelected: (AppSettingsManager.ThemeMode) -> Unit,
-    useSystemMonetColor: Boolean,
-    onMonetColorChanged: (Boolean) -> Unit,
+    useWallpaperColor: Boolean,
+    onWallpaperColorChanged: (Boolean) -> Unit,
     fontSizeScale: Int,
     onFontSizeScaleChanged: (Int) -> Unit
 ) {
@@ -805,7 +819,7 @@ private fun SettingThemeSection(
                         color = contentColor.copy(alpha = 0.6f)
                     )
                 }
-                Switch(checked = useSystemMonetColor, onCheckedChange = onMonetColorChanged)
+                Switch(checked = useWallpaperColor, onCheckedChange = onWallpaperColorChanged)
             }
         }
         // 页面缩放

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -198,9 +198,11 @@ fun WallpaperSettingsView(
         ActivityResultContracts.OpenDocument()
     ) { uri ->
         uri ?: return@rememberLauncherForActivityResult
-        context.contentResolver.takePersistableUriPermission(
-            uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
-        )
+        try {
+            context.contentResolver.takePersistableUriPermission(
+                uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
+        } catch (_: Exception) { }
         saveOriginalForReEdit(context, uri, originalFile)
         // New wallpaper chosen — clear saved crop
         viewModel.clearCropState()

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -3,7 +3,6 @@ package com.aliothmoon.maameow.presentation.view.settings
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Matrix
 import android.net.Uri
@@ -91,6 +90,7 @@ import com.aliothmoon.maameow.presentation.components.SettingRow
 import com.aliothmoon.maameow.presentation.components.TopAppBar
 import com.aliothmoon.maameow.presentation.viewmodel.SettingsViewModel
 import com.aliothmoon.maameow.theme.MaaDesignTokens
+import com.aliothmoon.maameow.utils.BitmapUtils
 import java.io.File
 import kotlin.math.max
 import kotlin.math.min
@@ -210,7 +210,7 @@ fun WallpaperSettingsView(
         saveOriginalForReEdit(context, uri, originalFile)
         // New wallpaper chosen — clear saved crop
         viewModel.clearCropState()
-        val bitmap = loadDownsampledBitmap(context, uri)
+        val bitmap = BitmapUtils.loadDownsampledBitmap(context, uri, maxDimension = 2560)
         if (bitmap != null) {
             viewModel.setWallpaperUri(uri.toString())
             enterEditMode(bitmap)
@@ -417,7 +417,11 @@ fun WallpaperSettingsView(
                         screenRatio = screenRatio,
                         onClick = {
                             val src = if (originalFile.exists()) originalFile.absolutePath else wallpaperUri
-                            val bitmap = loadDownsampledBitmap(context, Uri.parse(if (src.startsWith("content://") || src.startsWith("file://")) src else "file://$src"))
+                            val bitmap = BitmapUtils.loadDownsampledBitmap(
+                                context,
+                                if (src.startsWith("content://") || src.startsWith("file://")) src else "file://$src",
+                                maxDimension = 2560,
+                            )
                             if (bitmap != null) enterEditMode(bitmap)
                         },
                     )
@@ -503,7 +507,9 @@ private fun WallpaperPreview(
     onClick: () -> Unit,
 ) {
     val context = LocalContext.current
-    val bitmap = remember(wallpaperUri) { loadBitmapFromUri(context, wallpaperUri) } ?: return
+    val bitmap = remember(wallpaperUri) {
+        BitmapUtils.loadDownsampledBitmap(context, wallpaperUri)
+    } ?: return
     Box(
         modifier = Modifier
             .padding(horizontal = 24.dp, vertical = 8.dp)
@@ -525,35 +531,6 @@ private fun WallpaperPreview(
         )
     }
 }
-
-private fun loadDownsampledBitmap(context: Context, uri: Uri): Bitmap? {
-    return try {
-        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-        context.contentResolver.openInputStream(uri)?.use {
-            BitmapFactory.decodeStream(it, null, bounds)
-        }
-        val maxDim = max(bounds.outWidth, bounds.outHeight)
-        val sample = if (maxDim > 2560) (maxDim / 2560).coerceAtLeast(1) else 1
-        val opts = BitmapFactory.Options().apply { inSampleSize = sample }
-        context.contentResolver.openInputStream(uri)?.use {
-            BitmapFactory.decodeStream(it, null, opts)
-        }
-    } catch (_: Exception) { null }
-}
-
-private fun loadBitmapFromUri(context: Context, uriString: String): Bitmap? {
-    return try {
-        val uri = Uri.parse(uriString)
-        when (uri.scheme) {
-            "file" -> BitmapFactory.decodeFile(uri.path)
-            "content" -> context.contentResolver.openInputStream(uri)?.use {
-                BitmapFactory.decodeStream(it)
-            }
-            else -> BitmapFactory.decodeFile(uriString)
-        }
-    } catch (_: Exception) { null }
-}
-
 private fun saveOriginalForReEdit(context: Context, uri: Uri, destFile: File) {
     try {
         context.contentResolver.openInputStream(uri)?.use { input ->

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -524,7 +524,6 @@ private fun WallpaperPreview(
         AsyncImage(
             model = ImageRequest.Builder(context)
                 .data(wallpaperUri)
-                .crossfade(true)
                 .build(),
             contentDescription = null,
             contentScale = ContentScale.Crop,

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -134,30 +134,25 @@ class CropState {
         val bw = source.width.toFloat()
         val bh = source.height.toFloat()
         val baseScale = min(sw / bw, sh / bh)
+        val effectiveScale = baseScale * scale
+        if (effectiveScale <= 0f) return source
 
-        // Compute output size in source image pixel space for full resolution
-        val outW = (cropW / baseScale / scale).toInt().coerceAtLeast(1)
-        val outH = (cropH / baseScale / scale).toInt().coerceAtLeast(1)
-
-        val m = Matrix()
-        // Scale from source pixels to screen pixels
-        m.postScale(baseScale, baseScale)
-        m.postTranslate((sw - bw * baseScale) / 2f, (sh - bh * baseScale) / 2f)
-        // Apply user transforms (scale, rotate, pan)
-        m.postTranslate(-sw / 2f, -sh / 2f)
-        m.postScale(scale, scale)
-        m.postRotate(rotationDegrees)
-        m.postTranslate(sw / 2f, sh / 2f)
-        m.postTranslate(panX, panY)
-        // Move crop region to origin
-        m.postTranslate(-cropLeft, -cropTop)
-        // Scale output from screen pixels to output pixels
-        val scaleFactor = cropW / outW.toFloat()
-        m.postScale(1f / scaleFactor, 1f / scaleFactor)
-
+        val outW = (cropW / effectiveScale).toInt().coerceAtLeast(1)
+        val outH = (cropH / effectiveScale).toInt().coerceAtLeast(1)
         val result = Bitmap.createBitmap(outW, outH, Bitmap.Config.ARGB_8888)
-        val canvas = Canvas(result)
-        canvas.drawBitmap(source, m, null)
+        result.eraseColor(android.graphics.Color.BLACK)
+
+        val drawMatrix = Matrix().apply {
+            postScale(baseScale, baseScale)
+            postTranslate((sw - bw * baseScale) / 2f, (sh - bh * baseScale) / 2f)
+            postScale(scale, scale, sw / 2f, sh / 2f)
+            postRotate(rotationDegrees, sw / 2f, sh / 2f)
+            postTranslate(panX, panY)
+            postTranslate(-cropLeft, -cropTop)
+            postScale(outW / cropW, outH / cropH)
+        }
+
+        Canvas(result).drawBitmap(source, drawMatrix, null)
         return result
     }
 }
@@ -314,7 +309,7 @@ fun WallpaperSettingsView(
                             rotationZ = cropState.rotationDegrees
                         },
                 )
-                
+
                 ComposeCanvas(modifier = Modifier.fillMaxSize()) {
                     // Semi-transparent when touching so user can see uncropped parts
                     val maskAlpha = if (isTouching) 0.4f else 1f

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -175,6 +175,7 @@ fun WallpaperSettingsView(
 
     var isEditing by remember { mutableStateOf(false) }
     var sourceBitmap by remember { mutableStateOf<Bitmap?>(null) }
+    var pendingOriginalUri by remember { mutableStateOf<Uri?>(null) }
     val cropState = remember { CropState() }
     val originalFile = remember { File(context.filesDir, "wallpaper_original.jpg") }
 
@@ -183,7 +184,7 @@ fun WallpaperSettingsView(
     val savedCropPanX by viewModel.savedCropPanX.collectAsStateWithLifecycle()
     val savedCropPanY by viewModel.savedCropPanY.collectAsStateWithLifecycle()
     val savedCropRotation by viewModel.savedCropRotation.collectAsStateWithLifecycle()
-    val hasSavedCrop = !savedCropScale.isNaN()
+    val hasSavedCrop = pendingOriginalUri == null && !savedCropScale.isNaN()
 
     fun enterEditMode(bitmap: Bitmap) {
         sourceBitmap = bitmap
@@ -193,6 +194,7 @@ fun WallpaperSettingsView(
     fun exitEditMode() {
         sourceBitmap?.recycle()
         sourceBitmap = null
+        pendingOriginalUri = null
         isEditing = false
     }
 
@@ -209,12 +211,9 @@ fun WallpaperSettingsView(
         } catch (e: IllegalArgumentException) {
             android.util.Log.w("WallpaperSettings", "takePersistableUriPermission bad argument", e)
         }
-        saveOriginalForReEdit(context, uri, originalFile)
-        // New wallpaper chosen — clear saved crop
-        viewModel.clearCropState()
         val bitmap = BitmapUtils.loadDownsampledBitmap(context, uri, maxDimension = 2560)
         if (bitmap != null) {
-            viewModel.setWallpaperUri(uri.toString())
+            pendingOriginalUri = uri
             enterEditMode(bitmap)
         }
     }
@@ -373,11 +372,6 @@ fun WallpaperSettingsView(
                     modifier = Modifier.size(56.dp).align(Alignment.CenterHorizontally)
                         .clip(CircleShape).background(MaterialTheme.colorScheme.primary)
                         .clickable {
-                            // Save crop state for re-edit
-                            viewModel.savedCropScale.value = cropState.scale
-                            viewModel.savedCropPanX.value = cropState.panX
-                            viewModel.savedCropPanY.value = cropState.panY
-                            viewModel.savedCropRotation.value = cropState.rotationDegrees
                             val cropped = cropState.getCroppedBitmap(sourceBitmap!!)
                             // Guard: if getCroppedBitmap returned the original (crop failed), skip
                             if (cropped === sourceBitmap) {
@@ -385,11 +379,18 @@ fun WallpaperSettingsView(
                             } else {
                                 val path = saveBitmapToFile(context, cropped, "wallpaper.jpg")
                                 if (path != null) {
+                                    pendingOriginalUri?.let { saveOriginalForReEdit(context, it, originalFile) }
+                                    viewModel.setCropState(
+                                        cropState.scale,
+                                        cropState.panX,
+                                        cropState.panY,
+                                        cropState.rotationDegrees,
+                                    )
                                     viewModel.setWallpaperUri(Uri.fromFile(File(path)).toString())
                                 }
                                 cropped.recycle()
+                                exitEditMode()
                             }
-                            exitEditMode()
                         },
                     contentAlignment = Alignment.Center,
                 ) {

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -134,25 +134,30 @@ class CropState {
         val bw = source.width.toFloat()
         val bh = source.height.toFloat()
         val baseScale = min(sw / bw, sh / bh)
-        val effectiveScale = baseScale * scale
-        if (effectiveScale <= 0f) return source
 
-        val outW = (cropW / effectiveScale).toInt().coerceAtLeast(1)
-        val outH = (cropH / effectiveScale).toInt().coerceAtLeast(1)
+        // Compute output size in source image pixel space for full resolution
+        val outW = (cropW / baseScale / scale).toInt().coerceAtLeast(1)
+        val outH = (cropH / baseScale / scale).toInt().coerceAtLeast(1)
+
+        val m = Matrix()
+        // Scale from source pixels to screen pixels
+        m.postScale(baseScale, baseScale)
+        m.postTranslate((sw - bw * baseScale) / 2f, (sh - bh * baseScale) / 2f)
+        // Apply user transforms (scale, rotate, pan)
+        m.postTranslate(-sw / 2f, -sh / 2f)
+        m.postScale(scale, scale)
+        m.postRotate(rotationDegrees)
+        m.postTranslate(sw / 2f, sh / 2f)
+        m.postTranslate(panX, panY)
+        // Move crop region to origin
+        m.postTranslate(-cropLeft, -cropTop)
+        // Scale output from screen pixels to output pixels
+        val scaleFactor = cropW / outW.toFloat()
+        m.postScale(1f / scaleFactor, 1f / scaleFactor)
+
         val result = Bitmap.createBitmap(outW, outH, Bitmap.Config.ARGB_8888)
-        result.eraseColor(android.graphics.Color.BLACK)
-
-        val drawMatrix = Matrix().apply {
-            postScale(baseScale, baseScale)
-            postTranslate((sw - bw * baseScale) / 2f, (sh - bh * baseScale) / 2f)
-            postScale(scale, scale, sw / 2f, sh / 2f)
-            postRotate(rotationDegrees, sw / 2f, sh / 2f)
-            postTranslate(panX, panY)
-            postTranslate(-cropLeft, -cropTop)
-            postScale(outW / cropW, outH / cropH)
-        }
-
-        Canvas(result).drawBitmap(source, drawMatrix, null)
+        val canvas = Canvas(result)
+        canvas.drawBitmap(source, m, null)
         return result
     }
 }
@@ -309,7 +314,7 @@ fun WallpaperSettingsView(
                             rotationZ = cropState.rotationDegrees
                         },
                 )
-
+                
                 ComposeCanvas(modifier = Modifier.fillMaxSize()) {
                     // Semi-transparent when touching so user can see uncropped parts
                     val maskAlpha = if (isTouching) 0.4f else 1f

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -202,7 +202,11 @@ fun WallpaperSettingsView(
             context.contentResolver.takePersistableUriPermission(
                 uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
             )
-        } catch (_: Exception) { }
+        } catch (e: SecurityException) {
+            android.util.Log.w("WallpaperSettings", "takePersistableUriPermission security exception", e)
+        } catch (e: IllegalArgumentException) {
+            android.util.Log.w("WallpaperSettings", "takePersistableUriPermission bad argument", e)
+        }
         saveOriginalForReEdit(context, uri, originalFile)
         // New wallpaper chosen — clear saved crop
         viewModel.clearCropState()

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -1,0 +1,565 @@
+package com.aliothmoon.maameow.presentation.view.settings
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Matrix
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Canvas as ComposeCanvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Scaffold
+
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.activity.compose.BackHandler
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import com.aliothmoon.maameow.R
+import com.aliothmoon.maameow.data.preferences.AppSettingsManager
+import com.aliothmoon.maameow.presentation.components.SettingsGroupCard
+import com.aliothmoon.maameow.presentation.components.SettingRow
+import com.aliothmoon.maameow.presentation.components.TopAppBar
+import com.aliothmoon.maameow.presentation.viewmodel.SettingsViewModel
+import com.aliothmoon.maameow.theme.MaaDesignTokens
+import java.io.File
+import kotlin.math.max
+import kotlin.math.min
+
+@Stable
+class CropState {
+    var scale by mutableFloatStateOf(1f)
+        internal set
+    var panX by mutableFloatStateOf(0f)
+        internal set
+    var panY by mutableFloatStateOf(0f)
+        internal set
+    var rotationDegrees by mutableFloatStateOf(0f)
+        internal set
+    var screenW by mutableFloatStateOf(0f)
+        internal set
+    var screenH by mutableFloatStateOf(0f)
+        internal set
+    var cropW by mutableFloatStateOf(0f)
+        internal set
+    var cropH by mutableFloatStateOf(0f)
+        internal set
+    var cropLeft by mutableFloatStateOf(0f)
+        internal set
+    var cropTop by mutableFloatStateOf(0f)
+        internal set
+
+    fun reset() {
+        scale = 1f
+        panX = 0f
+        panY = 0f
+        rotationDegrees = 0f
+    }
+
+    fun getCroppedBitmap(source: Bitmap): Bitmap {
+        val sw = screenW
+        val sh = screenH
+        if (sw <= 0f || sh <= 0f || cropW <= 0f || cropH <= 0f) return source
+        val bw = source.width.toFloat()
+        val bh = source.height.toFloat()
+        val baseScale = min(sw / bw, sh / bh)
+
+        // Compute output size in source image pixel space for full resolution
+        val outW = (cropW / baseScale / scale).toInt().coerceAtLeast(1)
+        val outH = (cropH / baseScale / scale).toInt().coerceAtLeast(1)
+
+        val m = Matrix()
+        // Scale from source pixels to screen pixels
+        m.postScale(baseScale, baseScale)
+        m.postTranslate((sw - bw * baseScale) / 2f, (sh - bh * baseScale) / 2f)
+        // Apply user transforms (scale, rotate, pan)
+        m.postTranslate(-sw / 2f, -sh / 2f)
+        m.postScale(scale, scale)
+        m.postRotate(rotationDegrees)
+        m.postTranslate(sw / 2f, sh / 2f)
+        m.postTranslate(panX, panY)
+        // Move crop region to origin
+        m.postTranslate(-cropLeft, -cropTop)
+        // Scale output from screen pixels to output pixels
+        val scaleFactor = cropW / outW.toFloat()
+        m.postScale(1f / scaleFactor, 1f / scaleFactor)
+
+        val result = Bitmap.createBitmap(outW, outH, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(result)
+        canvas.drawBitmap(source, m, null)
+        return result
+    }
+}
+
+@Composable
+fun WallpaperSettingsView(
+    navController: NavController,
+    viewModel: SettingsViewModel,
+) {
+    val wallpaperUri by viewModel.wallpaperUri.collectAsStateWithLifecycle()
+    val wallpaperAlpha by viewModel.wallpaperAlpha.collectAsStateWithLifecycle()
+    val wallpaperBlur by viewModel.wallpaperBlur.collectAsStateWithLifecycle()
+    val wallpaperFrostedGlass by viewModel.wallpaperFrostedGlass.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    var isEditing by remember { mutableStateOf(false) }
+    var sourceBitmap by remember { mutableStateOf<Bitmap?>(null) }
+    val cropState = remember { CropState() }
+    val originalFile = remember { File(context.filesDir, "wallpaper_original.jpg") }
+
+    // Remember last confirmed crop params so re-edit restores the same view
+    val savedCropScale by viewModel.savedCropScale.collectAsStateWithLifecycle()
+    val savedCropPanX by viewModel.savedCropPanX.collectAsStateWithLifecycle()
+    val savedCropPanY by viewModel.savedCropPanY.collectAsStateWithLifecycle()
+    val savedCropRotation by viewModel.savedCropRotation.collectAsStateWithLifecycle()
+    val hasSavedCrop = !savedCropScale.isNaN()
+
+    fun enterEditMode(bitmap: Bitmap) {
+        sourceBitmap = bitmap
+        isEditing = true
+    }
+
+    fun exitEditMode() {
+        sourceBitmap?.recycle()
+        sourceBitmap = null
+        isEditing = false
+    }
+
+    val wallpaperPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri ?: return@rememberLauncherForActivityResult
+        context.contentResolver.takePersistableUriPermission(
+            uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
+        )
+        saveOriginalForReEdit(context, uri, originalFile)
+        // New wallpaper chosen — clear saved crop
+        viewModel.clearCropState()
+        val bitmap = loadDownsampledBitmap(context, uri)
+        if (bitmap != null) {
+            viewModel.setWallpaperUri(uri.toString())
+            enterEditMode(bitmap)
+        }
+    }
+
+    val configuration = LocalConfiguration.current
+    val screenRatio = configuration.screenWidthDp.toFloat() / configuration.screenHeightDp.toFloat()
+
+    if (isEditing && sourceBitmap != null) {
+        BackHandler(enabled = true) { exitEditMode() }
+        BoxWithConstraints(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+            val totalW = constraints.maxWidth.toFloat()
+            val totalH = constraints.maxHeight.toFloat()
+
+            // 裁切框 = 手机屏幕比例，占屏幕 70%×50%
+            val maxCropW = totalW * 0.70f
+            val maxCropH = totalH * 0.50f
+            val cropW: Float
+            val cropH: Float
+            if (maxCropW / screenRatio <= maxCropH) {
+                cropW = maxCropW
+                cropH = cropW / screenRatio
+            } else {
+                cropH = maxCropH
+                cropW = cropH * screenRatio
+            }
+            val cropLeft = (totalW - cropW) / 2f
+            val cropTop = (totalH - cropH) / 2f
+
+            cropState.apply {
+                screenW = totalW
+                screenH = totalH
+                this.cropW = cropW
+                this.cropH = cropH
+                this.cropLeft = cropLeft
+                this.cropTop = cropTop
+            }
+
+            // 初始缩放：让图片刚好填满裁切框（ContentScale.Fit 的显示尺寸基础上再放大）
+            val bw = sourceBitmap!!.width.toFloat()
+            val bh = sourceBitmap!!.height.toFloat()
+            val baseScale = min(totalW / bw, totalH / bh)
+            val displayW = bw * baseScale
+            val displayH = bh * baseScale
+            val initScale = max(cropW / displayW, cropH / displayH)
+            LaunchedEffect(sourceBitmap) {
+                if (!hasSavedCrop) {
+                    cropState.scale = initScale
+                    cropState.panX = 0f
+                    cropState.panY = 0f
+                    cropState.rotationDegrees = 0f
+                } else {
+                    cropState.scale = savedCropScale
+                    cropState.panX = savedCropPanX
+                    cropState.panY = savedCropPanY
+                    cropState.rotationDegrees = savedCropRotation
+                }
+            }
+
+            val s = cropState
+            var isTouching by remember { mutableStateOf(false) }
+
+            Box(modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            val pressedCount = event.changes.count { it.pressed }
+                            isTouching = pressedCount > 0
+                        }
+                    }
+                }
+                .pointerInput(Unit) {
+                    detectTransformGestures { _, pan, zoom, rotation ->
+                        s.apply {
+                            scale = (scale * zoom).coerceIn(0.3f, 5f)
+                            panX += pan.x
+                            panY += pan.y
+                            rotationDegrees += rotation
+                        }
+                    }
+                }
+            ) {
+                // Cached image bitmap to avoid re-creating on every recomposition
+                val imageBitmap = remember(sourceBitmap) { sourceBitmap!!.asImageBitmap() }
+                Image(
+                    bitmap = imageBitmap,
+                    contentDescription = null,
+                    contentScale = ContentScale.Fit,
+                    alpha = wallpaperAlpha / 100f,
+                    modifier = Modifier.fillMaxSize()
+                        .then(if (wallpaperBlur > 0) Modifier.blur(wallpaperBlur.dp) else Modifier)
+                        .graphicsLayer {
+                            scaleX = cropState.scale
+                            scaleY = cropState.scale
+                            translationX = cropState.panX
+                            translationY = cropState.panY
+                            rotationZ = cropState.rotationDegrees
+                        },
+                )
+                
+                ComposeCanvas(modifier = Modifier.fillMaxSize()) {
+                    // Semi-transparent when touching so user can see uncropped parts
+                    val maskAlpha = if (isTouching) 0.4f else 1f
+                    // Top
+                    drawRect(Color.Black.copy(alpha = maskAlpha),
+                        topLeft = Offset.Zero, size = Size(size.width, cropTop))
+                    // Bottom
+                    drawRect(Color.Black.copy(alpha = maskAlpha),
+                        topLeft = Offset(0f, cropTop + cropH),
+                        size = Size(size.width, size.height - cropTop - cropH))
+                    // Left
+                    drawRect(Color.Black.copy(alpha = maskAlpha),
+                        topLeft = Offset(0f, cropTop),
+                        size = Size(cropLeft, cropH))
+                    // Right
+                    drawRect(Color.Black.copy(alpha = maskAlpha),
+                        topLeft = Offset(cropLeft + cropW, cropTop),
+                        size = Size(size.width - cropLeft - cropW, cropH))
+                    // White crop border (always visible)
+                    drawRect(Color.White.copy(alpha = 0.8f),
+                        topLeft = Offset(cropLeft, cropTop),
+                        size = Size(cropW, cropH),
+                        style = Stroke(width = 2.dp.toPx()))
+                }
+            }
+
+            Box(modifier = Modifier.fillMaxWidth().statusBarsPadding()
+                .padding(horizontal = 4.dp, vertical = 4.dp)) {
+                IconButton(onClick = { exitEditMode() }) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = Color.White)
+                }
+            }
+
+            Column(
+                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth()
+                    .background(Brush.verticalGradient(
+                        listOf(Color.Transparent, Color.Black.copy(alpha = 0.7f))))
+                    .navigationBarsPadding()
+                    .padding(horizontal = 20.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(stringResource(R.string.settings_wallpaper_alpha, wallpaperAlpha),
+                    style = MaterialTheme.typography.bodyMedium, color = Color.White)
+                Slider(wallpaperAlpha.toFloat(),
+                    onValueChange = { viewModel.setWallpaperAlpha(it.toInt()) },
+                    valueRange = 0f..100f)
+                Text(stringResource(R.string.settings_wallpaper_blur, wallpaperBlur),
+                    style = MaterialTheme.typography.bodyMedium, color = Color.White)
+                Slider(wallpaperBlur.toFloat(),
+                    onValueChange = { viewModel.setWallpaperBlur(it.toInt()) },
+                    valueRange = 0f..25f)
+                Spacer(Modifier.height(4.dp))
+                Box(
+                    modifier = Modifier.size(56.dp).align(Alignment.CenterHorizontally)
+                        .clip(CircleShape).background(MaterialTheme.colorScheme.primary)
+                        .clickable {
+                            // Save crop state for re-edit
+                            viewModel.savedCropScale.value = cropState.scale
+                            viewModel.savedCropPanX.value = cropState.panX
+                            viewModel.savedCropPanY.value = cropState.panY
+                            viewModel.savedCropRotation.value = cropState.rotationDegrees
+                            val cropped = cropState.getCroppedBitmap(sourceBitmap!!)
+                            // Guard: if getCroppedBitmap returned the original (crop failed), skip
+                            if (cropped === sourceBitmap) {
+                                exitEditMode()
+                            } else {
+                                val path = saveBitmapToFile(context, cropped, "wallpaper.jpg")
+                                if (path != null) {
+                                    viewModel.setWallpaperUri(Uri.fromFile(File(path)).toString())
+                                }
+                                cropped.recycle()
+                            }
+                            exitEditMode()
+                        },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(Icons.Default.Check,
+                        stringResource(R.string.settings_wallpaper_confirm),
+                        tint = Color.White, modifier = Modifier.size(28.dp))
+                }
+            }
+        }
+    } else {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = stringResource(R.string.settings_wallpaper_title),
+                    navigationIcon = Icons.AutoMirrored.Filled.ArrowBack,
+                    onNavigationClick = { navController.popBackStack() },
+                )
+            },
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        ) { paddingValues ->
+            Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+                if (wallpaperUri.isNotEmpty()) {
+                    WallpaperPreview(
+                        wallpaperUri = wallpaperUri,
+                        alpha = wallpaperAlpha / 100f,
+                        blurDp = wallpaperBlur,
+                        screenRatio = screenRatio,
+                        onClick = {
+                            val src = if (originalFile.exists()) originalFile.absolutePath else wallpaperUri
+                            val bitmap = loadDownsampledBitmap(context, Uri.parse(if (src.startsWith("content://") || src.startsWith("file://")) src else "file://$src"))
+                            if (bitmap != null) enterEditMode(bitmap)
+                        },
+                    )
+                    Column(
+                        modifier = Modifier.fillMaxWidth()
+                            .padding(horizontal = MaaDesignTokens.Spacing.listHorizontal,
+                                vertical = MaaDesignTokens.Spacing.sm),
+                        verticalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.sectionGap),
+                    ) {
+                        SettingsGroupCard {
+                            SettingRow(
+                                title = stringResource(R.string.settings_wallpaper_change),
+                                onClick = { wallpaperPicker.launch(arrayOf("image/*")) },
+                            )
+                        }
+                        SettingsGroupCard {
+                            SettingRow(
+                                title = stringResource(R.string.settings_wallpaper_frosted_glass),
+                                description = stringResource(R.string.settings_wallpaper_frosted_glass_desc),
+                                trailing = {
+                                    Switch(
+                                        checked = wallpaperFrostedGlass,
+                                        onCheckedChange = { viewModel.setWallpaperFrostedGlass(it) },
+                                    )
+                                },
+                            )
+                        }
+                        OutlinedButton(
+                            onClick = {
+                                viewModel.setWallpaperUri("")
+                                viewModel.clearCropState()
+                                if (originalFile.exists()) originalFile.delete()
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = MaaDesignTokens.Spacing.listHorizontal, vertical = 8.dp),
+                            shape = MaterialTheme.shapes.large,
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = MaterialTheme.colorScheme.error.copy(alpha = 0.82f)
+                            ),
+                            border = BorderStroke(
+                                1.dp,
+                                MaterialTheme.colorScheme.error.copy(alpha = 0.45f)
+                            ),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Clear,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(modifier = Modifier.size(6.dp))
+                            Text(
+                                text = stringResource(R.string.settings_wallpaper_clear),
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Medium,
+                            )
+                        }
+                    }
+                } else {
+                    Column(
+                        modifier = Modifier.fillMaxWidth()
+                            .padding(horizontal = MaaDesignTokens.Spacing.listHorizontal),
+                    ) {
+                        SettingsGroupCard {
+                            SettingRow(
+                                title = stringResource(R.string.settings_wallpaper_desc),
+                                onClick = { wallpaperPicker.launch(arrayOf("image/*")) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WallpaperPreview(
+    wallpaperUri: String,
+    alpha: Float,
+    blurDp: Int,
+    screenRatio: Float,
+    onClick: () -> Unit,
+) {
+    val context = LocalContext.current
+    val bitmap = remember(wallpaperUri) { loadBitmapFromUri(context, wallpaperUri) } ?: return
+    Box(
+        modifier = Modifier
+            .padding(horizontal = 24.dp, vertical = 8.dp)
+            .fillMaxWidth()
+            .wrapContentSize(Alignment.Center)
+            .width(180.dp)
+            .aspectRatio(screenRatio)
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            alpha = alpha,
+            modifier = Modifier.fillMaxSize()
+                .then(if (blurDp > 0) Modifier.blur(blurDp.dp) else Modifier),
+        )
+    }
+}
+
+private fun loadDownsampledBitmap(context: Context, uri: Uri): Bitmap? {
+    return try {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        context.contentResolver.openInputStream(uri)?.use {
+            BitmapFactory.decodeStream(it, null, bounds)
+        }
+        val maxDim = max(bounds.outWidth, bounds.outHeight)
+        val sample = if (maxDim > 2560) (maxDim / 2560).coerceAtLeast(1) else 1
+        val opts = BitmapFactory.Options().apply { inSampleSize = sample }
+        context.contentResolver.openInputStream(uri)?.use {
+            BitmapFactory.decodeStream(it, null, opts)
+        }
+    } catch (_: Exception) { null }
+}
+
+private fun loadBitmapFromUri(context: Context, uriString: String): Bitmap? {
+    return try {
+        val uri = Uri.parse(uriString)
+        when (uri.scheme) {
+            "file" -> BitmapFactory.decodeFile(uri.path)
+            "content" -> context.contentResolver.openInputStream(uri)?.use {
+                BitmapFactory.decodeStream(it)
+            }
+            else -> BitmapFactory.decodeFile(uriString)
+        }
+    } catch (_: Exception) { null }
+}
+
+private fun saveOriginalForReEdit(context: Context, uri: Uri, destFile: File) {
+    try {
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            destFile.outputStream().use { output -> input.copyTo(output) }
+        }
+    } catch (_: Exception) { }
+}
+
+private fun saveBitmapToFile(context: Context, bitmap: Bitmap, filename: String): String? {
+    return try {
+        val file = File(context.filesDir, filename)
+        file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.JPEG, 95, it) }
+        file.absolutePath
+    } catch (_: Exception) { null }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -83,6 +83,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
 import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
 import com.aliothmoon.maameow.presentation.components.SettingsGroupCard
@@ -291,7 +293,7 @@ fun WallpaperSettingsView(
                             scale = (scale * zoom).coerceIn(0.3f, 5f)
                             panX += pan.x
                             panY += pan.y
-                            rotationDegrees += rotation
+                            rotationDegrees += Math.toDegrees(rotation.toDouble()).toFloat()
                         }
                     }
                 }
@@ -507,9 +509,6 @@ private fun WallpaperPreview(
     onClick: () -> Unit,
 ) {
     val context = LocalContext.current
-    val bitmap = remember(wallpaperUri) {
-        BitmapUtils.loadDownsampledBitmap(context, wallpaperUri)
-    } ?: return
     Box(
         modifier = Modifier
             .padding(horizontal = 24.dp, vertical = 8.dp)
@@ -521,8 +520,11 @@ private fun WallpaperPreview(
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
-        Image(
-            bitmap = bitmap.asImageBitmap(),
+        AsyncImage(
+            model = ImageRequest.Builder(context)
+                .data(wallpaperUri)
+                .crossfade(true)
+                .build(),
             contentDescription = null,
             contentScale = ContentScale.Crop,
             alpha = alpha,

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -292,7 +292,7 @@ fun WallpaperSettingsView(
                             scale = (scale * zoom).coerceIn(0.3f, 5f)
                             panX += pan.x
                             panY += pan.y
-                            rotationDegrees += Math.toDegrees(rotation.toDouble()).toFloat()
+                            rotationDegrees += rotation
                         }
                     }
                 }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -380,12 +380,10 @@ fun WallpaperSettingsView(
                                 val path = saveBitmapToFile(context, cropped, "wallpaper.jpg")
                                 if (path != null) {
                                     pendingOriginalUri?.let { saveOriginalForReEdit(context, it, originalFile) }
-                                    viewModel.setCropState(
-                                        cropState.scale,
-                                        cropState.panX,
-                                        cropState.panY,
-                                        cropState.rotationDegrees,
-                                    )
+                                    viewModel.savedCropScale.value = cropState.scale
+                                    viewModel.savedCropPanX.value = cropState.panX
+                                    viewModel.savedCropPanY.value = cropState.panY
+                                    viewModel.savedCropRotation.value = cropState.rotationDegrees
                                     viewModel.setWallpaperUri(Uri.fromFile(File(path)).toString())
                                 }
                                 cropped.recycle()

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -313,9 +313,21 @@ class SettingsViewModel(
         viewModelScope.launch { appSettingsManager.setWallpaperFrostedGlass(enabled) }
     }
 
-    // 裁切状态恢复（跨导航保持）
-    val savedCropScale = MutableStateFlow(Float.NaN)
-    val savedCropPanX = MutableStateFlow(0f)
-    val savedCropPanY = MutableStateFlow(0f)
-    val savedCropRotation = MutableStateFlow(0f)
-    fun clearCropState() { savedCropScale.value = Float.NaN }}
+    // 裁切状态恢复（持久化）
+    val savedCropScale: StateFlow<Float> = appSettingsManager.wallpaperCropScale
+    val savedCropPanX: StateFlow<Float> = appSettingsManager.wallpaperCropPanX
+    val savedCropPanY: StateFlow<Float> = appSettingsManager.wallpaperCropPanY
+    val savedCropRotation: StateFlow<Float> = appSettingsManager.wallpaperCropRotation
+
+    fun setCropState(scale: Float, panX: Float, panY: Float, rotation: Float) {
+        viewModelScope.launch {
+            appSettingsManager.setWallpaperCropState(scale, panX, panY, rotation)
+        }
+    }
+
+    fun clearCropState() {
+        viewModelScope.launch {
+            appSettingsManager.clearWallpaperCropState()
+        }
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -313,21 +313,16 @@ class SettingsViewModel(
         viewModelScope.launch { appSettingsManager.setWallpaperFrostedGlass(enabled) }
     }
 
-    // 裁切状态恢复（持久化）
-    val savedCropScale: StateFlow<Float> = appSettingsManager.wallpaperCropScale
-    val savedCropPanX: StateFlow<Float> = appSettingsManager.wallpaperCropPanX
-    val savedCropPanY: StateFlow<Float> = appSettingsManager.wallpaperCropPanY
-    val savedCropRotation: StateFlow<Float> = appSettingsManager.wallpaperCropRotation
-
-    fun setCropState(scale: Float, panX: Float, panY: Float, rotation: Float) {
-        viewModelScope.launch {
-            appSettingsManager.setWallpaperCropState(scale, panX, panY, rotation)
-        }
-    }
+    // 裁切状态恢复（跨导航保持）
+    val savedCropScale = MutableStateFlow(Float.NaN)
+    val savedCropPanX = MutableStateFlow(0f)
+    val savedCropPanY = MutableStateFlow(0f)
+    val savedCropRotation = MutableStateFlow(0f)
 
     fun clearCropState() {
-        viewModelScope.launch {
-            appSettingsManager.clearWallpaperCropState()
-        }
+        savedCropScale.value = Float.NaN
+        savedCropPanX.value = 0f
+        savedCropPanY.value = 0f
+        savedCropRotation.value = 0f
     }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -267,11 +267,11 @@ class SettingsViewModel(
         }
     }
 
-    // ============ System Monet theme color ============
-    val useSystemMonetColor: StateFlow<Boolean> = appSettingsManager.useSystemMonetColor
-    fun setUseSystemMonetColor(enabled: Boolean) {
+    // 壁纸动态取色
+    val useWallpaperColor: StateFlow<Boolean> = appSettingsManager.useWallpaperColor
+    fun setUseWallpaperColor(enabled: Boolean) {
         viewModelScope.launch {
-            appSettingsManager.setUseSystemMonetColor(enabled)
+            appSettingsManager.setUseWallpaperColor(enabled)
         }
     }
 
@@ -289,4 +289,33 @@ class SettingsViewModel(
             appSettingsManager.setShowAchievementSnackbar(enabled)
         }
     }
-}
+
+    // 自定义壁纸
+    val wallpaperUri: StateFlow<String> = appSettingsManager.wallpaperUri
+    fun setWallpaperUri(uri: String) {
+        viewModelScope.launch {
+            appSettingsManager.setWallpaperUri(uri)
+        }
+    }
+
+    val wallpaperAlpha: StateFlow<Int> = appSettingsManager.wallpaperAlpha
+    fun setWallpaperAlpha(alpha: Int) {
+        viewModelScope.launch { appSettingsManager.setWallpaperAlpha(alpha) }
+    }
+
+    val wallpaperBlur: StateFlow<Int> = appSettingsManager.wallpaperBlur
+    fun setWallpaperBlur(blur: Int) {
+        viewModelScope.launch { appSettingsManager.setWallpaperBlur(blur) }
+    }
+
+    val wallpaperFrostedGlass: StateFlow<Boolean> = appSettingsManager.wallpaperFrostedGlass
+    fun setWallpaperFrostedGlass(enabled: Boolean) {
+        viewModelScope.launch { appSettingsManager.setWallpaperFrostedGlass(enabled) }
+    }
+
+    // 裁切状态恢复（跨导航保持）
+    val savedCropScale = MutableStateFlow(Float.NaN)
+    val savedCropPanX = MutableStateFlow(0f)
+    val savedCropPanY = MutableStateFlow(0f)
+    val savedCropRotation = MutableStateFlow(0f)
+    fun clearCropState() { savedCropScale.value = Float.NaN }}

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/ui/ScheduleListView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/ui/ScheduleListView.kt
@@ -23,7 +23,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -201,11 +202,14 @@ private fun StrategyCard(
     onClick: () -> Unit,
     onDelete: () -> Unit
 ) {
-    ElevatedCard(
+    Card(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(12.dp)
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        )
     ) {
         Row(
             modifier = Modifier.padding(16.dp),

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/ui/ScheduleTriggerLogView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/ui/ScheduleTriggerLogView.kt
@@ -25,7 +25,8 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -197,11 +198,14 @@ private fun SummaryCard(
     val resultLabel = summary.footer?.result?.let { scheduleExecutionResultLabel(it) }
         ?: stringResource(R.string.schedule_result_in_progress)
 
-    ElevatedCard(
+    Card(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(8.dp)
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        )
     ) {
         Row(
             modifier = Modifier.padding(start = 12.dp, top = 12.dp, bottom = 12.dp, end = 4.dp),

--- a/app/src/main/java/com/aliothmoon/maameow/theme/Theme.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/theme/Theme.kt
@@ -162,7 +162,7 @@ object MaaThemeAlphas {
 @Composable
 fun MaaMeowTheme(
     themeMode: AppSettingsManager.ThemeMode = AppSettingsManager.ThemeMode.SYSTEM,
-    useSystemMonetColor: Boolean = true,
+    useWallpaperColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
@@ -173,10 +173,10 @@ fun MaaMeowTheme(
         AppSettingsManager.ThemeMode.DARK, AppSettingsManager.ThemeMode.PURE_DARK -> true
     }
     val isPureDark = themeMode == AppSettingsManager.ThemeMode.PURE_DARK
-    val colorScheme: ColorScheme = remember(themeMode, useSystemMonetColor, isDarkTheme, context) {
+    val colorScheme: ColorScheme = remember(themeMode, useWallpaperColor, isDarkTheme, context) {
         when {
-            // Android 12+ with monet enabled ==> system dynamic color (Material You)
-            useSystemMonetColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            // Android 12+ with monet enabled => system dynamic color (Material You)
+            useWallpaperColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
                 val dynamic =
                     if (isDarkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(
                         context

--- a/app/src/main/java/com/aliothmoon/maameow/theme/WallpaperColorScheme.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/theme/WallpaperColorScheme.kt
@@ -1,0 +1,218 @@
+package com.aliothmoon.maameow.theme
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color as ComposeColor
+import kotlin.math.*
+
+/**
+ * Extracts a dominant seed color from a wallpaper bitmap and generates
+ * a Material You-style color scheme, without any external library.
+ *
+ * - Score by hue-area-proportion + chroma
+ * - De-duplicate by hue distance
+ *
+ * Color scheme generation uses HSL-based tonal palette derivation.
+ */
+object WallpaperColorScheme {
+
+    private const val MIN_CHROMA = 0.10 // HSL saturation threshold
+    private const val GOOGLE_BLUE_ARGB = 0xFF1B6EF3.toInt()
+
+    fun extractSeedColor(bitmap: Bitmap): Int {
+        val maxDim = maxOf(bitmap.width, bitmap.height)
+        val sampleSize = (maxDim / 128).coerceAtLeast(1)
+        val w = (bitmap.width / sampleSize).coerceAtLeast(1)
+        val h = (bitmap.height / sampleSize).coerceAtLeast(1)
+        val scaled = Bitmap.createScaledBitmap(bitmap, w, h, false)
+        val pixels = IntArray(w * h)
+        scaled.getPixels(pixels, 0, w, 0, 0, w, h)
+        if (scaled !== bitmap) scaled.recycle()
+
+        // Quantize colors and count
+        val colorCounts = HashMap<Int, Int>()
+        for (p in pixels) {
+            val q = Color.rgb(
+                Color.red(p) and 0xF8, // 3-bit quantization
+                Color.green(p) and 0xF8,
+                Color.blue(p) and 0xF8
+            )
+            colorCounts[q] = (colorCounts[q] ?: 0) + 1
+        }
+
+        val total = pixels.size.toDouble()
+
+        // Build hue histogram and collect color info
+        data class CInfo(val argb: Int, val hue: Float, val sat: Float, val light: Float, val proportion: Double)
+
+        val hueProportions = DoubleArray(360)
+        val infos = ArrayList<CInfo>()
+        for ((argb, count) in colorCounts) {
+            val hsv = FloatArray(3)
+            Color.colorToHSV(argb, hsv)
+            val sat = hsv[1]
+            val light = hsv[2]
+            if (sat < MIN_CHROMA) continue
+            val proportion = count / total
+            val hue = ((hsv[0].toInt() % 360) + 360) % 360
+            infos.add(CInfo(argb, hsv[0], sat, light, proportion))
+            hueProportions[hue] += proportion
+        }
+
+        if (infos.isEmpty()) return GOOGLE_BLUE_ARGB
+
+        // Score: area-weighted hue density + chroma bonus
+        fun hueArea(hue: Float): Double {
+            var sum = 0.0
+            for (i in -15..15) {
+                val idx = (((hue.toInt() + i) % 360) + 360) % 360
+                sum += hueProportions[idx]
+            }
+            return sum
+        }
+        fun score(c: CInfo): Double = 0.8 * 100.0 * hueArea(c.hue) + 0.2 * 100.0 * (c.sat - 0.48).coerceAtLeast(0.0)
+
+        val sorted = infos.sortedByDescending { score(it) }
+
+        // Pick top color with hue distinctness
+        val picked = mutableListOf<CInfo>()
+        for (threshold in 90 downTo 15) {
+            picked.clear()
+            for (info in sorted) {
+                if (picked.any { hueDiff(info.hue.toDouble(), it.hue.toDouble()) < threshold }) continue
+                picked.add(info)
+                if (picked.size >= 4) break
+            }
+            if (picked.isNotEmpty()) break
+        }
+        return picked.firstOrNull()?.argb ?: GOOGLE_BLUE_ARGB
+    }
+
+    private fun hueDiff(a: Double, b: Double): Double {
+        val d = abs(a - b)
+        return if (d > 180.0) 360.0 - d else d
+    }
+
+    /**
+     * Generate a Material You-style Compose ColorScheme from a seed ARGB color.
+     *
+     * Uses HSL-based tonal palette:
+     * - Primary: seed hue, high saturation
+     * - Secondary: seed hue, medium saturation
+     * - Tertiary: seed hue + 60°, medium saturation
+     * - Neutral: seed hue, very low saturation
+     * - Error: red hue
+     *
+     * Each palette produces tones at 10/20/30/40/50/60/70/80/90/95/99/100.
+     */
+    fun generateColorScheme(seedArgb: Int, isDark: Boolean): androidx.compose.material3.ColorScheme {
+        val hsv = FloatArray(3)
+        Color.colorToHSV(seedArgb, hsv)
+        val seedHue = hsv[0]
+
+        // Tonal palette generator: given hue+sat, produce colors at different lightness levels
+        fun tonal(hue: Float, sat: Float, lightness: Int): ComposeColor {
+            val l = lightness / 100f
+            val adjustedSat = sat * (1f - abs(2f * l - 1f) * 0.3f) // reduce sat at extremes
+            return ComposeColor(Color.HSVToColor(floatArrayOf(hue, adjustedSat.coerceIn(0f, 1f), l)))
+        }
+        // Neutral: AOSP-style chroma ~4 for neutral, ~8 for neutral-var
+        // Saturation varies with lightness to approximate perceptual uniformity
+        fun neutral(hue: Float, lightness: Int): ComposeColor {
+            val l = lightness / 100f
+            val sat = 0.02f + abs(2f * l - 1f) * 0.04f  // higher at extremes
+            return ComposeColor(Color.HSVToColor(floatArrayOf(hue, sat.coerceIn(0f, 0.06f), l)))
+        }
+        fun neutralVar(hue: Float, lightness: Int): ComposeColor {
+            val l = lightness / 100f
+            val sat = 0.03f + abs(2f * l - 1f) * 0.06f  // higher at extremes
+            return ComposeColor(Color.HSVToColor(floatArrayOf(hue, sat.coerceIn(0f, 0.10f), l)))
+        }
+
+        val primaryHue = seedHue
+        val secondaryHue = seedHue
+        val tertiaryHue = (seedHue + 60f) % 360f
+        val errorHue = 0f
+
+        // Use container-level saturation as the main tone (softer, less heavy)
+        // primary itself is very subtle; primaryContainer carries the accent feel
+        val primarySat = 0.40f
+        val secondarySat = 0.24f
+        val tertiarySat = 0.30f
+        val errorSat = 0.65f
+
+        return if (isDark) {
+            darkColorScheme(
+                primary = tonal(primaryHue, primarySat, 80),
+                onPrimary = tonal(primaryHue, primarySat, 20),
+                primaryContainer = tonal(primaryHue, primarySat, 30),
+                onPrimaryContainer = tonal(primaryHue, primarySat, 90),
+                secondary = tonal(secondaryHue, secondarySat, 80),
+                onSecondary = tonal(secondaryHue, secondarySat, 20),
+                secondaryContainer = tonal(secondaryHue, secondarySat, 30),
+                onSecondaryContainer = tonal(secondaryHue, secondarySat, 90),
+                tertiary = tonal(tertiaryHue, tertiarySat, 80),
+                onTertiary = tonal(tertiaryHue, tertiarySat, 20),
+                tertiaryContainer = tonal(tertiaryHue, tertiarySat, 30),
+                onTertiaryContainer = tonal(tertiaryHue, tertiarySat, 90),
+                error = tonal(errorHue, errorSat, 80),
+                onError = tonal(errorHue, errorSat, 20),
+                errorContainer = tonal(errorHue, errorSat, 30),
+                onErrorContainer = tonal(errorHue, errorSat, 90),
+                background = neutral(primaryHue, 6),
+                onBackground = neutral(primaryHue, 90),
+                surface = neutral(primaryHue, 6),
+                onSurface = neutral(primaryHue, 90),
+                surfaceVariant = neutralVar(primaryHue, 30),
+                onSurfaceVariant = neutralVar(primaryHue, 80),
+                outline = neutralVar(primaryHue, 60),
+                outlineVariant = neutralVar(primaryHue, 30),
+                surfaceContainerLowest = neutral(primaryHue, 4),
+                surfaceContainerLow = neutral(primaryHue, 10),
+                surfaceContainer = neutral(primaryHue, 12),
+                surfaceContainerHigh = neutral(primaryHue, 17),
+                surfaceContainerHighest = neutral(primaryHue, 22),
+                inverseSurface = neutral(primaryHue, 90),
+                inverseOnSurface = neutral(primaryHue, 20),
+                inversePrimary = tonal(primaryHue, primarySat, 40),
+            )
+        } else {
+            lightColorScheme(
+                primary = tonal(primaryHue, primarySat, 40),
+                onPrimary = ComposeColor.White,
+                primaryContainer = tonal(primaryHue, primarySat, 90),
+                onPrimaryContainer = tonal(primaryHue, primarySat, 10),
+                secondary = tonal(secondaryHue, secondarySat, 40),
+                onSecondary = ComposeColor.White,
+                secondaryContainer = tonal(secondaryHue, secondarySat, 90),
+                onSecondaryContainer = tonal(secondaryHue, secondarySat, 10),
+                tertiary = tonal(tertiaryHue, tertiarySat, 40),
+                onTertiary = ComposeColor.White,
+                tertiaryContainer = tonal(tertiaryHue, tertiarySat, 90),
+                onTertiaryContainer = tonal(tertiaryHue, tertiarySat, 10),
+                error = tonal(errorHue, errorSat, 40),
+                onError = ComposeColor.White,
+                errorContainer = tonal(errorHue, errorSat, 90),
+                onErrorContainer = tonal(errorHue, errorSat, 10),
+                background = neutral(primaryHue, 98),
+                onBackground = neutral(primaryHue, 10),
+                surface = neutral(primaryHue, 98),
+                onSurface = neutral(primaryHue, 10),
+                surfaceVariant = neutralVar(primaryHue, 90),
+                onSurfaceVariant = neutralVar(primaryHue, 30),
+                outline = neutralVar(primaryHue, 50),
+                outlineVariant = neutralVar(primaryHue, 80),
+                surfaceContainerLowest = neutral(primaryHue, 100),
+                surfaceContainerLow = neutral(primaryHue, 96),
+                surfaceContainer = neutral(primaryHue, 94),
+                surfaceContainerHigh = neutral(primaryHue, 92),
+                surfaceContainerHighest = neutral(primaryHue, 90),
+                inverseSurface = neutral(primaryHue, 20),
+                inverseOnSurface = neutral(primaryHue, 95),
+                inversePrimary = tonal(primaryHue, primarySat, 80),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/utils/BitmapUtils.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/utils/BitmapUtils.kt
@@ -1,0 +1,50 @@
+package com.aliothmoon.maameow.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import java.io.File
+import kotlin.math.max
+
+object BitmapUtils {
+    fun loadDownsampledBitmap(
+        context: Context,
+        uri: Uri,
+        maxDimension: Int = 2048,
+    ): Bitmap? {
+        return try {
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            context.contentResolver.openInputStream(uri)?.use {
+                BitmapFactory.decodeStream(it, null, bounds)
+            }
+
+            val maxDim = max(bounds.outWidth, bounds.outHeight)
+            val sample = if (maxDim > maxDimension) {
+                (maxDim / maxDimension).coerceAtLeast(1)
+            } else {
+                1
+            }
+            val opts = BitmapFactory.Options().apply { inSampleSize = sample }
+            context.contentResolver.openInputStream(uri)?.use {
+                BitmapFactory.decodeStream(it, null, opts)
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun loadDownsampledBitmap(
+        context: Context,
+        uriString: String,
+        maxDimension: Int = 2048,
+    ): Bitmap? {
+        val uri = parseUri(uriString)
+        return loadDownsampledBitmap(context, uri, maxDimension)
+    }
+
+    private fun parseUri(uriString: String): Uri {
+        val uri = Uri.parse(uriString)
+        return if (uri.scheme == null) Uri.fromFile(File(uriString)) else uri
+    }
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1799,4 +1799,21 @@
     <string name="runlog_task_stopped">Tasks stopped, status: %1$s</string>
     <string name="runlog_service_terminated">MAA service terminated unexpectedly</string>
     <string name="runlog_game_process_gone">Game process not started or closed unexpectedly (%1$s)</string>
+    <string name="settings_wallpaper_title">Custom Wallpaper</string>
+    <string name="settings_wallpaper_desc">Choose an image as app background</string>
+    <string name="settings_wallpaper_set">Wallpaper set</string>
+    <string name="settings_wallpaper_clear">Cancel Setting</string>
+    <string name="settings_wallpaper_alpha">Opacity: %d%%</string>
+    <string name="settings_wallpaper_blur">Blur: %d</string>
+    <string name="settings_wallpaper_scale_mode">Scale Mode</string>
+    <string name="settings_wallpaper_scale_crop">Crop</string>
+    <string name="settings_wallpaper_scale_fit">Fit</string>
+    <string name="settings_wallpaper_scale_fill_width">Fill Width</string>
+    <string name="settings_wallpaper_scale_fill_height">Fill Height</string>
+    <string name="settings_wallpaper_adjust">Adjust</string>
+    <string name="settings_wallpaper_confirm">Confirm</string>
+    <string name="settings_wallpaper_change">Change Wallpaper</string>
+    <string name="settings_wallpaper_frosted_glass">Frosted Glass</string>
+    <string name="settings_wallpaper_frosted_glass_desc">Semi-transparent components that show wallpaper through</string>
+    
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1815,5 +1815,5 @@
     <string name="settings_wallpaper_change">Change Wallpaper</string>
     <string name="settings_wallpaper_frosted_glass">Frosted Glass</string>
     <string name="settings_wallpaper_frosted_glass_desc">Semi-transparent components that show wallpaper through</string>
-
+    
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1815,5 +1815,5 @@
     <string name="settings_wallpaper_change">Change Wallpaper</string>
     <string name="settings_wallpaper_frosted_glass">Frosted Glass</string>
     <string name="settings_wallpaper_frosted_glass_desc">Semi-transparent components that show wallpaper through</string>
-    
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1871,5 +1871,5 @@
     <string name="settings_wallpaper_change">更换壁纸</string>
     <string name="settings_wallpaper_frosted_glass">磨砂玻璃</string>
     <string name="settings_wallpaper_frosted_glass_desc">开启后组件背景半透明透出壁纸</string>
-    
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1855,4 +1855,21 @@
     <string name="runlog_task_stopped">任务停止，状态: %1$s</string>
     <string name="runlog_service_terminated">MAA服务异常终止</string>
     <string name="runlog_game_process_gone">游戏进程未启动或被异常关闭(%1$s)</string>
+    <string name="settings_wallpaper_title">自定义壁纸</string>
+    <string name="settings_wallpaper_desc">选择一张图片作为应用背景</string>
+    <string name="settings_wallpaper_set">已设置壁纸</string>
+    <string name="settings_wallpaper_clear">取消设置</string>
+    <string name="settings_wallpaper_alpha">透明度: %d%%</string>
+    <string name="settings_wallpaper_blur">模糊度: %d</string>
+    <string name="settings_wallpaper_scale_mode">缩放模式</string>
+    <string name="settings_wallpaper_scale_crop">裁切</string>
+    <string name="settings_wallpaper_scale_fit">适应</string>
+    <string name="settings_wallpaper_scale_fill_width">填宽</string>
+    <string name="settings_wallpaper_scale_fill_height">填高</string>
+    <string name="settings_wallpaper_adjust">调整参数</string>
+    <string name="settings_wallpaper_confirm">确认</string>
+    <string name="settings_wallpaper_change">更换壁纸</string>
+    <string name="settings_wallpaper_frosted_glass">磨砂玻璃</string>
+    <string name="settings_wallpaper_frosted_glass_desc">开启后组件背景半透明透出壁纸</string>
+    
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1871,5 +1871,5 @@
     <string name="settings_wallpaper_change">更换壁纸</string>
     <string name="settings_wallpaper_frosted_glass">磨砂玻璃</string>
     <string name="settings_wallpaper_frosted_glass_desc">开启后组件背景半透明透出壁纸</string>
-
+    
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ composeMarkdown = "0.5.8"
 deviceCompat = "2.3"
 xxPermissions = "28.0"
 reorderable = "3.1.0"
+coil = "3.2.0"
 
 # Kotlin libraries
 kotlinxSerializationJson = "1.11.0"
@@ -105,6 +106,8 @@ angus-mail = { group = "org.eclipse.angus", name = "jakarta.mail", version.ref =
 angus-activation = { group = "org.eclipse.angus", name = "angus-activation", version.ref = "angusActivation" }
 jakarta-activation-api = { group = "jakarta.activation", name = "jakarta.activation-api", version.ref = "jakartaActivationApi" }
 compose-markdown = { group = "com.github.jeziellago", name = "compose-markdown", version.ref = "composeMarkdown" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 reorderable = { group = "sh.calvin.reorderable", name = "reorderable", version.ref = "reorderable" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 


### PR DESCRIPTION
## Summary

Adds a customizable wallpaper background system for the app, including wallpaper selection, crop editing, preview, opacity, blur, frosted-glass surfaces, and wallpaper-based dynamic colors.

## Changes

- Add a dedicated wallpaper settings page for selecting, previewing, re-editing, and clearing a custom wallpaper.
- Add wallpaper opacity, blur, and frosted-glass controls for the app background and UI surfaces.
- Add wallpaper-driven dynamic color generation, with system dynamic color fallback when no custom wallpaper is set.
- Use Coil `AsyncImage` for wallpaper preview loading.
- Share downsampled bitmap loading through `BitmapUtils` to reduce duplicate decode logic and lower OOM risk.
- Defer applying a newly selected wallpaper until crop confirmation, so cancelling crop keeps the existing wallpaper.
- Narrow `takePersistableUriPermission` exception handling to `SecurityException` and `IllegalArgumentException`, with warning logs.

## Notes

- Crop state is kept in `SettingsViewModel` memory for re-editing during the current session; it is not persisted across process recreation.
- Legacy `useSystemMonetColor` migration is intentionally not included in this PR.
