### PR TITLE
feat: custom wallpaper settings (crop, blur%, dynamic color/text, backup-safe)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -169,6 +169,8 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.splashscreen)
+    implementation(libs.androidx.exifinterface)
+    implementation(libs.material.color.utilities)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.process)

--- a/app/src/main/java/com/aliothmoon/maameow/MainActivity.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/MainActivity.kt
@@ -68,10 +68,21 @@ class MainActivity : AppCompatActivity() {
         })
         setContent {
             val themeMode by appSettingsManager.themeMode.collectAsStateWithLifecycle()
-            val useSystemMonetColor by appSettingsManager.useSystemMonetColor.collectAsStateWithLifecycle()
+            val useWallpaperColor by appSettingsManager.useWallpaperColor.collectAsStateWithLifecycle()
+            val wallpaperUri by appSettingsManager.wallpaperUri.collectAsStateWithLifecycle()
             val fontSizeScale by appSettingsManager.fontSizeScale.collectAsStateWithLifecycle()
 
-            MaaMeowTheme(themeMode = themeMode, useSystemMonetColor = useSystemMonetColor) {
+            // System Monet when the switch is on and either there is no custom wallpaper
+            // seed path, or PURE_DARK (custom wallpaper is not drawn / not used for MCU).
+            // Custom wallpaper MCU is applied inside AppNavigation for non-pure-dark.
+            val applySystemDynamicColor = useWallpaperColor && (
+                wallpaperUri.isEmpty() ||
+                    themeMode == AppSettingsManager.ThemeMode.PURE_DARK
+            )
+            MaaMeowTheme(
+                themeMode = themeMode,
+                useWallpaperColor = applySystemDynamicColor,
+            ) {
                 val baseDensity = LocalDensity.current
                 CompositionLocalProvider(
                     LocalDensity provides Density(

--- a/app/src/main/java/com/aliothmoon/maameow/constant/Routes.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/constant/Routes.kt
@@ -13,4 +13,5 @@ object Routes {
     const val SCHEDULE_TRIGGER_LOG = "schedule_trigger_log"
     const val NOTIFICATION = "notification"
     const val TASK_OVERRIDE_EDITOR = "task_override_editor"
+    const val WALLPAPER_SETTINGS = "wallpaper_settings"
 }

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/AppSettingsManager.kt
@@ -3,6 +3,8 @@ package com.aliothmoon.maameow.data.preferences
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import com.aliothmoon.maameow.R
@@ -21,13 +23,17 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 
 class AppSettingsManager(
@@ -36,10 +42,14 @@ class AppSettingsManager(
 ) {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    /** Serializes multi-field settings writes (import / wallpaper preserve / bulk update). */
+    private val settingsMutex = Mutex()
 
     companion object {
         val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "app_settings")
-
+        /** Marks wallpaperBlur as 0..100 percent (post-migration). */
+        private val wallpaperBlurIsPercentKey =
+            booleanPreferencesKey("wallpaper_blur_is_percent")
         /** 页面缩放范围 */
         const val FONT_SIZE_SCALE_MIN = 80
         const val FONT_SIZE_SCALE_MAX = 110
@@ -53,11 +63,61 @@ class AppSettingsManager(
 
     val settings: Flow<AppSettings> = with(AppSettingsSchema) { context.dataStore.flow }
 
-    // 阻塞读取 DataStore 首次值，确保后续 .value 不会是默认值
-    private val initialSettings: AppSettings = runBlocking { settings.first() }
+    // 阻塞读取 DataStore 首次值，确保后续 .value 不会是默认值。
+    // 同步完成 blur 百分制迁移，避免首帧仍按旧 0..12 dp 展示。
+    private val initialSettings: AppSettings = runBlocking {
+        migrateWallpaperBlurToPercentIfNeeded()
+        settings.first()
+    }
+
+    /**
+     * One-shot: old builds stored blur as absolute Compose dp (0..12).
+     * Rewrite to 0..100% so UI matches opacity-style percent scale.
+     */
+    private suspend fun migrateWallpaperBlurToPercentIfNeeded() {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { prefs ->
+                if (prefs[wallpaperBlurIsPercentKey] == true) return@edit
+                val raw = prefs[wallpaperBlur]?.toIntOrNull() ?: 0
+                val percent = if (raw in 0..WallpaperBlur.RADIUS_DP_MAX.toInt()) {
+                    WallpaperBlur.legacyDpToPercent(raw)
+                } else {
+                    WallpaperBlur.parsePercent(raw.toString())
+                }
+                prefs[wallpaperBlur] = percent.toString()
+                prefs[wallpaperBlurIsPercentKey] = true
+            }
+        }
+    }
+
 
     suspend fun setSettings(settings: AppSettings) {
-        with(AppSettingsSchema) { context.dataStore.update(settings) }
+        settingsMutex.withLock {
+            with(AppSettingsSchema) { context.dataStore.update(settings) }
+        }
+    }
+
+    /**
+     * Full settings import that keeps this device's wallpaper-related prefs.
+     * Wallpaper files are device-local and must not be overwritten by backups.
+     * Locked so read-current + write cannot interleave with other bulk updates.
+     */
+    suspend fun setSettingsPreservingWallpaper(settings: AppSettings) {
+        settingsMutex.withLock {
+            val current = this.settings.first()
+            with(AppSettingsSchema) {
+                context.dataStore.update(
+                    settings.copy(
+                        wallpaperUri = current.wallpaperUri,
+                        wallpaperAlpha = current.wallpaperAlpha,
+                        wallpaperBlur = current.wallpaperBlur,
+                        wallpaperTextContrast = current.wallpaperTextContrast,
+                        wallpaperFrostedGlass = current.wallpaperFrostedGlass,
+                        useWallpaperColor = current.useWallpaperColor,
+                    ),
+                )
+            }
+        }
     }
 
     // 悬浮窗模式
@@ -552,18 +612,29 @@ class AppSettingsManager(
     }
 
 
-    // 是否启用系统莫奈主题色（Android 12+ Material You）
-    private fun parseUseSystemMonetColor(raw: String): Boolean =
-        raw.toBooleanStrictOrNull() ?: true
+    // 是否启用壁纸动态取色（有自定义壁纸时从壁纸取色，无壁纸时跟随系统壁纸）
+    // 兼容旧键 useSystemMonetColor，避免升级后开关状态丢失
+    private val legacyUseSystemMonetColorKey = stringPreferencesKey("useSystemMonetColor")
 
-    val useSystemMonetColor: StateFlow<Boolean> = settings
-        .map { parseUseSystemMonetColor(it.useSystemMonetColor) }
+    private fun parseUseWallpaperColor(raw: String?): Boolean =
+        raw?.toBooleanStrictOrNull() ?: false
+
+    val useWallpaperColor: StateFlow<Boolean> = context.dataStore.data
+        .map { prefs ->
+            val current = prefs[AppSettingsSchema.useWallpaperColor]
+            if (current != null) {
+                parseUseWallpaperColor(current)
+            } else {
+                parseUseWallpaperColor(prefs[legacyUseSystemMonetColorKey])
+            }
+        }
         .distinctUntilChanged()
-        .stateIn(scope, SharingStarted.Eagerly, parseUseSystemMonetColor(initialSettings.useSystemMonetColor))
+        .stateIn(scope, SharingStarted.Eagerly, parseUseWallpaperColor(initialSettings.useWallpaperColor))
 
-    suspend fun setUseSystemMonetColor(enabled: Boolean) {
-        with(AppSettingsSchema) {
-            context.dataStore.edit { it[useSystemMonetColor] = enabled.toString() }
+    suspend fun setUseWallpaperColor(enabled: Boolean) {
+        context.dataStore.edit {
+            it[AppSettingsSchema.useWallpaperColor] = enabled.toString()
+            it.remove(legacyUseSystemMonetColorKey)
         }
     }
 
@@ -588,6 +659,76 @@ class AppSettingsManager(
     suspend fun setShowAchievementSnackbar(enabled: Boolean) {
         with(AppSettingsSchema) {
             context.dataStore.edit { it[showAchievementSnackbar] = enabled.toString() }
+        }
+    }
+
+    // Bumped when wallpaper file content may change under the same URI path.
+    private val _wallpaperUpdateVersion = MutableStateFlow(0)
+    val wallpaperUpdateVersion: StateFlow<Int> = _wallpaperUpdateVersion.asStateFlow()
+
+    // 自定义壁纸
+    val wallpaperUri: StateFlow<String> = settings
+        .map { it.wallpaperUri }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperUri)
+
+    suspend fun setWallpaperUri(uri: String) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[wallpaperUri] = uri }
+        }
+        // Always bump so same-path recrop and clear both refresh collectors.
+        _wallpaperUpdateVersion.value++
+    }
+
+    // 壁纸透明度
+    val wallpaperAlpha: StateFlow<Int> = settings
+        .map { it.wallpaperAlpha.toIntOrNull() ?: 100 }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperAlpha.toIntOrNull() ?: 100)
+
+    suspend fun setWallpaperAlpha(alpha: Int) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[wallpaperAlpha] = alpha.coerceIn(0, 100).toString() }
+        }
+    }
+
+    // 壁纸模糊：0..100%（渲染映射到 0..12dp，见 WallpaperBlur）
+    val wallpaperBlur: StateFlow<Int> = settings
+        .map { WallpaperBlur.parsePercent(it.wallpaperBlur) }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, WallpaperBlur.parsePercent(initialSettings.wallpaperBlur))
+
+    suspend fun setWallpaperBlur(blur: Int) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit {
+                it[wallpaperBlur] = blur.coerceIn(0, WallpaperBlur.PERCENT_MAX).toString()
+                // User writes are always percent after this change.
+                it[wallpaperBlurIsPercentKey] = true
+            }
+        }
+    }
+
+    // 壁纸磨砂玻璃
+    // 壁纸文字对比度：独立控制是否基于壁纸亮度调整文字颜色（深动态色）
+    val wallpaperTextContrast: StateFlow<Boolean> = settings
+        .map { it.wallpaperTextContrast.toBoolean() }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperTextContrast.toBoolean())
+
+    suspend fun setWallpaperTextContrast(enabled: Boolean) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[wallpaperTextContrast] = enabled.toString() }
+        }
+    }
+
+    val wallpaperFrostedGlass: StateFlow<Boolean> = settings
+        .map { it.wallpaperFrostedGlass.toBoolean() }
+        .distinctUntilChanged()
+        .stateIn(scope, SharingStarted.Eagerly, initialSettings.wallpaperFrostedGlass.toBoolean())
+
+    suspend fun setWallpaperFrostedGlass(enabled: Boolean) {
+        with(AppSettingsSchema) {
+            context.dataStore.edit { it[wallpaperFrostedGlass] = enabled.toString() }
         }
     }
 

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/ConfigBackupManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/ConfigBackupManager.kt
@@ -62,7 +62,7 @@ class ConfigBackupManager(
         require(backup.version <= CURRENT_VERSION) {
             "不支持的备份版本: ${backup.version}，当前最高支持: $CURRENT_VERSION"
         }
-        appSettingsManager.setSettings(backup.appSettings.normalizedForImport())
+        appSettingsManager.setSettingsPreservingWallpaper(backup.appSettings.normalizedForImport())
         notificationSettingsManager.updateSettings(backup.notificationSettings)
         taskChainState.importProfiles(backup.taskProfiles, backup.activeProfileId)
 
@@ -76,7 +76,17 @@ class ConfigBackupManager(
     companion object {
         const val CURRENT_VERSION = 1
 
-        private fun AppSettings.sanitized() = copy(mirrorChyanCdk = "")
+        private fun AppSettings.sanitized() = copy(
+            mirrorChyanCdk = "",
+            // Device-local wallpaper path/files must never leave this device.
+            wallpaperUri = "",
+            wallpaperAlpha = "100",
+            wallpaperBlur = "0",
+            wallpaperTextContrast = "false",
+            wallpaperFrostedGlass = "false",
+            // Keep export free of wallpaper theme coupling; import preserves local value.
+            useWallpaperColor = "false",
+        )
 
         /**
          * 导入时对已废弃或非法的旧值做归一化，避免后续读取时违反非空约束。

--- a/app/src/main/java/com/aliothmoon/maameow/data/preferences/WallpaperBlur.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/preferences/WallpaperBlur.kt
@@ -1,0 +1,42 @@
+package com.aliothmoon.maameow.data.preferences
+
+import android.os.Build
+
+/**
+ * Wallpaper blur is user-facing as 0..100% (same scale as opacity).
+ *
+ * - API 31+: [androidx.compose.ui.draw.blur] with radius 0..[RADIUS_DP_MAX] dp.
+ * - API 28–30: Compose blur is a no-op; use software Stack Blur on a downscaled bitmap
+ *   with radius 0..[SOFTWARE_RADIUS_PX_MAX] px (see [BitmapUtils.blurForWallpaper]).
+ */
+object WallpaperBlur {
+    const val PERCENT_MAX = 100
+    /** Hard cap for Modifier.blur radius in dp (API 31+). */
+    const val RADIUS_DP_MAX = 12f
+    /**
+     * Hard cap for software Stack Blur radius in pixels on the downscaled bitmap.
+     * Tuned so 100% is clearly visible on API 28–30 without multi-second freezes.
+     */
+    const val SOFTWARE_RADIUS_PX_MAX = 25
+
+    /** True when we must pre-blur the bitmap instead of using Modifier.blur. */
+    val needsSoftwareBlur: Boolean
+        get() = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
+
+    fun parsePercent(raw: String?): Int =
+        (raw?.toIntOrNull() ?: 0).coerceIn(0, PERCENT_MAX)
+
+    fun percentToRadiusDp(percent: Int): Float =
+        (percent.coerceIn(0, PERCENT_MAX) / 100f) * RADIUS_DP_MAX
+
+    /** Software Stack Blur radius in pixels (downscaled bitmap space). */
+    fun percentToSoftwareRadiusPx(percent: Int): Int =
+        ((percent.coerceIn(0, PERCENT_MAX) / 100f) * SOFTWARE_RADIUS_PX_MAX)
+            .toInt()
+            .coerceIn(0, SOFTWARE_RADIUS_PX_MAX)
+
+    /** Legacy builds stored absolute blur dp in 0..12. */
+    fun legacyDpToPercent(legacyDp: Int): Int =
+        ((legacyDp.coerceIn(0, RADIUS_DP_MAX.toInt()) * PERCENT_MAX) / RADIUS_DP_MAX.toInt())
+            .coerceIn(0, PERCENT_MAX)
+}

--- a/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/models/AppSettings.kt
@@ -35,6 +35,7 @@ data class AppSettings(
 
     @PrefKey(default = "false") val muteOnGameLaunch: String = "false",
 
+    /** Write-ahead package name for in-progress game mute session; empty when not muted. */
     @PrefKey(default = "") val mutedGamePackage: String = "",
 
     @PrefKey(default = "false") val closeAppOnTaskEnd: String = "false",
@@ -78,16 +79,25 @@ data class AppSettings(
     /** 定时任务触发时跳过锁屏检查 */
     @PrefKey(default = "false") val runScheduleWhenLocked: String = "false",
 
-    /**
-     * 是否启用系统莫奈主题色（Android 12+ Material You）
-     * 启用后主题跟随系统壁纸动态取色，关闭则使用内置硬编码蓝色主题
-     * Android 12 以下设备只能使用内置蓝色主题
-     */
-    @PrefKey(default = "false") val useSystemMonetColor: String = "false",
+    /** 壁纸动态取色开关：开启后从自定义壁纸提取主色覆盖主题配色 */
+    @PrefKey(default = "false") val useWallpaperColor: String = "false",
 
     /** 页面缩放比例（80~110，默认 100 = 1.0x） */
     @PrefKey(default = "100") val fontSizeScale: String = "100",
 
     /** 是否显示成就解锁时的 Snackbar 提示 */
     @PrefKey(default = "true") val showAchievementSnackbar: String = "true",
+
+    /** 自定义壁纸 URI（content:// 或 file://），空串表示未设置 */
+    @PrefKey(default = "") val wallpaperUri: String = "",
+
+    /** 壁纸透明度 0~100，默认 100 */
+    @PrefKey(default = "100") val wallpaperAlpha: String = "100",
+
+    /** 壁纸模糊半径 0~12，默认 0 */
+    @PrefKey(default = "0") val wallpaperBlur: String = "0",
+
+    /** 壁纸磨砂玻璃效果：组件背景半透明透出壁纸，默认 false */
+    @PrefKey(default = "false") val wallpaperTextContrast: String = "false",
+    @PrefKey(default = "false") val wallpaperFrostedGlass: String = "false",
 )

--- a/app/src/main/java/com/aliothmoon/maameow/overlay/OverlayController.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/overlay/OverlayController.kt
@@ -25,7 +25,7 @@ import com.aliothmoon.maameow.presentation.LocalFloatingWindowContext
 import com.aliothmoon.maameow.presentation.view.panel.ExpandedControlPanel
 import com.aliothmoon.maameow.schedule.model.CountdownState
 import com.aliothmoon.maameow.service.AccessibilityHelperService
-import com.aliothmoon.maameow.theme.MaaMeowTheme
+import com.aliothmoon.maameow.theme.WallpaperAwareMaterialTheme
 import com.aliothmoon.maameow.utils.Misc
 import com.petterp.floatingx.FloatingX
 import com.petterp.floatingx.assist.FxDisplayMode
@@ -214,7 +214,7 @@ class OverlayController(
             setContent {
                 val themeMode by appSettings.themeMode.collectAsStateWithLifecycle()
 
-                MaaMeowTheme(themeMode = themeMode) {
+                WallpaperAwareMaterialTheme(themeMode = themeMode, appSettings = appSettings) {
                     val baseDensity = LocalDensity.current
                     CompositionLocalProvider(
                         LocalFloatingWindowContext provides true,
@@ -328,19 +328,22 @@ class OverlayController(
                         }
                         setContent {
                             // 悬浮窗需要在后台强行保持监听，不使用 collectAsStateWithLifecycle
+                            val themeMode by appSettings.themeMode.collectAsStateWithLifecycle()
                             val runningState by compositionService.state.collectAsState()
                             val countdown by countdownState.collectAsState()
-                            FloatBall(
-                                onClick = {
-                                    if (countdown is CountdownState.Counting) {
-                                        handleCountdownClick()
-                                    } else {
-                                        onFloatBallClick()
-                                    }
-                                },
-                                runningState = runningState,
-                                countdownSeconds = (countdown as? CountdownState.Counting)?.remainingSeconds,
-                            )
+                            WallpaperAwareMaterialTheme(themeMode = themeMode, appSettings = appSettings) {
+                                FloatBall(
+                                    onClick = {
+                                        if (countdown is CountdownState.Counting) {
+                                            handleCountdownClick()
+                                        } else {
+                                            onFloatBallClick()
+                                        }
+                                    },
+                                    runningState = runningState,
+                                    countdownSeconds = (countdown as? CountdownState.Counting)?.remainingSeconds,
+                                )
+                            }
                         }
                     }
                 )

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/AdaptiveTaskPromptDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/AdaptiveTaskPromptDialog.kt
@@ -58,6 +58,7 @@ import com.aliothmoon.maameow.R
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.aliothmoon.maameow.presentation.LocalFloatingWindowContext
+import com.aliothmoon.maameow.theme.overlayBoardColor
 
 /** 普通提示弹窗的最大宽度上限（手机按比例、平板/宽屏封顶） */
 private val DialogMaxWidth = 400.dp
@@ -306,10 +307,9 @@ private fun TaskPromptCard(
     Surface(
         modifier = modifier.fillMaxWidth().wrapContentHeight().heightIn(max = screenHeight * 0.85f),
         shape = RoundedCornerShape(8.dp),
-        color = MaterialTheme.colorScheme.surface,
+        color = overlayBoardColor(),
         contentColor = MaterialTheme.colorScheme.onSurface,
-        tonalElevation = 6.dp,
-        shadowElevation = 8.dp
+        tonalElevation = 6.dp
     ) {
         Column(
             modifier = Modifier.padding(20.dp),

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/AnnouncementDialog.kt
@@ -63,6 +63,7 @@ import com.aliothmoon.maameow.R
 import kotlinx.coroutines.flow.distinctUntilChanged
 import dev.jeziellago.compose.markdowntext.MarkdownText
 import kotlinx.coroutines.delay
+import com.aliothmoon.maameow.theme.overlayBoardColor
 
 /** 勾选"不再显示"前需停留的秒数 */
 private const val STAY_SECONDS_REQUIRED = 5
@@ -152,7 +153,7 @@ fun AnnouncementDialog(
                         vertical = maxVerticalInset,
                     ),
                 shape = RoundedCornerShape(12.dp),
-                color = MaterialTheme.colorScheme.surface,
+                color = overlayBoardColor(),
                 contentColor = MaterialTheme.colorScheme.onSurface,
                 tonalElevation = 6.dp,
                 shadowElevation = 8.dp,

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/InfoCard.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/InfoCard.kt
@@ -18,7 +18,7 @@ import com.aliothmoon.maameow.theme.MaaDesignTokens
 private fun BaseCard(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues,
-    containerColor: Color = MaterialTheme.colorScheme.surface,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerLowest,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Card(
@@ -40,7 +40,7 @@ private fun BaseCard(
 fun InfoCard(
     modifier: Modifier = Modifier,
     title: String = "",
-    containerColor: Color = MaterialTheme.colorScheme.surface,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerLowest,
     contentColor: Color = MaterialTheme.colorScheme.onSurface,
     content: @Composable ColumnScope.() -> Unit,
 ) {
@@ -64,7 +64,7 @@ fun InfoCard(
 @Composable
 fun SettingsGroupCard(
     modifier: Modifier = Modifier,
-    containerColor: Color = MaterialTheme.colorScheme.surface,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerLowest,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     BaseCard(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/OverlayDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/OverlayDialog.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.aliothmoon.maameow.R
+import com.aliothmoon.maameow.theme.overlayBoardColor
 
 /**
  * 悬浮窗专用对话框组件
@@ -97,7 +98,7 @@ fun OverlayDialog(
                         ) { /* 消费点击事件，防止穿透到遮罩层 */ },
                     shape = RoundedCornerShape(8.dp),
                     colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surface
+                        containerColor = overlayBoardColor()
                     )
                 ) {
                     Column(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/ResourceInitDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/ResourceInitDialog.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.domain.state.ResourceInitState
 import com.aliothmoon.maameow.utils.i18n.asString
+import com.aliothmoon.maameow.theme.overlayBoardColor
 
 /**
  * 资源初始化弹窗
@@ -48,7 +49,7 @@ fun ResourceInitDialog(
             ) {
                 Surface(
                     shape = RoundedCornerShape(8.dp),
-                    color = MaterialTheme.colorScheme.surface,
+                    color = overlayBoardColor(),
                     tonalElevation = 6.dp
                 ) {
                     Column(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/ResourceLoadingOverlay.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/ResourceLoadingOverlay.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.aliothmoon.maameow.domain.service.MaaResourceLoader
 import com.aliothmoon.maameow.utils.i18n.resourceLoaderMessage
 import org.koin.compose.koinInject
+import com.aliothmoon.maameow.theme.overlayBoardColor
 
 /**
  * 资源加载 Loading 遮罩
@@ -62,9 +63,8 @@ fun ResourceLoadingOverlay(
         ) {
             Card(
                 colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface
-                ),
-                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+                    containerColor = overlayBoardColor()
+                )
             ) {
                 Column(
                     modifier = Modifier.padding(32.dp),

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/components/UpdateCard.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/components/UpdateCard.kt
@@ -259,7 +259,7 @@ fun UpdateCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
         )
     ) {
         Column(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/AppNavigation.kt
@@ -1,13 +1,19 @@
 package com.aliothmoon.maameow.presentation.navigation
 
+import android.graphics.Bitmap
 import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -16,7 +22,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -27,6 +35,8 @@ import androidx.navigation.compose.rememberNavController
 import com.aliothmoon.maameow.announcement.AnnouncementConfig
 import com.aliothmoon.maameow.constant.Routes
 import com.aliothmoon.maameow.data.preferences.AppSettingsManager
+import com.aliothmoon.maameow.theme.rememberWallpaperDisplayBitmap
+import com.aliothmoon.maameow.theme.wallpaperBlurModifier
 import com.aliothmoon.maameow.domain.models.RunMode
 import com.aliothmoon.maameow.domain.service.ExternalNotificationService
 import com.aliothmoon.maameow.overlay.OverlayController
@@ -40,6 +50,7 @@ import com.aliothmoon.maameow.presentation.view.settings.AchievementView
 import com.aliothmoon.maameow.presentation.view.settings.ErrorLogView
 import com.aliothmoon.maameow.presentation.view.settings.LogHistoryView
 import com.aliothmoon.maameow.presentation.view.settings.TaskOverrideEditorView
+import com.aliothmoon.maameow.presentation.view.settings.WallpaperSettingsView
 import com.aliothmoon.maameow.presentation.viewmodel.AppEventsViewModel
 import com.aliothmoon.maameow.presentation.viewmodel.BackgroundTaskViewModel
 import com.aliothmoon.maameow.schedule.model.CountdownState
@@ -47,13 +58,19 @@ import com.aliothmoon.maameow.schedule.ui.CountdownDialog
 import com.aliothmoon.maameow.schedule.ui.ScheduleEditView
 import com.aliothmoon.maameow.schedule.ui.ScheduleTriggerLogView
 import com.aliothmoon.maameow.theme.MaaAnimations
+import com.aliothmoon.maameow.theme.WallpaperColorScheme
+import com.aliothmoon.maameow.theme.withPureDarkSurfaces
+import com.aliothmoon.maameow.utils.BitmapUtils
+import com.aliothmoon.maameow.utils.WallpaperFileStore
 import com.aliothmoon.maameow.utils.i18n.resolve
 import com.dokar.sonner.ToastType
 import com.dokar.sonner.Toaster
 import com.dokar.sonner.rememberToasterState
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
@@ -132,19 +149,235 @@ fun AppNavigation(
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        // MainScreen with HorizontalPager for smooth tab switching
-        MainScreen(
-            navController = navController,
-            backgroundTaskViewModel = backgroundTaskViewModel,
-            onViewAnnouncement = { forceShowAnnouncement = true },
-            visible = isOnMainTab,
-            fullscreen = isFullscreen,
-        )
+        // Full-screen wallpaper background — hide on wallpaper settings page & pure dark mode
+        val wallpaperUri by appSettings.wallpaperUri.collectAsStateWithLifecycle()
+        val wallpaperAlpha by appSettings.wallpaperAlpha.collectAsStateWithLifecycle()
+        val wallpaperBlur by appSettings.wallpaperBlur.collectAsStateWithLifecycle()
+        val wallpaperFrostedGlass by appSettings.wallpaperFrostedGlass.collectAsStateWithLifecycle()
+        val useWallpaperColor by appSettings.useWallpaperColor.collectAsStateWithLifecycle()
+        val wallpaperTextContrast by appSettings.wallpaperTextContrast.collectAsStateWithLifecycle()
 
-        // NavHost 只承载子页面；主 Tab 切换完全由 MainScreen 的 HorizontalPager 处理。
-        // 在此统一下发 LocalToaster，使所有子页面都能弹出顶部提示。
-        CompositionLocalProvider(LocalToaster provides toaster) {
-            NavHost(
+        // Theme awareness for wallpaper behavior
+        val themeMode by appSettings.themeMode.collectAsStateWithLifecycle()
+        val isDarkTheme = when (themeMode) {
+            AppSettingsManager.ThemeMode.SYSTEM -> isSystemInDarkTheme()
+            AppSettingsManager.ThemeMode.WHITE -> false
+            AppSettingsManager.ThemeMode.DARK, AppSettingsManager.ThemeMode.PURE_DARK -> true
+        }
+        val showWallpaper = wallpaperUri.isNotEmpty() &&
+            currentNavRoute != Routes.WALLPAPER_SETTINGS &&
+            themeMode != AppSettingsManager.ThemeMode.PURE_DARK
+
+        // Load full-quality bitmap for wallpaper display on a background thread.
+        // wallpaperUpdateVersion forces reload when the same file path is overwritten.
+        val wallpaperUpdateVersion by appSettings.wallpaperUpdateVersion.collectAsStateWithLifecycle()
+        var nativeBitmap by remember { mutableStateOf<Bitmap?>(null) }
+        // Load whenever a custom wallpaper URI is set (not only when the full-screen image is
+        // drawn). Seed extraction must keep working on the wallpaper settings page and while
+        // the image layer is hidden, otherwise components fall back to the outer blue theme.
+        val needWallpaperBitmap = wallpaperUri.isNotEmpty() &&
+            themeMode != AppSettingsManager.ThemeMode.PURE_DARK
+        LaunchedEffect(wallpaperUri, needWallpaperBitmap, wallpaperUpdateVersion) {
+            // nativeBitmap?.recycle() removed - GC handles it
+            if (!needWallpaperBitmap || wallpaperUri.isEmpty()) {
+                nativeBitmap = null
+                return@LaunchedEffect
+            }
+            val requestUri = wallpaperUri
+            val requestVersion = wallpaperUpdateVersion
+            // Migrate first if needed. Returning early after setWallpaperUri avoids a double
+            // decode: the URI/version change will re-enter this effect once.
+            val store = WallpaperFileStore(context)
+            val migratedUri = withContext(Dispatchers.IO) {
+                // Heal mid-edit crash before reading/migrating wallpaper files.
+                store.reconcileOrphanEditBackup()
+                store.migrateLegacyUriIfNeeded(requestUri)
+            }
+            if (requestUri != wallpaperUri || requestVersion != wallpaperUpdateVersion) return@LaunchedEffect
+            if (migratedUri != null && migratedUri != requestUri) {
+                appSettings.setWallpaperUri(migratedUri)
+                return@LaunchedEffect
+            }
+            // Stale preference path with missing file: clear so the UI does not stay on a
+            // transparent empty background forever.
+            val exists = withContext(Dispatchers.IO) { store.fileExistsForUri(requestUri) }
+            if (requestUri != wallpaperUri || requestVersion != wallpaperUpdateVersion) return@LaunchedEffect
+            if (!exists) {
+                nativeBitmap = null
+                appSettings.setWallpaperUri("")
+                return@LaunchedEffect
+            }
+            // Drop the previous frame immediately so same-path recrop cannot flash old pixels.
+            nativeBitmap = null
+            val loaded = withContext(Dispatchers.IO) {
+                BitmapUtils.loadDownsampledBitmap(context, requestUri)
+            }
+            if (requestUri != wallpaperUri || requestVersion != wallpaperUpdateVersion) return@LaunchedEffect
+            if (loaded == null) {
+                // File exists but decode failed (transient IO/OOM/corrupt frame).
+                // Keep wallpaperUri so a flaky decode does not wipe the user setting;
+                // missing paths are already cleared above via !exists.
+                nativeBitmap = null
+            } else {
+                nativeBitmap = loaded
+            }
+        }
+        // DisposableEffect removed - avoid race condition with recycled bitmap
+
+        if (showWallpaper) {
+            // API 31+: sharp bitmap + Modifier.blur; API 28–30: software Stack Blur bitmap.
+            val bitmap = rememberWallpaperDisplayBitmap(nativeBitmap, wallpaperBlur)
+            if (bitmap != null) {
+                val contentScale = ContentScale.Crop
+                // Wallpaper image
+                androidx.compose.foundation.Image(
+                    bitmap = bitmap,
+                    contentDescription = null,
+                    contentScale = contentScale,
+                    alpha = wallpaperAlpha / 100f,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .then(wallpaperBlurModifier(wallpaperBlur)),
+                )
+                // Dark mode: dim the wallpaper
+                if (isDarkTheme) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.Black.copy(alpha = 0.3f)),
+                    )
+                }
+            }
+        }
+
+        // Dynamic color: quantize seed once per wallpaper identity; rebuild scheme when theme flips.
+        // Do not gate on nativeBitmap alone — seed must still resolve when the full-screen image
+        // layer is hidden (settings page) or still loading, so UI components keep wallpaper colors.
+        var wallpaperSeedArgb by remember { mutableStateOf<Int?>(null) }
+        // Seed is used for (1) dynamic ColorScheme and (2) content/text contrast on wallpaper.
+        // Load whenever a wallpaper is set; PURE_DARK still skips bitmap load above so no seed there.
+        // Include the two color switches in keys so toggling them re-runs seed load/clear
+        // (otherwise needSeed is only read once and late ON may leave wallpaperSeedArgb null).
+        LaunchedEffect(
+            nativeBitmap,
+            wallpaperUri,
+            wallpaperUpdateVersion,
+            needWallpaperBitmap,
+            useWallpaperColor,
+            wallpaperTextContrast,
+        ) {
+            val needSeed = wallpaperTextContrast || useWallpaperColor
+            if (wallpaperUri.isEmpty() || !needWallpaperBitmap) {
+                wallpaperSeedArgb = null
+                return@LaunchedEffect
+            }
+            if (!needSeed) {
+                wallpaperSeedArgb = null
+                return@LaunchedEffect
+            }
+            val requestUri = wallpaperUri
+            val requestVersion = wallpaperUpdateVersion
+            val displayBitmap = nativeBitmap
+            val seed = withContext(Dispatchers.Default) {
+                val store = WallpaperFileStore(context)
+                val identity = store.wallpaperIdentity(requestUri)
+                store.loadCachedSeed(identity)?.let { return@withContext it }
+                val sourceBitmap = displayBitmap
+                    ?: BitmapUtils.loadDownsampledBitmap(context, requestUri, maxDimension = 512)
+                if (sourceBitmap == null) {
+                    null
+                } else {
+                    try {
+                        WallpaperColorScheme.extractSeedColor(sourceBitmap).also { extracted ->
+                            store.saveCachedSeed(identity, extracted)
+                        }
+                    } finally {
+                        // Only recycle the temporary sample we loaded ourselves.
+                        if (sourceBitmap !== displayBitmap && !sourceBitmap.isRecycled) {
+                            sourceBitmap.recycle()
+                        }
+                    }
+                }
+            }
+            // Drop superseded seed results from a faster previous recrop/switch.
+            if (requestUri == wallpaperUri && requestVersion == wallpaperUpdateVersion) {
+                wallpaperSeedArgb = seed
+            }
+        }
+        val dynamicColorScheme = remember(wallpaperSeedArgb, isDarkTheme) {
+            wallpaperSeedArgb?.let { WallpaperColorScheme.generateColorScheme(it, isDarkTheme) }
+        }
+        // Keep the last wallpaper-derived scheme to avoid flashing the outer system/monet
+        // theme while a new seed is being quantized.
+        var lastWallpaperScheme by remember { mutableStateOf<ColorScheme?>(null) }
+        SideEffect {
+            if (dynamicColorScheme != null) {
+                lastWallpaperScheme = dynamicColorScheme
+            } else if (!useWallpaperColor || wallpaperUri.isEmpty()) {
+                lastWallpaperScheme = null
+            }
+        }
+
+        // Adaptive color scheme: transparent Scaffold background when wallpaper is shown.
+        // Only background is transparent so wallpaper shows through the scaffold.
+        // When frosted glass is enabled, dialog/card surfaces become semi-transparent.
+        val isPureDark = themeMode == AppSettingsManager.ThemeMode.PURE_DARK
+        // PURE_DARK: never let wallpaper MCU / residual scheme tint surface containers gray.
+        // Still allow primary accents from outer theme; force pure-black surface family.
+        val baseScheme = when {
+            isPureDark -> MaterialTheme.colorScheme.withPureDarkSurfaces()
+            useWallpaperColor && dynamicColorScheme != null -> dynamicColorScheme
+            useWallpaperColor && wallpaperUri.isNotEmpty() && lastWallpaperScheme != null -> lastWallpaperScheme!!
+            else -> MaterialTheme.colorScheme
+        }.let { scheme ->
+            // Content/text only: pick readable ink from wallpaper seed.
+            // Independent of useWallpaperColor. Gate on wallpaper *existing* (and not
+            // PURE_DARK), not showWallpaper — settings page hides the full-screen layer
+            // but should still preview dynamic text when the toggle is on.
+            val seed = wallpaperSeedArgb
+            val wallpaperActive =
+                wallpaperUri.isNotEmpty() && !isPureDark
+            if (wallpaperActive && wallpaperTextContrast && seed != null) {
+                with(WallpaperColorScheme) { scheme.adaptContentForWallpaper(seed, isDarkTheme) }
+            } else {
+                scheme
+            }
+        }
+        val transparentColorScheme = if (showWallpaper) {
+            if (wallpaperFrostedGlass) {
+                baseScheme.copy(
+                    background = Color.Transparent,
+                    surface = baseScheme.surface.copy(alpha = 0.55f),
+                    surfaceVariant = baseScheme.surfaceVariant.copy(alpha = 0.55f),
+                    surfaceBright = baseScheme.surfaceBright.copy(alpha = 0.70f),
+                    surfaceDim = baseScheme.surfaceDim.copy(alpha = 0.50f),
+                    surfaceContainerLowest = baseScheme.surfaceContainerLowest.copy(alpha = 0.35f),
+                    surfaceContainerLow = baseScheme.surfaceContainerLow.copy(alpha = 0.40f),
+                    surfaceContainer = baseScheme.surfaceContainer.copy(alpha = 0.65f),
+                    surfaceContainerHigh = baseScheme.surfaceContainerHigh.copy(alpha = 0.80f),
+                    surfaceContainerHighest = baseScheme.surfaceContainerHighest.copy(alpha = 0.90f),
+                    outline = baseScheme.outline.copy(alpha = 0.35f),
+                    outlineVariant = baseScheme.outlineVariant.copy(alpha = 0.30f),
+                )
+            } else {
+                baseScheme.copy(background = Color.Transparent)
+            }
+        } else baseScheme
+
+        // MainScreen with HorizontalPager for smooth tab switching
+        MaterialTheme(colorScheme = transparentColorScheme) {
+            MainScreen(
+                navController = navController,
+                backgroundTaskViewModel = backgroundTaskViewModel,
+                onViewAnnouncement = { forceShowAnnouncement = true },
+                visible = isOnMainTab,
+                fullscreen = isFullscreen,
+            )
+
+            // NavHost 只承载子页面；主 Tab 切换完全由 MainScreen 的 HorizontalPager 处理。
+            // 在此统一下发 LocalToaster，使所有子页面都能弹出顶部提示。
+            CompositionLocalProvider(LocalToaster provides toaster) {
+                NavHost(
                 navController = navController,
                 startDestination = Routes.HOME,
                 enterTransition = { MaaAnimations.sharedAxisForwardEnter },
@@ -181,28 +414,40 @@ fun AppNavigation(
                 composable(Routes.TASK_OVERRIDE_EDITOR) {
                     TaskOverrideEditorView(navController = navController)
                 }
+                composable(Routes.WALLPAPER_SETTINGS) {
+                    val settingsVm: com.aliothmoon.maameow.presentation.viewmodel.SettingsViewModel = koinViewModel()
+                    WallpaperSettingsView(navController = navController, viewModel = settingsVm)
+                }
+            }  // NavHost
             }
-        }
-        ResourceLoadingOverlay()
+                ResourceLoadingOverlay()
+}  // MaterialTheme
         // 顶部轻提示（sonner）：替代旧的 Material3 Snackbar，按类型上色（成功=绿、错误=红）
-        Toaster(
-            state = toaster,
-            alignment = Alignment.TopCenter,
-            richColors = true,
-            showCloseButton = true,
-            darkTheme = MaterialTheme.colorScheme.background.luminance() < 0.5f,
-            containerPadding = PaddingValues(top = 8.dp),
-            modifier = Modifier.statusBarsPadding(),
-        )
+        // Outside main MaterialTheme: re-apply wallpaper baseScheme so toast chrome follows seed colors.
+        MaterialTheme(colorScheme = baseScheme) {
+            Toaster(
+                state = toaster,
+                alignment = Alignment.TopCenter,
+                richColors = true,
+                showCloseButton = true,
+                darkTheme = isDarkTheme,
+                containerPadding = PaddingValues(top = 8.dp),
+                modifier = Modifier.statusBarsPadding(),
+            )
+        }
         // 全局定时任务倒计时弹窗（前台所有控制模式均不弹出对话框，静默处理）
+        // Outside the main MaterialTheme block (same as announcement): must re-apply
+        // wallpaper-derived baseScheme so AlertDialog follows dynamic colors.
         val countdown = scheduledCountdownState
         val hideCountdownDialog = runMode == RunMode.FOREGROUND
         if (countdown is CountdownState.Counting && !hideCountdownDialog) {
-            CountdownDialog(
-                state = countdown,
-                onCancel = { backgroundTaskViewModel.onScheduledCountdownCancel() },
-                onStartNow = { backgroundTaskViewModel.onScheduledStartNow() },
-            )
+            MaterialTheme(colorScheme = baseScheme) {
+                CountdownDialog(
+                    state = countdown,
+                    onCancel = { backgroundTaskViewModel.onScheduledCountdownCancel() },
+                    onStartNow = { backgroundTaskViewModel.onScheduledStartNow() },
+                )
+            }
         }
         // 长期公告弹窗：每次公告版本变更后首次启动自动弹出，或从设置中手动打开
         val needsToShow = announcementReadVersion != AnnouncementConfig.CURRENT_VERSION
@@ -215,6 +460,7 @@ fun AppNavigation(
             }
         }
         if (announcementMarkdown != null) {
+            androidx.compose.material3.MaterialTheme(colorScheme = baseScheme) {
             AnnouncementDialog(
                 imageAssetPath = remember(language) { AnnouncementConfig.imageAssetPath(language) },
                 markdown = announcementMarkdown,
@@ -229,6 +475,7 @@ fun AppNavigation(
                     }
                 },
             )
+            }
         }
     }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/BottomNavigation.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/navigation/BottomNavigation.kt
@@ -71,7 +71,7 @@ fun AppBottomNavigation(
     modifier: Modifier = Modifier,
 ) {
     Surface(
-        modifier = modifier, color = MaterialTheme.colorScheme.surface, shadowElevation = 0.dp
+        modifier = modifier, color = MaterialTheme.colorScheme.surfaceContainerLowest, shadowElevation = 0.dp
     ) {
         Column {
             HorizontalDivider(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/background/BackgroundTaskView.kt
@@ -126,6 +126,7 @@ import com.aliothmoon.maameow.presentation.view.panel.rememberSafToolboxFileExpo
 import com.aliothmoon.maameow.theme.MaaAnimations
 import com.aliothmoon.maameow.theme.MaaThemeAlphas
 import androidx.compose.animation.core.tween
+import com.aliothmoon.maameow.theme.overlayBoardColor
 
 @Composable
 fun BackgroundTaskView(
@@ -371,7 +372,7 @@ fun BackgroundTaskView(
                                                 .weight(1f)
                                                 .fillMaxHeight(),
                                             colors = CardDefaults.cardColors(
-                                                containerColor = MaterialTheme.colorScheme.surface
+                                                containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
                                             )
                                         ) {
                                             Column(modifier = Modifier.padding(top = 10.dp)) {
@@ -676,7 +677,7 @@ fun BackgroundTaskView(
                     Icon(
                         imageVector = Icons.Default.Close,
                         contentDescription = stringResource(R.string.task_close_preview_cd),
-                        tint = Color.White.copy(alpha = 0.7f),
+                        tint = MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = 0.7f),
                         modifier = Modifier.size(28.dp)
                     )
                 }
@@ -804,10 +805,8 @@ private fun BackgroundMoreActionsOverlay(
                     interactionSource = cardInteractionSource, indication = null, onClick = {}),
             shape = RoundedCornerShape(4.dp),
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface
-            ),
-            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-            border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)) {
+                containerColor = overlayBoardColor()
+            )) {
             Column(modifier = Modifier.padding(10.dp)) {
                 // 标题与快速操作组
                 Text(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/home/HomeView.kt
@@ -339,7 +339,7 @@ private fun ScreenInfoCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
         )
     ) {
         Column(
@@ -564,7 +564,7 @@ private fun RunModeCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
         )
     ) {
         Row(
@@ -661,7 +661,7 @@ private fun PermissionCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
         )
     ) {
         Column(
@@ -774,7 +774,7 @@ private fun ForegroundModeSection(
             elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
             shape = MaterialTheme.shapes.medium,
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
             )
         ) {
             Column(modifier = Modifier.padding(12.dp)) {
@@ -834,7 +834,7 @@ private fun ForegroundModeSection(
             elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
             shape = MaterialTheme.shapes.medium,
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
             )
         ) {
             Row(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/ExpandedControlPanel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/ExpandedControlPanel.kt
@@ -1,5 +1,6 @@
 package com.aliothmoon.maameow.presentation.view.panel
 
+import androidx.compose.ui.graphics.Color
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -117,7 +118,7 @@ fun ExpandedControlPanel(
                 ),
             shape = RoundedCornerShape(4.dp),
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
             )
         ) {
             Column(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/LogPanel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/LogPanel.kt
@@ -118,42 +118,49 @@ fun LogPanel(
             }
         }
 
-        Box(modifier = Modifier.weight(1f)) {
-            LazyColumn(
-                state = listState,
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                items(
-                    items = logs,
-                    key = { it.id }
-                ) { logItem ->
-                    LogLine(
-                        logItem = logItem,
-                        onClick = { selectedLog = logItem }
-                    )
-                }
-            }
-
-            if (listState.canScrollForward && logs.isNotEmpty()) {
-                IconButton(
-                    onClick = { isAutoScroll = true },
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(16.dp)
-                        .size(40.dp)
-                        .background(
-                            MaterialTheme.colorScheme.primaryContainer,
-                            CircleShape
-                        )
+        Surface(
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerLowest,
+            tonalElevation = 1.dp,
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    Icon(
-                        imageVector = Icons.Filled.KeyboardArrowDown,
-                        contentDescription = stringResource(R.string.panel_log_resume_auto_scroll),
-                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                        modifier = Modifier.size(20.dp)
-                    )
+                    items(
+                        items = logs,
+                        key = { it.id }
+                    ) { logItem ->
+                        LogLine(
+                            logItem = logItem,
+                            onClick = { selectedLog = logItem }
+                        )
+                    }
+                }
+
+                if (listState.canScrollForward && logs.isNotEmpty()) {
+                    IconButton(
+                        onClick = { isAutoScroll = true },
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(16.dp)
+                            .size(40.dp)
+                            .background(
+                                MaterialTheme.colorScheme.primaryContainer,
+                                CircleShape
+                            )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.KeyboardArrowDown,
+                            contentDescription = stringResource(R.string.panel_log_resume_auto_scroll),
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/SettingsView.kt
@@ -117,9 +117,10 @@ fun SettingsView(
     val tasksOverrideEnabled by viewModel.tasksOverrideEnabled.collectAsStateWithLifecycle()
     val updateChannel by viewModel.updateChannel.collectAsStateWithLifecycle()
     val themeMode by viewModel.themeMode.collectAsStateWithLifecycle()
-    val useSystemMonetColor by viewModel.useSystemMonetColor.collectAsStateWithLifecycle()
+    val useWallpaperColor by viewModel.useWallpaperColor.collectAsStateWithLifecycle()
     val fontSizeScale by viewModel.fontSizeScale.collectAsStateWithLifecycle()
     val showAchievementSnackbar by viewModel.showAchievementSnackbar.collectAsStateWithLifecycle()
+    val wallpaperUri by viewModel.wallpaperUri.collectAsStateWithLifecycle()
     val backgroundResolution by viewModel.backgroundResolution.collectAsStateWithLifecycle()
     val language by viewModel.language.collectAsStateWithLifecycle()
     val backupMessage by viewModel.backupMessage.collectAsStateWithLifecycle()
@@ -461,12 +462,25 @@ fun SettingsView(
                         onLanguageSelected = { viewModel.setLanguage(it) }
                     )
                     ListItemDivider()
+                    // Custom wallpaper
+                    SettingClickItem(
+                        title = stringResource(R.string.settings_wallpaper_title),
+                        description = if (wallpaperUri.isNotEmpty()) {
+                            stringResource(R.string.settings_wallpaper_set)
+                        } else {
+                            stringResource(R.string.settings_wallpaper_desc)
+                        },
+                        contentColor = contentColor
+                    ) {
+                        navController.navigate(Routes.WALLPAPER_SETTINGS)
+                    }
+                    ListItemDivider()
                     SettingThemeSection(
                         contentColor = contentColor,
                         selectedMode = themeMode,
                         onModeSelected = { viewModel.setThemeMode(it) },
-                        useSystemMonetColor = useSystemMonetColor,
-                        onMonetColorChanged = { viewModel.setUseSystemMonetColor(it) },
+                        useWallpaperColor = useWallpaperColor,
+                        onWallpaperColorChanged = { viewModel.setUseWallpaperColor(it) },
                         fontSizeScale = fontSizeScale,
                         onFontSizeScaleChanged = { viewModel.setFontSizeScale(it) }
                     )
@@ -735,8 +749,8 @@ private fun SettingThemeSection(
     contentColor: Color,
     selectedMode: AppSettingsManager.ThemeMode,
     onModeSelected: (AppSettingsManager.ThemeMode) -> Unit,
-    useSystemMonetColor: Boolean,
-    onMonetColorChanged: (Boolean) -> Unit,
+    useWallpaperColor: Boolean,
+    onWallpaperColorChanged: (Boolean) -> Unit,
     fontSizeScale: Int,
     onFontSizeScaleChanged: (Int) -> Unit
 ) {
@@ -787,26 +801,24 @@ private fun SettingThemeSection(
                 }
             }
         }
-        // 莫奈主题色（SDK >= S）
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(R.string.settings_monet_color_title),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = contentColor
-                    )
-                    Text(
-                        text = stringResource(R.string.settings_monet_color_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = contentColor.copy(alpha = 0.6f)
-                    )
-                }
-                Switch(checked = useSystemMonetColor, onCheckedChange = onMonetColorChanged)
+        // 壁纸动态取色：自定义壁纸取色不依赖 API 31；无自定义壁纸时系统 dynamic color 仍仅在 S+ 生效。
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.settings_monet_color_title),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = contentColor
+                )
+                Text(
+                    text = stringResource(R.string.settings_monet_color_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = contentColor.copy(alpha = 0.6f)
+                )
             }
+            Switch(checked = useWallpaperColor, onCheckedChange = onWallpaperColorChanged)
         }
         // 页面缩放
         FontSizeSetting(

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperCropEditor.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperCropEditor.kt
@@ -1,0 +1,577 @@
+package com.aliothmoon.maameow.presentation.view.settings
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas as ComposeCanvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.RotateRight
+import androidx.compose.material.icons.outlined.BlurOn
+import androidx.compose.material.icons.outlined.Opacity
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.aliothmoon.maameow.R
+import com.aliothmoon.maameow.data.preferences.WallpaperBlur
+import com.aliothmoon.maameow.theme.rememberWallpaperDisplayBitmap
+import com.aliothmoon.maameow.theme.wallpaperBlurModifier
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.math.atan2
+import kotlin.math.hypot
+import kotlin.math.max
+import kotlin.math.min
+
+/** Which bottom-bar adjust control is expanded under the tool buttons. */
+private enum class CropAdjustTool {
+    Opacity,
+    Blur,
+}
+
+/** Full-screen wallpaper crop / pan / rotate editor. */
+@Composable
+internal fun WallpaperCropEditor(
+    session: WallpaperEditSession,
+    localAlpha: Float,
+    onLocalAlphaChange: (Float) -> Unit,
+    localBlur: Float,
+    onLocalBlurChange: (Float) -> Unit,
+    screenRatio: Float,
+) {
+    BackHandler(enabled = true) {
+        if (!session.isBusy) session.exitEditMode()
+    }
+    BoxWithConstraints(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+        val totalW = constraints.maxWidth.toFloat()
+        val totalH = constraints.maxHeight.toFloat()
+
+        // Crop frame uses phone aspect ratio and occupies ~70%x50% of the editor.
+        val maxCropW = totalW * 0.70f
+        val maxCropH = totalH * 0.50f
+        val cropW: Float
+        val cropH: Float
+        if (maxCropW / screenRatio <= maxCropH) {
+            cropW = maxCropW
+            cropH = cropW / screenRatio
+        } else {
+            cropH = maxCropH
+            cropW = cropH * screenRatio
+        }
+        val cropLeft = (totalW - cropW) / 2f
+        val cropTop = (totalH - cropH) / 2f
+
+        SideEffect {
+            // Only write geometry here. ensureCoverScale must NOT run every frame:
+            // composition during two-finger rotate would clamp/boost mid-gesture.
+            session.cropState.apply {
+                screenW = totalW
+                screenH = totalH
+                this.cropW = cropW
+                this.cropH = cropH
+                this.cropLeft = cropLeft
+                this.cropTop = cropTop
+                imageW = session.sourceBitmap!!.width.toFloat()
+                imageH = session.sourceBitmap!!.height.toFloat()
+            }
+        }
+
+        val bw = session.sourceBitmap!!.width.toFloat()
+        val bh = session.sourceBitmap!!.height.toFloat()
+        val baseScale = min(totalW / bw, totalH / bh)
+        val displayW = bw * baseScale
+        val displayH = bh * baseScale
+        val computedInitScale = max(cropW / displayW, cropH / displayH)
+        LaunchedEffect(session.sourceBitmap) {
+            session.initScale = computedInitScale
+            val restored = withContext(Dispatchers.IO) {
+                session.fileStore.loadCropParams(session.fileStore.sourceIdentity(session.sourceFile))
+            }
+            if (restored != null) {
+                session.cropState.restore(
+                    restoredScale = restored.scale,
+                    restoredPanX = restored.panX,
+                    restoredPanY = restored.panY,
+                    restoredRotation = restored.rotationDegrees,
+                    fallbackScale = computedInitScale,
+                )
+            } else {
+                session.cropState.reset(computedInitScale)
+            }
+        }
+
+        val s = session.cropState
+        var isTouching by remember { mutableStateOf(false) }
+        // null = only tool buttons; select one to expand its slider under the row.
+        var activeAdjustTool by remember { mutableStateOf<CropAdjustTool?>(null) }
+        // Resize / first layout: re-cover when not mid-gesture.
+        LaunchedEffect(totalW, totalH, session.sourceBitmap) {
+            if (!isTouching) {
+                s.ensureCoverScale()
+            }
+        }
+        // After rotate/pinch/pan, re-cover the crop window once the gesture ends.
+        LaunchedEffect(isTouching) {
+            if (!isTouching) {
+                s.ensureCoverScale()
+            }
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(session.isBusy) {
+                    if (session.isBusy) return@pointerInput
+                    // One-finger pan; two-finger: first finger = pivot, second orbits
+                    // for 1:1 rotation (Gallery-style absolute angle tracking).
+                    // isTouching is owned only by this detector so session.isBusy cancellation
+                    // always clears it via finally (avoids stuck mid-gesture cover skip).
+                    awaitEachGesture {
+                        val first = awaitFirstDown(requireUnconsumed = false)
+                        isTouching = true
+                        try {
+                        var pivotId = first.id
+                        var pivotPos = first.position
+                        var lastAngle = 0f
+                        var lastDist = 0f
+                        var multi = false
+
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            val pressed = event.changes.filter { it.pressed }
+                            if (pressed.isEmpty()) break
+
+                            if (pressed.size == 1) {
+                                val p = pressed[0]
+                                if (multi) {
+                                    // Left multi-touch: treat remaining finger as pan base.
+                                    pivotId = p.id
+                                    pivotPos = p.position
+                                    multi = false
+                                }
+                                val prev = p.previousPosition
+                                val dx = p.position.x - prev.x
+                                val dy = p.position.y - prev.y
+                                if (dx != 0f || dy != 0f) {
+                                    s.applyPan(dx, dy)
+                                }
+                                if (p.positionChanged()) p.consume()
+                                pivotPos = p.position
+                            } else {
+                                // Two or more: use first two pointers.
+                                val a = pressed[0]
+                                val b = pressed[1]
+                                // Keep pivot sticky: prefer previous pivotId if still down.
+                                val pivotChange = pressed.find { it.id == pivotId } ?: a
+                                val freeChange = pressed.firstOrNull { it.id != pivotChange.id } ?: b
+                                pivotId = pivotChange.id
+
+                                val newPivot = pivotChange.position
+                                val newFree = freeChange.position
+                                val dx = newFree.x - newPivot.x
+                                val dy = newFree.y - newPivot.y
+                                val dist = hypot(dx, dy).coerceAtLeast(1f)
+                                // Screen y grows downward: atan2 increases clockwise,
+                                // matching Compose rotationZ / Matrix.postRotate.
+                                val angle = atan2(dy, dx)
+
+                                if (!multi) {
+                                    multi = true
+                                    lastAngle = angle
+                                    lastDist = dist
+                                    pivotPos = newPivot
+                                } else {
+                                    val dAngle = angle - lastAngle
+                                    // Wrap to [-PI, PI] for stable 1:1 deltas across ±180°.
+                                    var wrapped = dAngle
+                                    val pi = Math.PI.toFloat()
+                                    if (wrapped > pi) wrapped -= 2f * pi
+                                    if (wrapped < -pi) wrapped += 2f * pi
+                                    val deg = Math.toDegrees(wrapped.toDouble()).toFloat()
+                                    val zoom = if (lastDist > 0f) dist / lastDist else 1f
+                                    // Pivot finger movement pans the whole transform.
+                                    val panX = newPivot.x - pivotPos.x
+                                    val panY = newPivot.y - pivotPos.y
+                                    s.applyTransform(
+                                        zoom = zoom,
+                                        panDeltaX = panX,
+                                        panDeltaY = panY,
+                                        rotationDegreesDelta = deg,
+                                        pivotX = newPivot.x,
+                                        pivotY = newPivot.y,
+                                    )
+                                    lastAngle = angle
+                                    lastDist = dist
+                                    pivotPos = newPivot
+                                }
+                                if (pivotChange.positionChanged()) pivotChange.consume()
+                                if (freeChange.positionChanged()) freeChange.consume()
+                            }
+                        }
+                        } finally {
+                            isTouching = false
+                        }
+                    }
+                }
+        ) {
+            // API 31+: Modifier.blur; API < 31: software Stack Blur on a downscaled copy.
+            val imageBitmap = rememberWallpaperDisplayBitmap(
+                source = session.sourceBitmap,
+                blurPercent = localBlur.toInt(),
+                softwareMaxDimension = 720,
+            )
+            if (imageBitmap != null) {
+            Image(
+                bitmap = imageBitmap,
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                alpha = localAlpha / 100f,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .then(wallpaperBlurModifier(localBlur.toInt()))
+                    .graphicsLayer {
+                        // Keep pivot at screen center so preview matches Matrix export.
+                        transformOrigin = TransformOrigin.Center
+                        scaleX = session.cropState.scale
+                        scaleY = session.cropState.scale
+                        translationX = session.cropState.panX
+                        translationY = session.cropState.panY
+                        rotationZ = session.cropState.rotationDegrees
+                    },
+            )
+            }
+
+            ComposeCanvas(modifier = Modifier.fillMaxSize()) {
+                val maskAlpha = if (isTouching) 0.4f else 1f
+                drawRect(
+                    Color.Black.copy(alpha = maskAlpha),
+                    topLeft = Offset.Zero,
+                    size = Size(size.width, cropTop),
+                )
+                drawRect(
+                    Color.Black.copy(alpha = maskAlpha),
+                    topLeft = Offset(0f, cropTop + cropH),
+                    size = Size(size.width, size.height - cropTop - cropH),
+                )
+                drawRect(
+                    Color.Black.copy(alpha = maskAlpha),
+                    topLeft = Offset(0f, cropTop),
+                    size = Size(cropLeft, cropH),
+                )
+                drawRect(
+                    Color.Black.copy(alpha = maskAlpha),
+                    topLeft = Offset(cropLeft + cropW, cropTop),
+                    size = Size(size.width - cropLeft - cropW, cropH),
+                )
+                drawRect(
+                    Color.White.copy(alpha = 0.8f),
+                    topLeft = Offset(cropLeft, cropTop),
+                    size = Size(cropW, cropH),
+                    style = Stroke(width = 2.dp.toPx()),
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 4.dp, vertical = 4.dp)
+        ) {
+            IconButton(onClick = { if (!session.isBusy) session.exitEditMode() }) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = Color.White)
+            }
+            Row(
+                modifier = Modifier.align(Alignment.CenterEnd),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = { if (!session.isBusy) session.cropState.rotateBy(90f) }) {
+                    Icon(Icons.Default.RotateRight, contentDescription = null, tint = Color.White)
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        stringResource(R.string.settings_wallpaper_rotate),
+                        color = Color.White,
+                    )
+                }
+                TextButton(onClick = { if (!session.isBusy) session.cropState.reset(session.initScale) }) {
+                    Icon(Icons.Default.Refresh, contentDescription = null, tint = Color.White)
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        stringResource(R.string.settings_wallpaper_reset_crop),
+                        color = Color.White,
+                    )
+                }
+                // Save moved from bottom bar so sliders keep full width.
+                IconButton(
+                    onClick = { if (!session.isBusy) session.confirmCrop() },
+                    enabled = !session.isBusy,
+                ) {
+                    if (session.isBusy) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(22.dp),
+                            color = Color.White,
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        Icon(
+                            Icons.Default.Check,
+                            contentDescription = stringResource(R.string.settings_wallpaper_confirm),
+                            tint = Color.White,
+                        )
+                    }
+                }
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .background(
+                    Brush.verticalGradient(
+                        listOf(Color.Transparent, Color.Black.copy(alpha = 0.7f))
+                    )
+                )
+                .navigationBarsPadding()
+                .padding(horizontal = 20.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            // Expand/collapse: fadeIn 200 / fadeOut 150 (original feel).
+            // Opacity ↔ Blur: sequential — fade out current, then fade in target
+            // (same as collapsing one tool then opening the other).
+            AnimatedContent(
+                targetState = activeAdjustTool,
+                transitionSpec = {
+                    val switchingTools = initialState != null && targetState != null
+                    if (switchingTools) {
+                        fadeIn(
+                            animationSpec = tween(
+                                durationMillis = 200,
+                                delayMillis = 150,
+                            ),
+                        ) togetherWith fadeOut(
+                            animationSpec = tween(durationMillis = 150),
+                        )
+                    } else {
+                        fadeIn(animationSpec = tween(durationMillis = 200)) togetherWith
+                            fadeOut(animationSpec = tween(durationMillis = 150))
+                    }
+                },
+                label = "cropAdjustSlider",
+                modifier = Modifier.fillMaxWidth(),
+            ) { tool ->
+                when (tool) {
+                    CropAdjustTool.Opacity -> {
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                stringResource(
+                                    R.string.settings_wallpaper_alpha,
+                                    localAlpha.toInt(),
+                                ),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = Color.White,
+                            )
+                            Slider(
+                                value = localAlpha,
+                                onValueChange = onLocalAlphaChange,
+                                valueRange = 0f..100f,
+                                enabled = !session.isBusy,
+                                // ~4/5 screen width; centered by parent Column.
+                                modifier = Modifier.fillMaxWidth(0.8f),
+                            )
+                        }
+                    }
+                    CropAdjustTool.Blur -> {
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                stringResource(
+                                    R.string.settings_wallpaper_blur,
+                                    localBlur.toInt(),
+                                ),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = Color.White,
+                            )
+                            Slider(
+                                value = localBlur,
+                                onValueChange = onLocalBlurChange,
+                                valueRange = 0f..WallpaperBlur.PERCENT_MAX.toFloat(),
+                                enabled = !session.isBusy,
+                                // ~4/5 screen width; centered by parent Column.
+                                modifier = Modifier.fillMaxWidth(0.8f),
+                            )
+                        }
+                    }
+                    null -> {
+                        Spacer(Modifier.fillMaxWidth().height(0.dp))
+                    }
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.Top,
+            ) {
+                CropAdjustToolButton(
+                    icon = Icons.Outlined.Opacity,
+                    label = stringResource(R.string.settings_wallpaper_opacity_label),
+                    selected = activeAdjustTool == CropAdjustTool.Opacity,
+                    enabled = !session.isBusy,
+                    onClick = {
+                        activeAdjustTool =
+                            if (activeAdjustTool == CropAdjustTool.Opacity) {
+                                null
+                            } else {
+                                CropAdjustTool.Opacity
+                            }
+                    },
+                )
+                CropAdjustToolButton(
+                    icon = Icons.Outlined.BlurOn,
+                    label = stringResource(R.string.settings_wallpaper_blur_label),
+                    selected = activeAdjustTool == CropAdjustTool.Blur,
+                    enabled = !session.isBusy,
+                    onClick = {
+                        activeAdjustTool =
+                            if (activeAdjustTool == CropAdjustTool.Blur) {
+                                null
+                            } else {
+                                CropAdjustTool.Blur
+                            }
+                    },
+                )
+            }
+        }
+
+        if (session.isBusy) {
+            // Consume taps so save/back/tools cannot re-enter while IO is in flight.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.25f))
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = {},
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    stringResource(R.string.settings_wallpaper_saving),
+                    color = Color.White,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+
+}
+
+@Composable
+private fun CropAdjustToolButton(
+    icon: ImageVector,
+    label: String,
+    selected: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val circleColor = if (selected) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        Color.White.copy(alpha = 0.18f)
+    }
+    val contentColor = if (selected) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        Color.White
+    }
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .width(96.dp)
+            .clickable(enabled = enabled, onClick = onClick),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(52.dp)
+                .clip(CircleShape)
+                .background(circleColor),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = label,
+                tint = contentColor,
+                modifier = Modifier.size(26.dp),
+            )
+        }
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White,
+        )
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperCropState.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperCropState.kt
@@ -1,0 +1,279 @@
+package com.aliothmoon.maameow.presentation.view.settings
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Matrix
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.setValue
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sin
+
+@Stable
+class CropState {
+    var scale by mutableFloatStateOf(1f)
+        internal set
+    var panX by mutableFloatStateOf(0f)
+        internal set
+    var panY by mutableFloatStateOf(0f)
+        internal set
+    var rotationDegrees by mutableFloatStateOf(0f)
+        internal set
+    var screenW by mutableFloatStateOf(0f)
+        internal set
+    var screenH by mutableFloatStateOf(0f)
+        internal set
+    var cropW by mutableFloatStateOf(0f)
+        internal set
+    var cropH by mutableFloatStateOf(0f)
+        internal set
+    var cropLeft by mutableFloatStateOf(0f)
+        internal set
+    var cropTop by mutableFloatStateOf(0f)
+        internal set
+
+    // Source image pixel size, used for pan clamping / cover scale.
+    var imageW by mutableFloatStateOf(0f)
+        internal set
+    var imageH by mutableFloatStateOf(0f)
+        internal set
+
+    fun reset(initScale: Float = 1f) {
+        scale = initScale
+        panX = 0f
+        panY = 0f
+        rotationDegrees = 0f
+        ensureCoverScale()
+    }
+
+    fun restore(
+        restoredScale: Float,
+        restoredPanX: Float,
+        restoredPanY: Float,
+        restoredRotation: Float,
+        fallbackScale: Float,
+    ) {
+        scale = restoredScale.coerceIn(MIN_SCALE, MAX_SCALE).takeIf { it.isFinite() } ?: fallbackScale
+        panX = restoredPanX.takeIf { it.isFinite() } ?: 0f
+        panY = restoredPanY.takeIf { it.isFinite() } ?: 0f
+        rotationDegrees = normalizeDegrees(restoredRotation.takeIf { it.isFinite() } ?: 0f)
+        ensureCoverScale()
+    }
+
+    fun rotateBy(degrees: Float) {
+        // Snap 90° steps to exact multiples to avoid float drift on the button path.
+        val next = normalizeDegrees(rotationDegrees + degrees)
+        rotationDegrees = if (abs(degrees) % 90f < 0.01f || abs(abs(degrees) % 90f - 90f) < 0.01f) {
+            (kotlin.math.round(next / 90f) * 90f).let { normalizeDegrees(it) }
+        } else {
+            next
+        }
+        ensureCoverScale()
+    }
+
+    /**
+     * Apply pan/zoom/rotate with [pivotX]/[pivotY] as the rotation/scale center
+     * (one finger stays put; the other orbits for 1:1 angle tracking).
+     *
+     * [rotationDegreesDelta] is already in degrees and applied 1:1 (no gain).
+     * graphicsLayer still uses layer-center + pan; pan is compensated so the
+     * pivot stays fixed under pure rotate/scale.
+     */
+    fun applyTransform(
+        zoom: Float,
+        panDeltaX: Float,
+        panDeltaY: Float,
+        rotationDegreesDelta: Float,
+        pivotX: Float,
+        pivotY: Float,
+    ) {
+        val oldScale = scale
+        val oldRot = rotationDegrees
+        val oldPanX = panX
+        val oldPanY = panY
+        val newScale = (oldScale * zoom).coerceIn(MIN_SCALE, MAX_SCALE)
+        val newRot = if (rotationDegreesDelta != 0f) {
+            normalizeDegrees(oldRot + rotationDegreesDelta)
+        } else {
+            oldRot
+        }
+
+        // graphicsLayer (transformOrigin=Center):
+        //   screen = R(scale * (local - center)) + center + pan
+        val centerX = if (screenW > 0f) screenW / 2f else pivotX
+        val centerY = if (screenH > 0f) screenH / 2f else pivotY
+        // pivotX/Y are the CURRENT pivot-finger position. Recover the pre-pan
+        // pivot so rotate/scale compensation is 1:1 around the finger and pan
+        // is not double-counted when the pivot finger also moves.
+        val oldPivotX = pivotX - panDeltaX
+        val oldPivotY = pivotY - panDeltaY
+        val mappedOldX = oldPivotX - centerX - oldPanX
+        val mappedOldY = oldPivotY - centerY - oldPanY
+        val (localX, localY) = unmapAroundOrigin(mappedOldX, mappedOldY, oldScale, oldRot)
+        val (mappedNewX, mappedNewY) = mapAroundOrigin(localX, localY, newScale, newRot)
+
+        scale = newScale
+        rotationDegrees = newRot
+        // Move with the pivot finger, then keep that contact point fixed under
+        // pure rotate/scale (Gallery / Matrix.postRotate(pivot) style).
+        panX = oldPanX + panDeltaX + (mappedOldX - mappedNewX)
+        panY = oldPanY + panDeltaY + (mappedOldY - mappedNewY)
+    }
+
+    fun applyPan(panDeltaX: Float, panDeltaY: Float) {
+        panX += panDeltaX
+        panY += panDeltaY
+    }
+
+    /**
+     * Map a vector from layer-center coords through uniform scale then
+     * clockwise rotation (matches Compose rotationZ / Android Matrix).
+     */
+    private fun mapAroundOrigin(
+        x: Float,
+        y: Float,
+        s: Float,
+        degrees: Float,
+    ): Pair<Float, Float> {
+        val sx = x * s
+        val sy = y * s
+        val rad = Math.toRadians(degrees.toDouble())
+        val c = cos(rad).toFloat()
+        val sn = sin(rad).toFloat()
+        // Clockwise: x' = x*cos + y*sin, y' = -x*sin + y*cos
+        return (sx * c + sy * sn) to (-sx * sn + sy * c)
+    }
+
+    /** Inverse of [mapAroundOrigin]: counter-clockwise unrotate then unscale. */
+    private fun unmapAroundOrigin(
+        x: Float,
+        y: Float,
+        s: Float,
+        degrees: Float,
+    ): Pair<Float, Float> {
+        val safe = if (s == 0f) 1f else s
+        val rad = Math.toRadians(degrees.toDouble())
+        val c = cos(rad).toFloat()
+        val sn = sin(rad).toFloat()
+        // Inverse of clockwise: x = x'cos - y'sin, y = x'sin + y'cos, then /s
+        val ux = x * c - y * sn
+        val uy = x * sn + y * c
+        return (ux / safe) to (uy / safe)
+    }
+
+    /**
+     * After rotation the axis-aligned bounds change; boost scale if needed so the
+     * image still fully covers the crop window (no black bars), then clamp pan.
+     */
+    fun ensureCoverScale() {
+        if (screenW <= 0f || screenH <= 0f || cropW <= 0f || cropH <= 0f) return
+        if (imageW <= 0f || imageH <= 0f) return
+
+        val baseScale = min(screenW / imageW, screenH / imageH)
+        if (baseScale <= 0f) return
+        val dispW = imageW * baseScale
+        val dispH = imageH * baseScale
+        val rad = Math.toRadians(rotationDegrees.toDouble())
+        val c = abs(cos(rad)).toFloat()
+        val s = abs(sin(rad)).toFloat()
+        val unitW = dispW * c + dispH * s
+        val unitH = dispW * s + dispH * c
+        if (unitW <= 0f || unitH <= 0f) return
+
+        val minCover = max(cropW / unitW, cropH / unitH)
+        if (scale < minCover) {
+            scale = minCover.coerceIn(MIN_SCALE, MAX_SCALE)
+        }
+        clampPan()
+    }
+
+    /**
+     * Keep the scaled/rotated image covering the crop window so saves do not include
+     * empty black borders from over-panning.
+     */
+    fun clampPan() {
+        if (screenW <= 0f || screenH <= 0f || cropW <= 0f || cropH <= 0f) return
+        if (imageW <= 0f || imageH <= 0f) return
+
+        val baseScale = min(screenW / imageW, screenH / imageH)
+        val dispW = imageW * baseScale * scale
+        val dispH = imageH * baseScale * scale
+        val rad = Math.toRadians(rotationDegrees.toDouble())
+        val c = abs(cos(rad)).toFloat()
+        val s = abs(sin(rad)).toFloat()
+        val boundW = dispW * c + dispH * s
+        val boundH = dispW * s + dispH * c
+
+        // Max pan so the image AABB still fully covers the crop rect.
+        val maxPanX = max(0f, (boundW - cropW) / 2f)
+        val maxPanY = max(0f, (boundH - cropH) / 2f)
+        panX = panX.coerceIn(-maxPanX, maxPanX)
+        panY = panY.coerceIn(-maxPanY, maxPanY)
+    }
+
+    fun getCroppedBitmap(source: Bitmap, maxOutputDimension: Int = 2048): Bitmap? {
+        val sw = screenW
+        val sh = screenH
+        // Geometry is written in SideEffect; refuse save until it is ready.
+        if (sw <= 0f || sh <= 0f || cropW <= 0f || cropH <= 0f) return null
+        val bw = source.width.toFloat()
+        val bh = source.height.toFloat()
+        if (bw <= 0f || bh <= 0f) return null
+        val baseScale = min(sw / bw, sh / bh)
+        if (baseScale <= 0f || scale <= 0f) return null
+
+        // Output matches the crop window in screen space mapped back through user scale.
+        // Rotation is baked by the draw matrix; size stays crop-aspect.
+        var outW = (cropW / baseScale / scale).toInt().coerceAtLeast(1)
+        var outH = (cropH / baseScale / scale).toInt().coerceAtLeast(1)
+        val maxOut = maxOf(outW, outH)
+        if (maxOut > maxOutputDimension) {
+            val ratio = maxOutputDimension.toFloat() / maxOut.toFloat()
+            outW = (outW * ratio).toInt().coerceAtLeast(1)
+            outH = (outH * ratio).toInt().coerceAtLeast(1)
+        }
+
+        val m = Matrix()
+        // Source pixels -> fit-centered screen pixels (matches ContentScale.Fit).
+        m.postScale(baseScale, baseScale)
+        m.postTranslate((sw - bw * baseScale) / 2f, (sh - bh * baseScale) / 2f)
+        // User transforms: scale then rotate around screen center, then pan.
+        // Matches Compose graphicsLayer order (scale -> rotate -> translate) with center pivot.
+        m.postTranslate(-sw / 2f, -sh / 2f)
+        m.postScale(scale, scale)
+        m.postRotate(rotationDegrees)
+        m.postTranslate(sw / 2f, sh / 2f)
+        m.postTranslate(panX, panY)
+        // Crop window -> output bitmap origin
+        m.postTranslate(-cropLeft, -cropTop)
+        val scaleFactor = cropW / outW.toFloat()
+        m.postScale(1f / scaleFactor, 1f / scaleFactor)
+
+        return try {
+            val result = Bitmap.createBitmap(outW, outH, Bitmap.Config.ARGB_8888)
+            val canvas = Canvas(result)
+            canvas.drawBitmap(source, m, null)
+            result
+        } catch (_: OutOfMemoryError) {
+            null
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private companion object {
+        const val MIN_SCALE = 0.3f
+        const val MAX_SCALE = 5f
+
+        fun normalizeDegrees(degrees: Float): Float {
+            if (!degrees.isFinite()) return 0f
+            var d = degrees % 360f
+            if (d < 0f) d += 360f
+            return d
+        }
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperEditSession.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperEditSession.kt
@@ -1,0 +1,294 @@
+package com.aliothmoon.maameow.presentation.view.settings
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.aliothmoon.maameow.R
+import com.aliothmoon.maameow.presentation.viewmodel.SettingsViewModel
+import com.aliothmoon.maameow.utils.BitmapUtils
+import com.aliothmoon.maameow.utils.WallpaperFileStore
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Wallpaper pick / crop / backup lifecycle for [WallpaperSettingsView].
+ * UI-free so crop editor and settings body stay presentational.
+ *
+ * Compose state is only written on the main dispatcher (session [scope]).
+ * IO work returns plain values; UI flags are applied after [withContext] returns.
+ */
+class WallpaperEditSession(
+    private val context: Context,
+    private val viewModel: SettingsViewModel,
+    val scope: CoroutineScope,
+    val fileStore: WallpaperFileStore,
+    private val showError: (String) -> Unit,
+) {
+    var isEditing by mutableStateOf(false)
+        private set
+    var sourceBitmap by mutableStateOf<Bitmap?>(null)
+        private set
+    var isBusy by mutableStateOf(false)
+    var initScale by mutableFloatStateOf(1f)
+    val cropState = CropState()
+
+    /** Not Compose state — only used on the main thread between pick/confirm/cancel. */
+    private var editPendingBackup: File? = null
+
+    val sourceFile: File get() = fileStore.sourceFile
+    val croppedFile: File get() = fileStore.croppedFile
+
+    fun enterEditMode(bitmap: Bitmap) {
+        sourceBitmap = bitmap
+        isEditing = true
+    }
+
+    /** Leave crop UI only; does not touch source backup. */
+    fun leaveEditUi() {
+        sourceBitmap = null
+        isEditing = false
+        isBusy = false
+    }
+
+    /**
+     * User abandoned cropping (back). Restore previous source if we had replaced it
+     * for a pending new pick, so re-open crop still matches the on-screen preview.
+     * Stays [isBusy] until restore finishes so a quick re-open cannot race the old source.
+     */
+    fun exitEditMode() {
+        if (isBusy) return
+        val backup = editPendingBackup
+        editPendingBackup = null
+        sourceBitmap = null
+        isEditing = false
+        if (backup != null) {
+            isBusy = true
+            scope.launch {
+                try {
+                    withContext(Dispatchers.IO) {
+                        fileStore.restoreSourceFile(backup, sourceFile)
+                        fileStore.deleteBackup(backup)
+                    }
+                } catch (_: Exception) {
+                    // Best-effort restore; orphan backup is healed on next enter.
+                    try {
+                        withContext(Dispatchers.IO) { fileStore.deleteBackup(backup) }
+                    } catch (_: Exception) {
+                    }
+                } finally {
+                    isBusy = false
+                }
+            }
+        } else {
+            isBusy = false
+        }
+    }
+
+    /**
+     * Crop saved: keep new sourceFile and leave UI.
+     * Pending backup must already be deleted on the confirm IO path (or be null)
+     * so reconcile cannot restore the old source after a durable save.
+     */
+    fun finishEditModeAfterSave() {
+        editPendingBackup = null
+        leaveEditUi()
+    }
+
+    suspend fun onEnterPage(wallpaperUri: String) {
+        withContext(Dispatchers.IO) {
+            fileStore.reconcileOrphanEditBackup()
+        }
+        if (wallpaperUri.isEmpty()) return
+        val result = withContext(Dispatchers.IO) {
+            val migrated = fileStore.migrateLegacyUriIfNeeded(wallpaperUri)
+            when {
+                migrated != null -> "migrated" to migrated
+                fileStore.fileExistsForUri(wallpaperUri) -> "ok" to null
+                else -> "missing" to null
+            }
+        }
+        when (result.first) {
+            "migrated" -> viewModel.setWallpaperUri(result.second!!)
+            "missing" -> {
+                viewModel.setWallpaperUri("")
+                showError(context.getString(R.string.settings_wallpaper_missing))
+            }
+        }
+    }
+
+    fun onPickedUri(uri: Uri) {
+        if (isBusy) return
+        scope.launch {
+            isBusy = true
+            try {
+                // IO returns values only — do not touch Compose state / editPendingBackup on IO.
+                data class PickResult(val bitmap: Bitmap?, val pendingBackup: File?)
+                val pick = withContext(Dispatchers.IO) {
+                    val backup = fileStore.backupSourceFile(sourceFile)
+                    try {
+                        val copied = fileStore.copyFromUri(uri, sourceFile)
+                        val loaded = if (!copied) {
+                            val fallback = BitmapUtils.loadDownsampledBitmap(
+                                context,
+                                uri,
+                                maxDimension = 2560,
+                            )
+                            if (fallback != null) {
+                                fileStore.saveBitmap(sourceFile, fallback)
+                            }
+                            fallback
+                        } else {
+                            BitmapUtils.loadDownsampledBitmap(sourceFile, maxDimension = 2560)
+                        }
+                        if (loaded == null) {
+                            fileStore.restoreSourceFile(backup, sourceFile)
+                            fileStore.deleteBackup(backup)
+                            PickResult(bitmap = null, pendingBackup = null)
+                        } else {
+                            fileStore.clearCropParams()
+                            PickResult(bitmap = loaded, pendingBackup = backup)
+                        }
+                    } catch (t: Throwable) {
+                        fileStore.restoreSourceFile(backup, sourceFile)
+                        fileStore.deleteBackup(backup)
+                        throw t
+                    }
+                }
+                editPendingBackup = pick.pendingBackup
+                val bitmap = pick.bitmap
+                if (bitmap != null) {
+                    enterEditMode(bitmap)
+                } else {
+                    showError(context.getString(R.string.settings_wallpaper_load_failed))
+                }
+            } catch (_: Exception) {
+                editPendingBackup = null
+                showError(context.getString(R.string.settings_wallpaper_load_failed))
+            } finally {
+                isBusy = false
+            }
+        }
+    }
+
+    fun openExistingForEdit() {
+        if (isBusy) return
+        scope.launch {
+            isBusy = true
+            try {
+                val bitmap = withContext(Dispatchers.IO) {
+                    when {
+                        sourceFile.exists() -> BitmapUtils.loadDownsampledBitmap(
+                            sourceFile,
+                            maxDimension = 2560,
+                        )
+                        croppedFile.exists() -> {
+                            val loaded = BitmapUtils.loadDownsampledBitmap(
+                                croppedFile,
+                                maxDimension = 2560,
+                            )
+                            if (loaded != null) fileStore.saveBitmap(sourceFile, loaded)
+                            loaded
+                        }
+                        else -> {
+                            val uri = viewModel.wallpaperUri.value
+                            val loaded = if (uri.isNotEmpty()) {
+                                BitmapUtils.loadDownsampledBitmap(
+                                    context,
+                                    uri,
+                                    maxDimension = 2560,
+                                )
+                            } else {
+                                null
+                            }
+                            if (loaded != null) fileStore.saveBitmap(sourceFile, loaded)
+                            loaded
+                        }
+                    }
+                }
+                if (bitmap != null) {
+                    enterEditMode(bitmap)
+                } else {
+                    showError(context.getString(R.string.settings_wallpaper_load_failed))
+                }
+            } catch (_: Exception) {
+                showError(context.getString(R.string.settings_wallpaper_load_failed))
+            } finally {
+                isBusy = false
+            }
+        }
+    }
+
+    fun confirmCrop() {
+        val bitmap = sourceBitmap ?: return
+        if (isBusy) return
+        // Capture before IO: after a durable crop we must drop backup in the same
+        // IO work so process death cannot leave orphan backup for reconcile-restore.
+        val pendingBackup = editPendingBackup
+        scope.launch {
+            isBusy = true
+            try {
+                cropState.ensureCoverScale()
+                val scale = cropState.scale
+                val panX = cropState.panX
+                val panY = cropState.panY
+                val rotationDegrees = cropState.rotationDegrees
+                val result = withContext(Dispatchers.IO) {
+                    val cropped = cropState.getCroppedBitmap(bitmap) ?: return@withContext null
+                    val saved = fileStore.saveBitmap(croppedFile, cropped)
+                    if (!cropped.isRecycled) {
+                        cropped.recycle()
+                    }
+                    if (saved == null) return@withContext null
+                    fileStore.saveCropParams(
+                        WallpaperFileStore.CropParams(
+                            scale = scale,
+                            panX = panX,
+                            panY = panY,
+                            rotationDegrees = rotationDegrees,
+                            sourceIdentity = fileStore.sourceIdentity(sourceFile),
+                        )
+                    )
+                    fileStore.clearSeedCache()
+                    // Confirmed pick: never restore this backup. Delete before returning
+                    // so onEnterPage/AppNav reconcile only sees a clean tree.
+                    fileStore.deleteBackup(pendingBackup)
+                    saved
+                }
+                if (result != null) {
+                    viewModel.setWallpaperUriSync(fileStore.croppedUriString())
+                    finishEditModeAfterSave()
+                } else {
+                    showError(context.getString(R.string.settings_wallpaper_save_failed))
+                }
+            } catch (_: Exception) {
+                showError(context.getString(R.string.settings_wallpaper_save_failed))
+            } finally {
+                // Success path already cleared busy via leaveEditUi(); keep safe on failure.
+                isBusy = false
+            }
+        }
+    }
+
+    fun clearWallpaper() {
+        if (isBusy) return
+        scope.launch {
+            isBusy = true
+            try {
+                withContext(Dispatchers.IO) { fileStore.clearFiles() }
+                // Await version bump so collectors drop the old bitmap immediately.
+                viewModel.setWallpaperUriSync("")
+            } catch (_: Exception) {
+                showError(context.getString(R.string.settings_wallpaper_save_failed))
+            } finally {
+                isBusy = false
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperPreviewCard.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperPreviewCard.kt
@@ -1,0 +1,94 @@
+package com.aliothmoon.maameow.presentation.view.settings
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.aliothmoon.maameow.theme.rememberWallpaperDisplayBitmap
+import com.aliothmoon.maameow.theme.wallpaperBlurModifier
+import com.aliothmoon.maameow.utils.BitmapUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+internal fun WallpaperPreviewCard(
+    wallpaperUri: String,
+    version: Int = 0,
+    alpha: Float,
+    blurPercent: Int,
+    screenRatio: Float,
+    onClick: () -> Unit,
+) {
+    val context = LocalContext.current
+    var previewBitmap by remember { mutableStateOf<Bitmap?>(null) }
+    // Same file path is overwritten on every recrop; version forces reload.
+    // Clear immediately so we never keep showing a stale frame while decoding.
+    LaunchedEffect(wallpaperUri, version) {
+        previewBitmap = null
+        if (wallpaperUri.isEmpty()) return@LaunchedEffect
+        val requestUri = wallpaperUri
+        val requestVersion = version
+        val loaded = withContext(Dispatchers.IO) {
+            BitmapUtils.loadDownsampledBitmap(context, requestUri, maxDimension = 512)
+        }
+        // Drop late results from an older recrop / URI.
+        if (requestUri == wallpaperUri && requestVersion == version) {
+            previewBitmap = loaded
+        }
+    }
+    Box(
+        modifier = Modifier
+            .padding(horizontal = 24.dp, vertical = 8.dp)
+            .fillMaxWidth()
+            .wrapContentSize(Alignment.Center)
+            .width(180.dp)
+            .aspectRatio(screenRatio)
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        // Software path pre-blurs; hardware path uses Modifier.blur.
+        val bitmap = rememberWallpaperDisplayBitmap(
+            source = previewBitmap,
+            blurPercent = blurPercent,
+            softwareMaxDimension = 360,
+        )
+        if (bitmap != null) {
+            Image(
+                bitmap = bitmap,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                alpha = alpha,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .then(wallpaperBlurModifier(blurPercent)),
+            )
+        } else {
+            CircularProgressIndicator(modifier = Modifier.size(28.dp), strokeWidth = 2.dp)
+        }
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsBody.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsBody.kt
@@ -1,0 +1,212 @@
+package com.aliothmoon.maameow.presentation.view.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.remember
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.aliothmoon.maameow.R
+import com.aliothmoon.maameow.data.preferences.WallpaperBlur
+import com.aliothmoon.maameow.presentation.components.SettingRow
+import com.aliothmoon.maameow.presentation.components.SettingsGroupCard
+import com.aliothmoon.maameow.presentation.components.TopAppBar
+import com.aliothmoon.maameow.theme.MaaDesignTokens
+import com.aliothmoon.maameow.presentation.viewmodel.SettingsViewModel
+
+/** Settings page body: preview, sliders, toggles, clear. */
+@Composable
+internal fun WallpaperSettingsBody(
+    navController: NavController,
+    viewModel: SettingsViewModel,
+    session: WallpaperEditSession,
+    wallpaperUri: String,
+    wallpaperUpdateVersion: Int,
+    wallpaperFrostedGlass: Boolean,
+    wallpaperTextContrast: Boolean,
+    localAlpha: Float,
+    onLocalAlphaChange: (Float) -> Unit,
+    localBlur: Float,
+    onLocalBlurChange: (Float) -> Unit,
+    screenRatio: Float,
+    onChangeWallpaper: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = stringResource(R.string.settings_wallpaper_title),
+                navigationIcon = Icons.AutoMirrored.Filled.ArrowBack,
+                onNavigationClick = { navController.popBackStack() },
+            )
+        },
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+    ) { paddingValues ->
+        Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                if (wallpaperUri.isNotEmpty()) {
+                    WallpaperPreviewCard(
+                        wallpaperUri = wallpaperUri,
+                        version = wallpaperUpdateVersion,
+                        alpha = localAlpha / 100f,
+                        blurPercent = localBlur.toInt(),
+                        screenRatio = screenRatio,
+                            onClick = { session.openExistingForEdit() },
+                    )
+                    Text(
+                        text = stringResource(R.string.settings_wallpaper_edit_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp),
+                    )
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(
+                                horizontal = MaaDesignTokens.Spacing.listHorizontal,
+                                vertical = MaaDesignTokens.Spacing.sm,
+                            ),
+                        verticalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.sectionGap),
+                    ) {
+                        SettingsGroupCard {
+                            SettingRow(
+                                title = stringResource(R.string.settings_wallpaper_change),
+                                onClick = { onChangeWallpaper() },
+                            )
+                        }
+                        SettingsGroupCard {
+                            Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                                Text(
+                                    stringResource(R.string.settings_wallpaper_alpha, localAlpha.toInt()),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                                Slider(
+                                    localAlpha,
+                                    onValueChange = onLocalAlphaChange,
+                                    valueRange = 0f..100f,
+                                )
+                                Spacer(Modifier.height(8.dp))
+                                Text(
+                                    stringResource(R.string.settings_wallpaper_blur, localBlur.toInt()),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                                Slider(
+                                    localBlur,
+                                    onValueChange = onLocalBlurChange,
+                                    valueRange = 0f..WallpaperBlur.PERCENT_MAX.toFloat(),
+                                )
+                            }
+                        }
+                        SettingsGroupCard {
+                            SettingRow(
+                                title = stringResource(R.string.settings_wallpaper_frosted_glass),
+                                trailing = {
+                                    Switch(
+                                        checked = wallpaperFrostedGlass,
+                                        onCheckedChange = { viewModel.setWallpaperFrostedGlass(it) },
+                                    )
+                                },
+                            )
+                        }
+                        SettingsGroupCard {
+                            SettingRow(
+                                title = stringResource(R.string.settings_wallpaper_text_contrast),
+                                trailing = {
+                                    Switch(
+                                        checked = wallpaperTextContrast,
+                                        onCheckedChange = { viewModel.setWallpaperTextContrast(it) },
+                                    )
+                                },
+                            )
+                        }
+                        OutlinedButton(
+                            onClick = { session.clearWallpaper() },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(
+                                    horizontal = MaaDesignTokens.Spacing.listHorizontal,
+                                    vertical = 8.dp,
+                                ),
+                            shape = MaterialTheme.shapes.large,
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = MaterialTheme.colorScheme.error.copy(alpha = 0.82f)
+                            ),
+                            border = BorderStroke(
+                                1.dp,
+                                MaterialTheme.colorScheme.error.copy(alpha = 0.45f),
+                            ),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Clear,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(modifier = Modifier.size(6.dp))
+                            Text(
+                                text = stringResource(R.string.settings_wallpaper_clear),
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Medium,
+                            )
+                        }
+                    }
+                } else {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = MaaDesignTokens.Spacing.listHorizontal),
+                    ) {
+                        SettingsGroupCard {
+                            SettingRow(
+                                title = stringResource(R.string.settings_wallpaper_desc),
+                                onClick = { onChangeWallpaper() },
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (session.isBusy) {
+                // Swallow all pointer input so clear/change/preview cannot re-enter while busy.
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.background.copy(alpha = 0.35f))
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = {},
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        CircularProgressIndicator()
+                        Spacer(Modifier.height(12.dp))
+                        Text(
+                            stringResource(R.string.settings_wallpaper_loading),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperSettingsView.kt
@@ -1,0 +1,128 @@
+package com.aliothmoon.maameow.presentation.view.settings
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import com.aliothmoon.maameow.presentation.LocalToaster
+import com.aliothmoon.maameow.presentation.viewmodel.SettingsViewModel
+import com.aliothmoon.maameow.utils.WallpaperFileStore
+import com.dokar.sonner.ToastType
+
+/**
+ * Wallpaper settings entry: owns DataStore-bound state and [WallpaperEditSession],
+ * then hosts either the crop editor or the settings body.
+ */
+@Composable
+fun WallpaperSettingsView(
+    navController: NavController,
+    viewModel: SettingsViewModel,
+) {
+    val wallpaperUri by viewModel.wallpaperUri.collectAsStateWithLifecycle()
+    val wallpaperAlpha by viewModel.wallpaperAlpha.collectAsStateWithLifecycle()
+    val wallpaperBlur by viewModel.wallpaperBlur.collectAsStateWithLifecycle()
+    val wallpaperFrostedGlass by viewModel.wallpaperFrostedGlass.collectAsStateWithLifecycle()
+    val wallpaperTextContrast by viewModel.wallpaperTextContrast.collectAsStateWithLifecycle()
+    val wallpaperUpdateVersion by viewModel.wallpaperUpdateVersion.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val toaster = LocalToaster.current
+    val coroutineScope = rememberCoroutineScope()
+    val fileStore = remember { WallpaperFileStore(context) }
+    val session = remember(context, viewModel, coroutineScope, fileStore) {
+        WallpaperEditSession(
+            context = context,
+            viewModel = viewModel,
+            scope = coroutineScope,
+            fileStore = fileStore,
+            showError = { msg -> toaster.show(msg, type = ToastType.Error) },
+        )
+    }
+
+    var localAlpha by remember { mutableFloatStateOf(wallpaperAlpha.toFloat()) }
+    var localBlur by remember { mutableFloatStateOf(wallpaperBlur.toFloat()) }
+    LaunchedEffect(wallpaperAlpha) {
+        if (kotlin.math.abs(localAlpha - wallpaperAlpha) > 0.5f) {
+            localAlpha = wallpaperAlpha.toFloat()
+        }
+    }
+    LaunchedEffect(wallpaperBlur) {
+        if (kotlin.math.abs(localBlur - wallpaperBlur) > 0.5f) {
+            localBlur = wallpaperBlur.toFloat()
+        }
+    }
+    LaunchedEffect(localAlpha) {
+        if (kotlin.math.abs(localAlpha - wallpaperAlpha) < 0.5f) return@LaunchedEffect
+        kotlinx.coroutines.delay(200)
+        viewModel.setWallpaperAlpha(localAlpha.toInt())
+    }
+    LaunchedEffect(localBlur) {
+        if (kotlin.math.abs(localBlur - wallpaperBlur) < 0.5f) return@LaunchedEffect
+        kotlinx.coroutines.delay(200)
+        viewModel.setWallpaperBlur(localBlur.toInt())
+    }
+    // Read latest local + committed values on leave (do not capture first composition snapshot).
+    DisposableEffect(viewModel) {
+        onDispose {
+            val alpha = localAlpha.toInt()
+            val blur = localBlur.toInt()
+            if (alpha != viewModel.wallpaperAlpha.value) {
+                viewModel.setWallpaperAlpha(alpha)
+            }
+            if (blur != viewModel.wallpaperBlur.value) {
+                viewModel.setWallpaperBlur(blur)
+            }
+        }
+    }
+
+    LaunchedEffect(wallpaperUri) {
+        session.onEnterPage(wallpaperUri)
+    }
+
+    val wallpaperPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetContent(),
+    ) { uri ->
+        uri ?: return@rememberLauncherForActivityResult
+        session.onPickedUri(uri)
+    }
+
+    val configuration = LocalConfiguration.current
+    val screenRatio =
+        configuration.screenWidthDp.toFloat() / configuration.screenHeightDp.toFloat()
+
+    if (session.isEditing && session.sourceBitmap != null) {
+        WallpaperCropEditor(
+            session = session,
+            localAlpha = localAlpha,
+            onLocalAlphaChange = { localAlpha = it },
+            localBlur = localBlur,
+            onLocalBlurChange = { localBlur = it },
+            screenRatio = screenRatio,
+        )
+    } else {
+        WallpaperSettingsBody(
+            navController = navController,
+            viewModel = viewModel,
+            session = session,
+            wallpaperUri = wallpaperUri,
+            wallpaperUpdateVersion = wallpaperUpdateVersion,
+            wallpaperFrostedGlass = wallpaperFrostedGlass,
+            wallpaperTextContrast = wallpaperTextContrast,
+            localAlpha = localAlpha,
+            onLocalAlphaChange = { localAlpha = it },
+            localBlur = localBlur,
+            onLocalBlurChange = { localBlur = it },
+            screenRatio = screenRatio,
+            onChangeWallpaper = { wallpaperPicker.launch("image/*") },
+        )
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/viewmodel/SettingsViewModel.kt
@@ -267,11 +267,11 @@ class SettingsViewModel(
         }
     }
 
-    // ============ System Monet theme color ============
-    val useSystemMonetColor: StateFlow<Boolean> = appSettingsManager.useSystemMonetColor
-    fun setUseSystemMonetColor(enabled: Boolean) {
+    // 壁纸动态取色
+    val useWallpaperColor: StateFlow<Boolean> = appSettingsManager.useWallpaperColor
+    fun setUseWallpaperColor(enabled: Boolean) {
         viewModelScope.launch {
-            appSettingsManager.setUseSystemMonetColor(enabled)
+            appSettingsManager.setUseWallpaperColor(enabled)
         }
     }
 
@@ -288,5 +288,42 @@ class SettingsViewModel(
         viewModelScope.launch {
             appSettingsManager.setShowAchievementSnackbar(enabled)
         }
+    }
+
+    // 壁纸更新版本号（由 AppSettingsManager 在 URI 写入后统一递增）
+    val wallpaperUpdateVersion: StateFlow<Int> = appSettingsManager.wallpaperUpdateVersion
+
+    // 自定义壁纸
+    val wallpaperUri: StateFlow<String> = appSettingsManager.wallpaperUri
+    fun setWallpaperUri(uri: String) {
+        viewModelScope.launch {
+            appSettingsManager.setWallpaperUri(uri)
+        }
+    }
+
+    /** Awaitable write so UI can refresh only after version bump. */
+    suspend fun setWallpaperUriSync(uri: String) {
+        appSettingsManager.setWallpaperUri(uri)
+    }
+
+    val wallpaperAlpha: StateFlow<Int> = appSettingsManager.wallpaperAlpha
+    fun setWallpaperAlpha(alpha: Int) {
+        viewModelScope.launch { appSettingsManager.setWallpaperAlpha(alpha) }
+    }
+
+    val wallpaperBlur: StateFlow<Int> = appSettingsManager.wallpaperBlur
+    fun setWallpaperBlur(blur: Int) {
+        viewModelScope.launch { appSettingsManager.setWallpaperBlur(blur) }
+    }
+
+    val wallpaperTextContrast: StateFlow<Boolean> = appSettingsManager.wallpaperTextContrast
+
+    fun setWallpaperTextContrast(enabled: Boolean) {
+        viewModelScope.launch { appSettingsManager.setWallpaperTextContrast(enabled) }
+    }
+
+    val wallpaperFrostedGlass: StateFlow<Boolean> = appSettingsManager.wallpaperFrostedGlass
+    fun setWallpaperFrostedGlass(enabled: Boolean) {
+        viewModelScope.launch { appSettingsManager.setWallpaperFrostedGlass(enabled) }
     }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/ui/CountdownDialog.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/ui/CountdownDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.aliothmoon.maameow.R
 import com.aliothmoon.maameow.schedule.model.CountdownState
+import com.aliothmoon.maameow.theme.overlayBoardColor
 
 @Composable
 fun CountdownDialog(
@@ -29,6 +30,7 @@ fun CountdownDialog(
 ) {
     AlertDialog(
         onDismissRequest = { /* 不可关闭 */ },
+        containerColor = overlayBoardColor(),
         title = { Text(stringResource(R.string.schedule_countdown_title)) },
         text = {
             Column(

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/ui/ScheduleEditView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/ui/ScheduleEditView.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
@@ -32,9 +33,14 @@ import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.InputChip
+import androidx.compose.material3.InputChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Card
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -78,6 +84,7 @@ import java.time.Instant
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import com.aliothmoon.maameow.theme.overlayBoardColor
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -135,8 +142,15 @@ fun ScheduleEditView(
                             strokeWidth = 2.dp
                         )
                     } else {
-                        TextButton(onClick = { viewModel.onSave(context) }) {
-                            Text(stringResource(R.string.schedule_save))
+                        // Match BackgroundTask "快捷操作" card: surfaceContainerHighest @ 0.96.
+                        Surface(
+                            shape = RoundedCornerShape(20.dp),
+                            color = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.96f),
+                            modifier = Modifier.padding(end = 8.dp),
+                        ) {
+                            TextButton(onClick = { viewModel.onSave(context) }) {
+                                Text(stringResource(R.string.schedule_save))
+                            }
                         }
                     }
                 }
@@ -145,62 +159,57 @@ fun ScheduleEditView(
     ) { padding ->
         LazyColumn(
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .padding(padding),
             contentPadding = PaddingValues(
                 horizontal = MaaDesignTokens.Spacing.listHorizontal,
                 vertical = MaaDesignTokens.Spacing.sm
-            )
+            ),
+            verticalArrangement = Arrangement.spacedBy(MaaDesignTokens.Spacing.sectionGap),
         ) {
             item {
-                SectionHeader(stringResource(R.string.schedule_section_basic_info))
-            }
-            if (!state.isNew && state.strategyId != null) {
-                item {
-                    Text(
-                        text = "ID: ${state.strategyId}",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(vertical = 4.dp)
+                ScheduleEditSection(title = stringResource(R.string.schedule_section_basic_info)) {
+                    if (!state.isNew && state.strategyId != null) {
+                        Text(
+                            text = "ID: ${state.strategyId}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                    }
+                    OutlinedTextField(
+                        value = state.name,
+                        onValueChange = viewModel::onNameChanged,
+                        label = { Text(stringResource(R.string.schedule_name)) },
+                        placeholder = { Text(stringResource(R.string.schedule_name_placeholder)) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
                     )
                 }
             }
-            item {
-                OutlinedTextField(
-                    value = state.name,
-                    onValueChange = viewModel::onNameChanged,
-                    label = { Text(stringResource(R.string.schedule_name)) },
-                    placeholder = { Text(stringResource(R.string.schedule_name_placeholder)) },
-                    singleLine = true,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                )
-            }
 
             item {
-                SectionHeader(stringResource(R.string.schedule_section_type))
-            }
-            item {
-                SingleChoiceSegmentedButtonRow(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                ) {
-                    ScheduleType.entries.forEachIndexed { index, type ->
-                        SegmentedButton(
-                            selected = state.scheduleType == type,
-                            onClick = { viewModel.onScheduleTypeChanged(type) },
-                            shape = SegmentedButtonDefaults.itemShape(
-                                index = index,
-                                count = ScheduleType.entries.size,
-                                baseShape = RoundedCornerShape(4.dp)
-                            )
-                        ) {
-                            Text(
-                                when (type) {
-                                    ScheduleType.FIXED_TIME -> stringResource(R.string.schedule_type_fixed_time)
-                                    ScheduleType.INTERVAL -> stringResource(R.string.schedule_type_interval)
-                                }
-                            )
+                ScheduleEditSection(title = stringResource(R.string.schedule_section_type)) {
+                    SingleChoiceSegmentedButtonRow(
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        ScheduleType.entries.forEachIndexed { index, type ->
+                            SegmentedButton(
+                                selected = state.scheduleType == type,
+                                onClick = { viewModel.onScheduleTypeChanged(type) },
+                                shape = SegmentedButtonDefaults.itemShape(
+                                    index = index,
+                                    count = ScheduleType.entries.size,
+                                    baseShape = RoundedCornerShape(4.dp)
+                                )
+                            ) {
+                                Text(
+                                    when (type) {
+                                        ScheduleType.FIXED_TIME -> stringResource(R.string.schedule_type_fixed_time)
+                                        ScheduleType.INTERVAL -> stringResource(R.string.schedule_type_interval)
+                                    }
+                                )
+                            }
                         }
                     }
                 }
@@ -209,213 +218,211 @@ fun ScheduleEditView(
             when (state.scheduleType) {
                 ScheduleType.FIXED_TIME -> {
                     item {
-                        SectionHeader(stringResource(R.string.schedule_section_days))
+                        ScheduleEditSection(title = stringResource(R.string.schedule_section_days)) {
+                            FlowRow(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                val chipColors = FilterChipDefaults.filterChipColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+                                    labelColor = MaterialTheme.colorScheme.onSurface,
+                                    selectedContainerColor = MaterialTheme.colorScheme.primary,
+                                    selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                                )
+                                val allSelected = DayOfWeek.entries.all { it in state.daysOfWeek }
+                                FilterChip(
+                                    selected = allSelected,
+                                    onClick = { viewModel.onToggleAllDays() },
+                                    label = { Text(stringResource(R.string.schedule_every_day)) },
+                                    colors = chipColors
+                                )
+                                DayOfWeek.entries.forEach { day ->
+                                    FilterChip(
+                                        selected = day in state.daysOfWeek,
+                                        onClick = { viewModel.onToggleDay(day) },
+                                        label = { Text(scheduleDayChipLabel(day)) },
+                                        colors = chipColors
+                                    )
+                                }
+                            }
+                        }
                     }
                     item {
-                        FlowRow(
-                            modifier = Modifier
-                                .fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            val chipColors = FilterChipDefaults.filterChipColors(
-                                selectedContainerColor = MaterialTheme.colorScheme.primary,
-                                selectedLabelColor = MaterialTheme.colorScheme.onPrimary
-                            )
-                            val allSelected = DayOfWeek.entries.all { it in state.daysOfWeek }
-                            FilterChip(
-                                selected = allSelected,
-                                onClick = { viewModel.onToggleAllDays() },
-                                label = { Text(stringResource(R.string.schedule_every_day)) },
-                                colors = chipColors
-                            )
-                            DayOfWeek.entries.forEach { day ->
-                                FilterChip(
-                                    selected = day in state.daysOfWeek,
-                                    onClick = { viewModel.onToggleDay(day) },
-                                    label = { Text(scheduleDayChipLabel(day)) },
-                                    colors = chipColors
+                        ScheduleEditSection(title = stringResource(R.string.schedule_section_times)) {
+                            val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+                            FlowRow(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                state.executionTimes.forEach { time ->
+                                    InputChip(
+                                        selected = false,
+                                        onClick = {
+                                            editingTime = time
+                                            showTimePicker = true
+                                        },
+                                        label = { Text(time.format(timeFormatter)) },
+                                        colors = InputChipDefaults.inputChipColors(
+                                            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+                                            labelColor = MaterialTheme.colorScheme.onSurface,
+                                            trailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        ),
+                                        trailingIcon = {
+                                            IconButton(
+                                                onClick = { viewModel.onRemoveTime(time) },
+                                                modifier = Modifier.size(18.dp)
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Default.Close,
+                                                    contentDescription = stringResource(R.string.common_delete),
+                                                    modifier = Modifier.size(14.dp)
+                                                )
+                                            }
+                                        }
+                                    )
+                                }
+                                AssistChip(
+                                    onClick = {
+                                        editingTime = null
+                                        showTimePicker = true
+                                    },
+                                    label = { Text(stringResource(R.string.schedule_add_time)) },
+                                    colors = AssistChipDefaults.assistChipColors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+                                        labelColor = MaterialTheme.colorScheme.onSurface,
+                                        leadingIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    ),
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.Default.Add,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                    }
                                 )
                             }
                         }
                     }
-
+                }
+                ScheduleType.INTERVAL -> {
                     item {
-                        SectionHeader(stringResource(R.string.schedule_section_times))
-                    }
-                    item {
-                        val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
-                        FlowRow(
-                            modifier = Modifier
-                                .fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            state.executionTimes.forEach { time ->
-                                InputChip(
-                                    selected = false,
-                                    onClick = {
-                                        editingTime = time
-                                        showTimePicker = true
+                        ScheduleEditSection(title = stringResource(R.string.schedule_section_start_time)) {
+                            var showDatePicker by remember { mutableStateOf(false) }
+                            var showStartTimePicker by remember { mutableStateOf(false) }
+                            // 暂存选中的日期，等时间也选完后一起写入
+                            var pendingDateMs by remember { mutableStateOf<Long?>(null) }
+                            val displayText = state.startTimeMs?.let { ms ->
+                                val zdt = Instant.ofEpochMilli(ms).atZone(ZoneId.systemDefault())
+                                zdt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+                            } ?: stringResource(R.string.schedule_tap_to_choose)
+                            OutlinedTextField(
+                                value = displayText,
+                                onValueChange = {},
+                                readOnly = true,
+                                label = { Text(stringResource(R.string.schedule_first_execution_time)) },
+                                modifier = Modifier.fillMaxWidth(),
+                                interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }.also { source ->
+                                    LaunchedEffect(source) {
+                                        source.interactions.collect { interaction ->
+                                            if (interaction is androidx.compose.foundation.interaction.PressInteraction.Release) {
+                                                showDatePicker = true
+                                            }
+                                        }
+                                    }
+                                }
+                            )
+                            if (showDatePicker) {
+                                val datePickerState = rememberDatePickerState(
+                                    initialSelectedDateMillis = state.startTimeMs
+                                        ?: System.currentTimeMillis()
+                                )
+                                DatePickerDialog(
+                                    onDismissRequest = { showDatePicker = false },
+                                    confirmButton = {
+                                        TextButton(onClick = {
+                                            pendingDateMs = datePickerState.selectedDateMillis
+                                            showDatePicker = false
+                                            showStartTimePicker = true
+                                        }) { Text(stringResource(R.string.schedule_next_step)) }
                                     },
-                                    label = { Text(time.format(timeFormatter)) },
-                                    trailingIcon = {
-                                        IconButton(
-                                            onClick = { viewModel.onRemoveTime(time) },
-                                            modifier = Modifier.size(18.dp)
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.Default.Close,
-                                                contentDescription = stringResource(R.string.common_delete),
-                                                modifier = Modifier.size(14.dp)
+                                    dismissButton = {
+                                        TextButton(onClick = { showDatePicker = false }) {
+                                            Text(
+                                                stringResource(R.string.common_cancel)
                                             )
                                         }
                                     }
+                                ) {
+                                    DatePicker(state = datePickerState)
+                                }
+                            }
+                            if (showStartTimePicker) {
+                                val existingTime = state.startTimeMs?.let { ms ->
+                                    Instant.ofEpochMilli(ms).atZone(ZoneId.systemDefault())
+                                        .toLocalTime()
+                                }
+                                TimePickerDialog(
+                                    initialTime = existingTime,
+                                    onDismiss = { showStartTimePicker = false },
+                                    onConfirm = { time ->
+                                        val dateMs = pendingDateMs ?: return@TimePickerDialog
+                                        val date = Instant.ofEpochMilli(dateMs)
+                                            .atZone(ZoneId.of("UTC"))
+                                            .toLocalDate()
+                                        val combined = date.atTime(time)
+                                            .atZone(ZoneId.systemDefault())
+                                            .toInstant()
+                                            .toEpochMilli()
+                                        viewModel.onStartTimeChanged(combined)
+                                        showStartTimePicker = false
+                                    }
                                 )
                             }
-                            AssistChip(
-                                onClick = {
-                                    editingTime = null
-                                    showTimePicker = true
-                                },
-                                label = { Text(stringResource(R.string.schedule_add_time)) },
-                                leadingIcon = {
-                                    Icon(
-                                        imageVector = Icons.Default.Add,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(18.dp)
-                                    )
-                                }
-                            )
                         }
                     }
-                }
-
-                ScheduleType.INTERVAL -> {
                     item {
-                        SectionHeader(stringResource(R.string.schedule_section_start_time))
-                    }
-                    item {
-                        var showDatePicker by remember { mutableStateOf(false) }
-                        var showStartTimePicker by remember { mutableStateOf(false) }
-                        // 暂存选中的日期，等时间也选完后一起写入
-                        var pendingDateMs by remember { mutableStateOf<Long?>(null) }
-
-                        val displayText = state.startTimeMs?.let { ms ->
-                            val zdt = Instant.ofEpochMilli(ms).atZone(ZoneId.systemDefault())
-                            zdt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
-                        } ?: stringResource(R.string.schedule_tap_to_choose)
-
-                        OutlinedTextField(
-                            value = displayText,
-                            onValueChange = {},
-                            readOnly = true,
-                            label = { Text(stringResource(R.string.schedule_first_execution_time)) },
-                            modifier = Modifier
-                                .fillMaxWidth(),
-                            interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }.also { source ->
-                                LaunchedEffect(source) {
-                                    source.interactions.collect { interaction ->
-                                        if (interaction is androidx.compose.foundation.interaction.PressInteraction.Release) {
-                                            showDatePicker = true
-                                        }
-                                    }
-                                }
-                            }
-                        )
-
-                        if (showDatePicker) {
-                            val datePickerState = rememberDatePickerState(
-                                initialSelectedDateMillis = state.startTimeMs
-                                    ?: System.currentTimeMillis()
-                            )
-                            DatePickerDialog(
-                                onDismissRequest = { showDatePicker = false },
-                                confirmButton = {
-                                    TextButton(onClick = {
-                                        pendingDateMs = datePickerState.selectedDateMillis
-                                        showDatePicker = false
-                                        showStartTimePicker = true
-                                    }) { Text(stringResource(R.string.schedule_next_step)) }
-                                },
-                                dismissButton = {
-                                    TextButton(onClick = { showDatePicker = false }) {
-                                        Text(
-                                            stringResource(R.string.common_cancel)
-                                        )
-                                    }
-                                }
+                        ScheduleEditSection(title = stringResource(R.string.schedule_section_interval)) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
-                                DatePicker(state = datePickerState)
-                            }
-                        }
-
-                        if (showStartTimePicker) {
-                            val existingTime = state.startTimeMs?.let { ms ->
-                                Instant.ofEpochMilli(ms).atZone(ZoneId.systemDefault())
-                                    .toLocalTime()
-                            }
-                            TimePickerDialog(
-                                initialTime = existingTime,
-                                onDismiss = { showStartTimePicker = false },
-                                onConfirm = { time ->
-                                    val dateMs = pendingDateMs ?: return@TimePickerDialog
-                                    val date = Instant.ofEpochMilli(dateMs)
-                                        .atZone(ZoneId.of("UTC"))
-                                        .toLocalDate()
-                                    val combined = date.atTime(time)
-                                        .atZone(ZoneId.systemDefault())
-                                        .toInstant()
-                                        .toEpochMilli()
-                                    viewModel.onStartTimeChanged(combined)
-                                    showStartTimePicker = false
+                                OutlinedTextField(
+                                    value = if (state.intervalDays > 0) state.intervalDays.toString() else "",
+                                    onValueChange = {
+                                        viewModel.onIntervalDaysChanged(
+                                            it.toIntOrNull() ?: 0
+                                        )
+                                    },
+                                    label = { Text(stringResource(R.string.schedule_days_unit)) },
+                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                    singleLine = true,
+                                    modifier = Modifier.width(80.dp)
+                                )
+                                OutlinedTextField(
+                                    value = if (state.intervalHours > 0) state.intervalHours.toString() else "",
+                                    onValueChange = {
+                                        viewModel.onIntervalHoursChanged(
+                                            it.toIntOrNull() ?: 0
+                                        )
+                                    },
+                                    label = { Text(stringResource(R.string.schedule_hours_unit)) },
+                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                    singleLine = true,
+                                    modifier = Modifier.width(80.dp)
+                                )
+                                val totalMinutes =
+                                    state.intervalDays * 24 * 60 + state.intervalHours * 60
+                                if (totalMinutes > 0) {
+                                    Text(
+                                        text = stringResource(
+                                            R.string.schedule_total_hours,
+                                            totalMinutes / 60
+                                        ),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
                                 }
-                            )
-                        }
-                    }
-
-                    item {
-                        SectionHeader(stringResource(R.string.schedule_section_interval))
-                    }
-                    item {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            OutlinedTextField(
-                                value = if (state.intervalDays > 0) state.intervalDays.toString() else "",
-                                onValueChange = {
-                                    viewModel.onIntervalDaysChanged(
-                                        it.toIntOrNull() ?: 0
-                                    )
-                                },
-                                label = { Text(stringResource(R.string.schedule_days_unit)) },
-                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                singleLine = true,
-                                modifier = Modifier.width(80.dp)
-                            )
-                            OutlinedTextField(
-                                value = if (state.intervalHours > 0) state.intervalHours.toString() else "",
-                                onValueChange = {
-                                    viewModel.onIntervalHoursChanged(
-                                        it.toIntOrNull() ?: 0
-                                    )
-                                },
-                                label = { Text(stringResource(R.string.schedule_hours_unit)) },
-                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                singleLine = true,
-                                modifier = Modifier.width(80.dp)
-                            )
-                            val totalMinutes =
-                                state.intervalDays * 24 * 60 + state.intervalHours * 60
-                            if (totalMinutes > 0) {
-                                Text(
-                                    text = stringResource(
-                                        R.string.schedule_total_hours,
-                                        totalMinutes / 60
-                                    ),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
                             }
                         }
                     }
@@ -423,84 +430,83 @@ fun ScheduleEditView(
             }
 
             item {
-                SectionHeader(stringResource(R.string.schedule_section_task_config))
-            }
-            item {
-                if (state.profiles.isEmpty()) {
-                    Text(
-                        text = stringResource(R.string.schedule_no_profiles),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                } else {
-                    FlowRow(
-                        modifier = Modifier
-                            .fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        state.profiles.forEach { profile ->
-                            FilterChip(
-                                selected = profile.id == state.selectedProfileId,
-                                onClick = { viewModel.onSelectProfile(profile.id) },
-                                label = { Text(profile.name) },
-                                colors = FilterChipDefaults.filterChipColors(
-                                    selectedContainerColor = MaterialTheme.colorScheme.primary,
-                                    selectedLabelColor = MaterialTheme.colorScheme.onPrimary
+                ScheduleEditSection(title = stringResource(R.string.schedule_section_task_config)) {
+                    if (state.profiles.isEmpty()) {
+                        Text(
+                            text = stringResource(R.string.schedule_no_profiles),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    } else {
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            state.profiles.forEach { profile ->
+                                FilterChip(
+                                    selected = profile.id == state.selectedProfileId,
+                                    onClick = { viewModel.onSelectProfile(profile.id) },
+                                    label = { Text(profile.name) },
+                                    colors = FilterChipDefaults.filterChipColors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+                                        labelColor = MaterialTheme.colorScheme.onSurface,
+                                        selectedContainerColor = MaterialTheme.colorScheme.primary,
+                                        selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                                    )
                                 )
+                            }
+                        }
+                        // 显示选中 Profile 的已启用任务摘要
+                        val selectedProfile = state.profiles.find { it.id == state.selectedProfileId }
+                        val enabledTasks = selectedProfile?.chain
+                            ?.filter { it.enabled }
+                            ?.joinToString("、") { it.name }
+                        if (!enabledTasks.isNullOrEmpty()) {
+                            Text(
+                                text = stringResource(R.string.schedule_enabled_tasks, enabledTasks),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(top = 8.dp)
                             )
                         }
-                    }
-                    // 显示选中 Profile 的已启用任务摘要
-                    val selectedProfile = state.profiles.find { it.id == state.selectedProfileId }
-                    val enabledTasks = selectedProfile?.chain
-                        ?.filter { it.enabled }
-                        ?.joinToString("、") { it.name }
-                    if (!enabledTasks.isNullOrEmpty()) {
-                        Text(
-                            text = stringResource(R.string.schedule_enabled_tasks, enabledTasks),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp)
-                        )
                     }
                 }
             }
 
             item {
-                SectionHeader(stringResource(R.string.schedule_section_advanced))
-                val (expanded, setExpanded) = remember { mutableStateOf(false) }
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
+                ScheduleEditSection(title = stringResource(R.string.schedule_section_advanced)) {
+                    val (expanded, setExpanded) = remember { mutableStateOf(false) }
                     Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Text(
-                            stringResource(R.string.schedule_force_start),
-                            style = MaterialTheme.typography.bodyLarge
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(
+                                stringResource(R.string.schedule_force_start),
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                            ExpandableTipIcon(
+                                modifier = Modifier.padding(start = 8.dp),
+                                expanded = expanded,
+                                onExpandedChange = { setExpanded(it) })
+                        }
+                        Switch(
+                            checked = state.forceStart,
+                            onCheckedChange = { viewModel.onForceStartChanged(it) }
                         )
-                        ExpandableTipIcon(
-                            modifier = Modifier.padding(start = 8.dp),
-                            expanded = expanded,
-                            onExpandedChange = { setExpanded(it) })
                     }
-                    Switch(
-                        checked = state.forceStart,
-                        onCheckedChange = { viewModel.onForceStartChanged(it) }
+                    ExpandableTipContent(
+                        visible = expanded,
+                        tipText = stringResource(R.string.schedule_force_start_tip),
                     )
                 }
-                ExpandableTipContent(
-                    visible = expanded,
-                    tipText = stringResource(R.string.schedule_force_start_tip),
-                )
             }
         }
     }
-
     if (showTimePicker) {
         TimePickerDialog(
             initialTime = editingTime,
@@ -528,6 +534,7 @@ fun ScheduleEditView(
                 showPermissionDialog = false
                 navController.popBackStack()
             },
+            containerColor = overlayBoardColor(),
             title = { Text(stringResource(R.string.schedule_permission_title)) },
             text = {
                 Text(
@@ -586,6 +593,7 @@ private fun TimePickerDialog(
     BasicAlertDialog(onDismissRequest = onDismiss) {
         Surface(
             shape = MaterialTheme.shapes.extraLarge,
+            color = overlayBoardColor(),
             tonalElevation = 6.dp
         ) {
             Column(
@@ -627,6 +635,30 @@ private fun TimePickerDialog(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun ScheduleEditSection(
+    title: String,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            SectionHeader(title)
+            content()
         }
     }
 }

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/ui/ScheduleListView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/ui/ScheduleListView.kt
@@ -23,7 +23,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -55,6 +56,7 @@ import com.aliothmoon.maameow.schedule.model.ScheduleStrategy
 import com.aliothmoon.maameow.schedule.service.AutoStartHelper
 import com.aliothmoon.maameow.theme.MaaDesignTokens
 import org.koin.androidx.compose.koinViewModel
+import com.aliothmoon.maameow.theme.overlayBoardColor
 
 @Composable
 fun ScheduleListView(
@@ -109,27 +111,39 @@ fun ScheduleListView(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(padding),
+                    .padding(padding)
+                    .padding(horizontal = MaaDesignTokens.Spacing.listHorizontal),
                 contentAlignment = Alignment.Center
             ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        imageVector = Icons.Default.DateRange,
-                        contentDescription = null,
-                        modifier = Modifier.size(64.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                // Compact board wrapping content with a little padding (readable on wallpaper).
+                Card(
+                    shape = RoundedCornerShape(12.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
                     )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        stringResource(R.string.schedule_empty_state),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Text(
-                        stringResource(R.string.schedule_empty_hint_add),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                    )
+                ) {
+                    Column(
+                        modifier = Modifier.padding(horizontal = 28.dp, vertical = 24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.DateRange,
+                            contentDescription = null,
+                            modifier = Modifier.size(56.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(
+                            stringResource(R.string.schedule_empty_state),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            stringResource(R.string.schedule_empty_hint_add),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        )
+                    }
                 }
             }
         } else {
@@ -157,6 +171,7 @@ fun ScheduleListView(
         if (deleteConfirmId != null) {
             AlertDialog(
                 onDismissRequest = { deleteConfirmId = null },
+                containerColor = overlayBoardColor(),
                 title = { Text(stringResource(R.string.schedule_delete_strategy_title)) },
                 text = { Text(stringResource(R.string.schedule_delete_strategy_message)) },
                 confirmButton = {
@@ -174,6 +189,7 @@ fun ScheduleListView(
         if (showAutoStartGuide) {
             AlertDialog(
                 onDismissRequest = { showAutoStartGuide = false },
+                containerColor = overlayBoardColor(),
                 title = { Text(stringResource(R.string.schedule_auto_start_permission_title)) },
                 text = { Text(stringResource(R.string.schedule_auto_start_permission_message)) },
                 confirmButton = {
@@ -201,11 +217,14 @@ private fun StrategyCard(
     onClick: () -> Unit,
     onDelete: () -> Unit
 ) {
-    ElevatedCard(
+    Card(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(12.dp)
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
+        )
     ) {
         Row(
             modifier = Modifier.padding(16.dp),

--- a/app/src/main/java/com/aliothmoon/maameow/schedule/ui/ScheduleTriggerLogView.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/schedule/ui/ScheduleTriggerLogView.kt
@@ -25,7 +25,8 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -54,6 +55,7 @@ import org.koin.androidx.compose.koinViewModel
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import com.aliothmoon.maameow.theme.overlayBoardColor
 
 @Composable
 fun ScheduleTriggerLogView(
@@ -109,22 +111,34 @@ fun ScheduleTriggerLogView(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(padding),
+                        .padding(padding)
+                        .padding(horizontal = MaaDesignTokens.Spacing.listHorizontal),
                     contentAlignment = Alignment.Center
                 ) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Icon(
-                            imageVector = Icons.Default.DateRange,
-                            contentDescription = null,
-                            modifier = Modifier.size(64.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                    // Compact board wrapping content with a little padding (same as schedule empty state).
+                    Card(
+                        shape = RoundedCornerShape(12.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
                         )
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text(
-                            stringResource(R.string.schedule_log_empty_state),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(horizontal = 28.dp, vertical = 24.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.DateRange,
+                                contentDescription = null,
+                                modifier = Modifier.size(56.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Text(
+                                stringResource(R.string.schedule_log_empty_state),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
             }
@@ -151,6 +165,7 @@ fun ScheduleTriggerLogView(
         if (showClearConfirm) {
             AlertDialog(
                 onDismissRequest = { showClearConfirm = false },
+                containerColor = overlayBoardColor(),
                 title = { Text(stringResource(R.string.schedule_log_clear_title)) },
                 text = { Text(stringResource(R.string.schedule_log_clear_message)) },
                 confirmButton = {
@@ -168,6 +183,7 @@ fun ScheduleTriggerLogView(
         if (deleteConfirmFileName != null) {
             AlertDialog(
                 onDismissRequest = { deleteConfirmFileName = null },
+                containerColor = overlayBoardColor(),
                 title = { Text(stringResource(R.string.schedule_log_delete_title)) },
                 text = { Text(stringResource(R.string.schedule_log_delete_message)) },
                 confirmButton = {
@@ -197,11 +213,14 @@ private fun SummaryCard(
     val resultLabel = summary.footer?.result?.let { scheduleExecutionResultLabel(it) }
         ?: stringResource(R.string.schedule_result_in_progress)
 
-    ElevatedCard(
+    Card(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(8.dp)
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
+        )
     ) {
         Row(
             modifier = Modifier.padding(start = 12.dp, top = 12.dp, bottom = 12.dp, end = 4.dp),

--- a/app/src/main/java/com/aliothmoon/maameow/theme/Theme.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/theme/Theme.kt
@@ -42,6 +42,24 @@ private val PureDarkBackground = Color(0xFF000000)
 private val PureDarkSurface = Color(0xFF000000)
 private val PureDarkSurfaceVariant = Color(0xFF121212)
 
+/** Pure black surface family for PURE_DARK (M3 surfaceContainer* must be forced too). */
+internal fun ColorScheme.withPureDarkSurfaces(): ColorScheme = copy(
+    background = PureDarkBackground,
+    surface = PureDarkSurface,
+    surfaceVariant = PureDarkSurfaceVariant,
+    surfaceBright = PureDarkSurfaceVariant,
+    surfaceDim = PureDarkBackground,
+    surfaceContainerLowest = PureDarkBackground,
+    surfaceContainerLow = PureDarkBackground,
+    surfaceContainer = PureDarkSurface,
+    surfaceContainerHigh = PureDarkSurfaceVariant,
+    surfaceContainerHighest = PureDarkSurfaceVariant,
+    surfaceTint = PureDarkSurface,
+    outlineVariant = PureDarkSurfaceVariant,
+    scrim = PureDarkBackground,
+)
+
+
 
 private fun createLightColorScheme(
     primary: Color, primaryContainer: Color, onPrimaryContainer: Color
@@ -159,10 +177,21 @@ object MaaThemeAlphas {
     const val Medium = 0.74f
 }
 
+
+/**
+ * Secondary overlay boards that float above primary page content
+ * (dialogs, announcement, quick-actions sheet, loading cards, etc.).
+ * Matches BackgroundTask "快捷操作": surfaceContainerHighest @ 0.96, no blur.
+ * Primary in-page cards keep surfaceContainerLowest.
+ */
+@Composable
+fun overlayBoardColor(): Color =
+    MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.96f)
+
 @Composable
 fun MaaMeowTheme(
     themeMode: AppSettingsManager.ThemeMode = AppSettingsManager.ThemeMode.SYSTEM,
-    useSystemMonetColor: Boolean = true,
+    useWallpaperColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
@@ -173,21 +202,17 @@ fun MaaMeowTheme(
         AppSettingsManager.ThemeMode.DARK, AppSettingsManager.ThemeMode.PURE_DARK -> true
     }
     val isPureDark = themeMode == AppSettingsManager.ThemeMode.PURE_DARK
-    val colorScheme: ColorScheme = remember(themeMode, useSystemMonetColor, isDarkTheme, context) {
+    val colorScheme: ColorScheme = remember(themeMode, useWallpaperColor, isDarkTheme, context) {
         when {
-            // Android 12+ with monet enabled ==> system dynamic color (Material You)
-            useSystemMonetColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            // Android 12+: when wallpaper color is enabled and no custom wallpaper scheme is applied, use system dynamic color
+            useWallpaperColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
                 val dynamic =
                     if (isDarkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(
                         context
                     )
                 // PURE_DARK keeps the monet-tinted primary but forces pure-black surfaces
                 if (isPureDark) {
-                    dynamic.copy(
-                        background = PureDarkBackground,
-                        surface = PureDarkSurface,
-                        surfaceVariant = PureDarkSurfaceVariant
-                    )
+                    dynamic.withPureDarkSurfaces()
                 } else dynamic
             }
             // Otherwise fall back to the built-in blue palette
@@ -195,7 +220,7 @@ fun MaaMeowTheme(
                 AppSettingsManager.ThemeMode.SYSTEM -> if (systemDarkTheme) BlueDark else BlueLight
                 AppSettingsManager.ThemeMode.WHITE -> BlueLight
                 AppSettingsManager.ThemeMode.DARK -> BlueDark
-                AppSettingsManager.ThemeMode.PURE_DARK -> BluePureDark
+                AppSettingsManager.ThemeMode.PURE_DARK -> BluePureDark.withPureDarkSurfaces()
             }
         }
     }

--- a/app/src/main/java/com/aliothmoon/maameow/theme/WallpaperAwareTheme.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/theme/WallpaperAwareTheme.kt
@@ -1,0 +1,117 @@
+package com.aliothmoon.maameow.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.aliothmoon.maameow.data.preferences.AppSettingsManager
+import com.aliothmoon.maameow.utils.BitmapUtils
+import com.aliothmoon.maameow.utils.WallpaperFileStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Theme for UI trees outside AppNavigation (system overlays, etc.).
+ *
+ * Applies [MaaMeowTheme] base palette, then overrides with a wallpaper-derived
+ * ColorScheme when dynamic color is enabled and a custom wallpaper is set.
+ * Seed prefers the on-disk cache written by AppNavigation to avoid re-quantize.
+ */
+@Composable
+fun WallpaperAwareMaterialTheme(
+    themeMode: AppSettingsManager.ThemeMode,
+    appSettings: AppSettingsManager,
+    content: @Composable () -> Unit,
+) {
+    val context = LocalContext.current
+    val useWallpaperColor by appSettings.useWallpaperColor.collectAsStateWithLifecycle()
+    val wallpaperTextContrast by appSettings.wallpaperTextContrast.collectAsStateWithLifecycle()
+    val wallpaperUri by appSettings.wallpaperUri.collectAsStateWithLifecycle()
+    val wallpaperUpdateVersion by appSettings.wallpaperUpdateVersion.collectAsStateWithLifecycle()
+    val systemDark = isSystemInDarkTheme()
+    val isDarkTheme = when (themeMode) {
+        AppSettingsManager.ThemeMode.SYSTEM -> systemDark
+        AppSettingsManager.ThemeMode.WHITE -> false
+        AppSettingsManager.ThemeMode.DARK,
+        AppSettingsManager.ThemeMode.PURE_DARK -> true
+    }
+    var wallpaperSeedArgb by remember { mutableStateOf<Int?>(null) }
+    // Match AppNavigation: seed for full dynamic color and/or dynamic text.
+    LaunchedEffect(wallpaperUri, useWallpaperColor, wallpaperTextContrast, wallpaperUpdateVersion) {
+        if ((!useWallpaperColor && !wallpaperTextContrast) || wallpaperUri.isEmpty()) {
+            wallpaperSeedArgb = null
+            return@LaunchedEffect
+        }
+        val requestUri = wallpaperUri
+        val requestVersion = wallpaperUpdateVersion
+        val seed = withContext(Dispatchers.Default) {
+            val store = WallpaperFileStore(context)
+            val identity = store.wallpaperIdentity(requestUri)
+            store.loadCachedSeed(identity)?.let { return@withContext it }
+            val source = BitmapUtils.loadDownsampledBitmap(context, requestUri, maxDimension = 512)
+                ?: return@withContext null
+            try {
+                WallpaperColorScheme.extractSeedColor(source).also { extracted ->
+                    store.saveCachedSeed(identity, extracted)
+                }
+            } finally {
+                if (!source.isRecycled) source.recycle()
+            }
+        }
+        if (requestUri == wallpaperUri && requestVersion == wallpaperUpdateVersion) {
+            wallpaperSeedArgb = seed
+        }
+    }
+
+    val isPureDark = themeMode == AppSettingsManager.ThemeMode.PURE_DARK
+
+    // Outer theme: system Monet when switch is on and there is no custom wallpaper
+    // seed path — or PURE_DARK (never uses custom wallpaper MCU; keep system accents).
+    val applySystemDynamicColor = useWallpaperColor && (
+        wallpaperUri.isEmpty() || isPureDark
+    )
+    MaaMeowTheme(
+        themeMode = themeMode,
+        useWallpaperColor = applySystemDynamicColor,
+    ) {
+        val seed = wallpaperSeedArgb
+        // Align with AppNavigation: full MCU when dynamic color on; text adapt
+        // only when wallpaperTextContrast is on (light/dark tones via isDarkTheme).
+        // PURE_DARK never overrides with wallpaper seed (surfaces stay pure black via outer theme).
+        val overrideScheme = when {
+            isPureDark || seed == null -> null
+            useWallpaperColor -> {
+                val scheme = WallpaperColorScheme.generateColorScheme(seed, isDarkTheme)
+                if (wallpaperTextContrast) {
+                    with(WallpaperColorScheme) {
+                        scheme.adaptContentForWallpaper(seed, isDarkTheme)
+                    }
+                } else {
+                    scheme
+                }
+            }
+            wallpaperTextContrast -> {
+                with(WallpaperColorScheme) {
+                    MaterialTheme.colorScheme.adaptContentForWallpaper(seed, isDarkTheme)
+                }
+            }
+            else -> null
+        }
+        if (overrideScheme != null) {
+            MaterialTheme(
+                colorScheme = overrideScheme,
+                typography = MaterialTheme.typography,
+                shapes = MaterialTheme.shapes,
+                content = content,
+            )
+        } else {
+            content()
+        }
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/theme/WallpaperBlurDisplay.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/theme/WallpaperBlurDisplay.kt
@@ -1,0 +1,70 @@
+package com.aliothmoon.maameow.theme
+
+import android.graphics.Bitmap
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.unit.dp
+import com.aliothmoon.maameow.data.preferences.WallpaperBlur
+import com.aliothmoon.maameow.utils.BitmapUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Wallpaper display blur:
+ * - API 31+: leave [source] sharp and use [wallpaperBlurModifier] (Compose RenderEffect).
+ * - API 28–30: pre-blur a downscaled copy on a background thread (Stack Blur).
+ */
+@Composable
+fun rememberWallpaperDisplayBitmap(
+    source: Bitmap?,
+    blurPercent: Int,
+    softwareMaxDimension: Int = 720,
+): ImageBitmap? {
+    val useSoftware = WallpaperBlur.needsSoftwareBlur
+    val radiusPx = if (useSoftware) {
+        WallpaperBlur.percentToSoftwareRadiusPx(blurPercent)
+    } else {
+        0
+    }
+    val sharp = remember(source) { source?.asImageBitmap() }
+
+    // Always call remember (Compose rules); only used on software path.
+    var soft by remember(source, radiusPx, softwareMaxDimension) {
+        mutableStateOf<ImageBitmap?>(null)
+    }
+    LaunchedEffect(source, radiusPx, softwareMaxDimension, useSoftware) {
+        if (!useSoftware || source == null || radiusPx <= 0) {
+            soft = null
+            return@LaunchedEffect
+        }
+        soft = null
+        val blurred = withContext(Dispatchers.Default) {
+            BitmapUtils.blurForWallpaper(source, radiusPx, softwareMaxDimension)
+        }
+        soft = blurred.asImageBitmap()
+    }
+
+    return when {
+        source == null -> null
+        useSoftware && radiusPx > 0 -> soft ?: sharp
+        else -> sharp
+    }
+}
+
+/**
+ * Apply Compose [Modifier.blur] only when the platform supports it (API 31+).
+ * On older APIs this is always [Modifier] — blur is baked into the bitmap instead.
+ */
+fun wallpaperBlurModifier(blurPercent: Int): Modifier {
+    if (WallpaperBlur.needsSoftwareBlur) return Modifier
+    val radius = WallpaperBlur.percentToRadiusDp(blurPercent)
+    return if (radius > 0f) Modifier.blur(radius.dp) else Modifier
+}

--- a/app/src/main/java/com/aliothmoon/maameow/theme/WallpaperColorScheme.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/theme/WallpaperColorScheme.kt
@@ -1,0 +1,192 @@
+package com.aliothmoon.maameow.theme
+
+import android.graphics.Bitmap
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color as ComposeColor
+import com.materialkolor.hct.Hct
+import com.materialkolor.quantize.QuantizerCelebi
+import com.materialkolor.scheme.SchemeTonalSpot
+import com.materialkolor.score.Score
+
+/**
+ * Extracts a seed color from wallpaper bitmaps and builds a Material You
+ * ColorScheme using the official Material Color Utilities algorithms
+ * (via the maintained materialkolor JVM packaging).
+ */
+object WallpaperColorScheme {
+
+    private const val GOOGLE_BLUE_ARGB = 0xFF1B6EF3.toInt()
+    private const val QUANTIZE_MAX_COLORS = 128
+    private const val SAMPLE_TARGET = 128
+
+    fun extractSeedColor(bitmap: Bitmap): Int {
+        if (bitmap.isRecycled || bitmap.width <= 0 || bitmap.height <= 0) {
+            return GOOGLE_BLUE_ARGB
+        }
+        val maxDim = maxOf(bitmap.width, bitmap.height).coerceAtLeast(1)
+        val sampleSize = (maxDim / SAMPLE_TARGET).coerceAtLeast(1)
+        val w = (bitmap.width / sampleSize).coerceAtLeast(1)
+        val h = (bitmap.height / sampleSize).coerceAtLeast(1)
+        val scaled = if (w == bitmap.width && h == bitmap.height) {
+            bitmap
+        } else {
+            Bitmap.createScaledBitmap(bitmap, w, h, false)
+        }
+        return try {
+            val pixels = IntArray(w * h)
+            scaled.getPixels(pixels, 0, w, 0, 0, w, h)
+            val quantized = QuantizerCelebi.quantize(pixels, QUANTIZE_MAX_COLORS)
+            if (quantized.isEmpty()) {
+                GOOGLE_BLUE_ARGB
+            } else {
+                // Explicit desired count; default helper can be brittle across MCU packaging.
+                // Positional args match MCU Score.score(map, desired, fallback, filter).
+                val ranked = Score.score(quantized, 4, GOOGLE_BLUE_ARGB, true)
+                ranked.firstOrNull() ?: GOOGLE_BLUE_ARGB
+            }
+        } catch (_: Exception) {
+            GOOGLE_BLUE_ARGB
+        } finally {
+            if (scaled !== bitmap && !scaled.isRecycled) {
+                scaled.recycle()
+            }
+        }
+    }
+
+    fun generateColorScheme(seedArgb: Int, isDark: Boolean): ColorScheme {
+        val source = Hct.fromInt(seedArgb)
+        // contrastLevel 0.0 matches the Material You default contrast.
+        val scheme = SchemeTonalSpot(source, isDark, 0.0)
+        return toComposeColorScheme(scheme, isDark)
+    }
+
+    /**
+     * Rewrite content/text roles from a wallpaper seed. Surfaces/primary stay.
+     *
+     * Built-in theme body ink is ~tone 10 (light) / ~100 (dark). Dynamic text uses
+     * a **high-contrast** colored ink (hue from seed) so body text stays readable
+     * on wallpaper/cards while still carrying wallpaper tint:
+     * - **Dark theme**: ink **90**, muted **82**
+     * - **Light theme**: ink **18**, muted **28**
+     *
+     * Does not touch [onSurfaceVariant] (hints) or filled-button on-colors
+     * ([onPrimary] etc.).
+     *
+     * @param isDark true for dark / pure-dark theme; false for light theme.
+     */
+    fun ColorScheme.adaptContentForWallpaper(seedArgb: Int, isDark: Boolean): ColorScheme {
+        val seedHct = Hct.fromInt(seedArgb)
+        // Extreme tones for readability; keep seed hue (not pure black/white).
+        val inkTone = if (isDark) 90.0 else 18.0
+        val mutedTone = if (isDark) 82.0 else 28.0
+        val inkChromaScale = 0.65
+        val mutedChromaScale = 0.45
+        val ink = ComposeColor(
+            Hct.from(
+                seedHct.hue,
+                (seedHct.chroma * inkChromaScale).coerceIn(20.0, 48.0),
+                inkTone,
+            ).toInt()
+        )
+        val muted = ComposeColor(
+            Hct.from(
+                seedHct.hue,
+                (seedHct.chroma * mutedChromaScale).coerceIn(14.0, 32.0),
+                mutedTone,
+            ).toInt()
+        )
+        return copy(
+            onBackground = ink,
+            onSurface = ink,
+            onPrimaryContainer = muted,
+            onSecondaryContainer = muted,
+            onTertiaryContainer = muted,
+            inverseOnSurface = muted,
+        )
+    }
+
+    private fun toComposeColorScheme(scheme: SchemeTonalSpot, isDark: Boolean): ColorScheme {
+        fun c(argb: Int): ComposeColor = ComposeColor(argb)
+        return if (isDark) {
+            darkColorScheme(
+                primary = c(scheme.primary),
+                onPrimary = c(scheme.onPrimary),
+                primaryContainer = c(scheme.primaryContainer),
+                onPrimaryContainer = c(scheme.onPrimaryContainer),
+                inversePrimary = c(scheme.inversePrimary),
+                secondary = c(scheme.secondary),
+                onSecondary = c(scheme.onSecondary),
+                secondaryContainer = c(scheme.secondaryContainer),
+                onSecondaryContainer = c(scheme.onSecondaryContainer),
+                tertiary = c(scheme.tertiary),
+                onTertiary = c(scheme.onTertiary),
+                tertiaryContainer = c(scheme.tertiaryContainer),
+                onTertiaryContainer = c(scheme.onTertiaryContainer),
+                background = c(scheme.background),
+                onBackground = c(scheme.onBackground),
+                surface = c(scheme.surface),
+                onSurface = c(scheme.onSurface),
+                surfaceVariant = c(scheme.surfaceVariant),
+                onSurfaceVariant = c(scheme.onSurfaceVariant),
+                surfaceTint = c(scheme.surfaceTint),
+                inverseSurface = c(scheme.inverseSurface),
+                inverseOnSurface = c(scheme.inverseOnSurface),
+                error = c(scheme.error),
+                onError = c(scheme.onError),
+                errorContainer = c(scheme.errorContainer),
+                onErrorContainer = c(scheme.onErrorContainer),
+                outline = c(scheme.outline),
+                outlineVariant = c(scheme.outlineVariant),
+                scrim = c(scheme.scrim),
+                surfaceBright = c(scheme.surfaceBright),
+                surfaceDim = c(scheme.surfaceDim),
+                surfaceContainer = c(scheme.surfaceContainer),
+                surfaceContainerHigh = c(scheme.surfaceContainerHigh),
+                surfaceContainerHighest = c(scheme.surfaceContainerHighest),
+                surfaceContainerLow = c(scheme.surfaceContainerLow),
+                surfaceContainerLowest = c(scheme.surfaceContainerLowest),
+            )
+        } else {
+            lightColorScheme(
+                primary = c(scheme.primary),
+                onPrimary = c(scheme.onPrimary),
+                primaryContainer = c(scheme.primaryContainer),
+                onPrimaryContainer = c(scheme.onPrimaryContainer),
+                inversePrimary = c(scheme.inversePrimary),
+                secondary = c(scheme.secondary),
+                onSecondary = c(scheme.onSecondary),
+                secondaryContainer = c(scheme.secondaryContainer),
+                onSecondaryContainer = c(scheme.onSecondaryContainer),
+                tertiary = c(scheme.tertiary),
+                onTertiary = c(scheme.onTertiary),
+                tertiaryContainer = c(scheme.tertiaryContainer),
+                onTertiaryContainer = c(scheme.onTertiaryContainer),
+                background = c(scheme.background),
+                onBackground = c(scheme.onBackground),
+                surface = c(scheme.surface),
+                onSurface = c(scheme.onSurface),
+                surfaceVariant = c(scheme.surfaceVariant),
+                onSurfaceVariant = c(scheme.onSurfaceVariant),
+                surfaceTint = c(scheme.surfaceTint),
+                inverseSurface = c(scheme.inverseSurface),
+                inverseOnSurface = c(scheme.inverseOnSurface),
+                error = c(scheme.error),
+                onError = c(scheme.onError),
+                errorContainer = c(scheme.errorContainer),
+                onErrorContainer = c(scheme.onErrorContainer),
+                outline = c(scheme.outline),
+                outlineVariant = c(scheme.outlineVariant),
+                scrim = c(scheme.scrim),
+                surfaceBright = c(scheme.surfaceBright),
+                surfaceDim = c(scheme.surfaceDim),
+                surfaceContainer = c(scheme.surfaceContainer),
+                surfaceContainerHigh = c(scheme.surfaceContainerHigh),
+                surfaceContainerHighest = c(scheme.surfaceContainerHighest),
+                surfaceContainerLow = c(scheme.surfaceContainerLow),
+                surfaceContainerLowest = c(scheme.surfaceContainerLowest),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/utils/BitmapUtils.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/utils/BitmapUtils.kt
@@ -1,0 +1,471 @@
+package com.aliothmoon.maameow.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.net.Uri
+import androidx.exifinterface.media.ExifInterface
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+object BitmapUtils {
+    // Avoid loading multi-dozen-MB originals fully into RAM for picker fallbacks.
+    private const val MAX_CONTENT_BYTES = 25L * 1024 * 1024
+
+    fun loadDownsampledBitmap(
+        context: Context,
+        uri: Uri,
+        maxDimension: Int = 2048,
+    ): Bitmap? {
+        return try {
+            when (uri.scheme) {
+                null, "file" -> {
+                    val path = uri.path ?: return null
+                    loadDownsampledBitmap(File(path), maxDimension)
+                }
+                else -> loadFromContentUri(context, uri, maxDimension)
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun loadDownsampledBitmap(
+        context: Context,
+        uriString: String,
+        maxDimension: Int = 2048,
+    ): Bitmap? {
+        val uri = parseUri(uriString)
+        return loadDownsampledBitmap(context, uri, maxDimension)
+    }
+
+    fun loadDownsampledBitmap(
+        file: File,
+        maxDimension: Int = 2048,
+    ): Bitmap? {
+        if (!file.exists() || file.length() <= 0L) return null
+        return try {
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeFile(file.absolutePath, bounds)
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+
+            val opts = BitmapFactory.Options().apply {
+                inSampleSize = sampleSizeFor(bounds.outWidth, bounds.outHeight, maxDimension)
+            }
+            val decoded = BitmapFactory.decodeFile(file.absolutePath, opts) ?: return null
+            applyExifOrientation(file, decoded)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Content providers may revoke temporary grants after the first open.
+     * Read the stream once into memory, then decode bounds + pixels + EXIF from bytes.
+     */
+    private fun loadFromContentUri(
+        context: Context,
+        uri: Uri,
+        maxDimension: Int,
+    ): Bitmap? {
+        val bytes = openInputStream(context, uri)?.use { input ->
+            val buffer = java.io.ByteArrayOutputStream()
+            val chunk = ByteArray(64 * 1024)
+            var total = 0L
+            while (true) {
+                val n = input.read(chunk)
+                if (n <= 0) break
+                total += n
+                if (total > MAX_CONTENT_BYTES) {
+                    // Too large for in-memory content decode; fail over to File-based path if caller copied.
+                    return null
+                }
+                buffer.write(chunk, 0, n)
+            }
+            buffer.toByteArray()
+        } ?: return null
+        if (bytes.isEmpty()) return null
+
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+
+        val opts = BitmapFactory.Options().apply {
+            inSampleSize = sampleSizeFor(bounds.outWidth, bounds.outHeight, maxDimension)
+        }
+        val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts) ?: return null
+
+        val orientation = try {
+            ExifInterface(ByteArrayInputStream(bytes)).getAttributeInt(
+                ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_UNDEFINED,
+            )
+        } catch (_: Exception) {
+            ExifInterface.ORIENTATION_UNDEFINED
+        }
+        return transformByOrientation(decoded, orientation)
+    }
+
+    private fun sampleSizeFor(width: Int, height: Int, maxDimension: Int): Int {
+        val maxDim = max(width, height)
+        if (maxDim <= maxDimension) return 1
+        var s = 1
+        while (maxDim / s > maxDimension) s *= 2
+        return s
+    }
+
+    private fun openInputStream(context: Context, uri: Uri): InputStream? {
+        return try {
+            when (uri.scheme) {
+                null, "file" -> {
+                    val path = uri.path ?: return null
+                    val file = File(path)
+                    if (!file.exists()) null else FileInputStream(file)
+                }
+                else -> context.contentResolver.openInputStream(uri)
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun applyExifOrientation(file: File, bitmap: Bitmap): Bitmap {
+        val orientation = try {
+            ExifInterface(file.absolutePath).getAttributeInt(
+                ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_UNDEFINED,
+            )
+        } catch (_: Exception) {
+            return bitmap
+        }
+        return transformByOrientation(bitmap, orientation)
+    }
+
+    private fun transformByOrientation(bitmap: Bitmap, orientation: Int): Bitmap {
+        val matrix = Matrix()
+        when (orientation) {
+            ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.preScale(-1f, 1f)
+            ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
+            ExifInterface.ORIENTATION_FLIP_VERTICAL -> matrix.preScale(1f, -1f)
+            ExifInterface.ORIENTATION_TRANSPOSE -> {
+                matrix.postRotate(90f)
+                matrix.preScale(-1f, 1f)
+            }
+            ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
+            ExifInterface.ORIENTATION_TRANSVERSE -> {
+                matrix.postRotate(270f)
+                matrix.preScale(-1f, 1f)
+            }
+            ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
+            else -> return bitmap
+        }
+        return try {
+            val oriented = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+            if (oriented !== bitmap && !bitmap.isRecycled) {
+                bitmap.recycle()
+            }
+            oriented
+        } catch (_: Exception) {
+            bitmap
+        }
+    }
+
+    private fun parseUri(uriString: String): Uri {
+        val uri = Uri.parse(uriString)
+        return if (uri.scheme == null) Uri.fromFile(File(uriString)) else uri
+    }
+    /**
+     * Approximate Gaussian blur for API < 31 where [androidx.compose.ui.draw.blur] is a no-op.
+     * Operates on a downscaled **mutable** ARGB copy for speed; never mutates or recycles [source].
+     *
+     * Note: [Bitmap.createScaledBitmap] often returns an immutable bitmap when [source] is
+     * immutable. [stackBlurInPlace] needs [Bitmap.setPixels], so we always force a mutable copy.
+     *
+     * @param radius blur radius in pixels on the downscaled bitmap (0 = return source).
+     * @param maxDimension longest edge after downscale before blurring.
+     */
+    fun blurForWallpaper(
+        source: Bitmap,
+        radius: Int,
+        maxDimension: Int = 720,
+    ): Bitmap {
+        if (source.isRecycled || source.width <= 0 || source.height <= 0) return source
+        val r = radius.coerceAtLeast(0)
+        if (r == 0) return source
+
+        val maxDim = max(source.width, source.height)
+        // Intermediate may be immutable (especially createScaledBitmap from immutable source).
+        var intermediate: Bitmap? = null
+        val working: Bitmap = try {
+            if (maxDim > maxDimension) {
+                val scale = maxDimension.toFloat() / maxDim.toFloat()
+                val w = (source.width * scale).toInt().coerceAtLeast(1)
+                val h = (source.height * scale).toInt().coerceAtLeast(1)
+                val scaled = Bitmap.createScaledBitmap(source, w, h, true)
+                intermediate = if (scaled !== source) scaled else null
+                ensureMutableArgb8888(scaled, recycleIfCopied = scaled !== source)
+            } else {
+                // Always copy: never blur the caller's source in place.
+                source.copy(Bitmap.Config.ARGB_8888, true)
+                    ?: return source
+            }
+        } catch (_: Exception) {
+            intermediate?.takeIf { !it.isRecycled }?.recycle()
+            return source
+        } ?: run {
+            // copy failed after scale: drop intermediate if it is not the working bitmap.
+            intermediate?.takeIf { !it.isRecycled }?.recycle()
+            return source
+        }
+
+        return try {
+            stackBlurInPlace(working, r.coerceAtMost(50))
+            working
+        } catch (_: Exception) {
+            if (working !== source && !working.isRecycled) working.recycle()
+            source
+        }
+    }
+
+    /**
+     * Returns a mutable ARGB_8888 bitmap. If [bitmap] is already mutable ARGB_8888, returns it as-is.
+     * Otherwise copies; when [recycleIfCopied] is true and a new bitmap is created, recycles [bitmap]
+     * (only safe when [bitmap] is not owned by the caller / is an intermediate).
+     */
+    private fun ensureMutableArgb8888(
+        bitmap: Bitmap,
+        recycleIfCopied: Boolean,
+    ): Bitmap? {
+        if (!bitmap.isRecycled &&
+            bitmap.isMutable &&
+            bitmap.config == Bitmap.Config.ARGB_8888
+        ) {
+            return bitmap
+        }
+        val copy = bitmap.copy(Bitmap.Config.ARGB_8888, true) ?: return null
+        if (recycleIfCopied && copy !== bitmap && !bitmap.isRecycled) {
+            bitmap.recycle()
+        }
+        return copy
+    }
+
+    /**
+     * Stack Blur (Mario Klingemann) — good quality / cost tradeoff for software fallback.
+     * Mutates [bitmap] in place; requires ARGB_8888 mutable bitmap.
+     */
+    private fun stackBlurInPlace(bitmap: Bitmap, radius: Int) {
+        if (radius < 1) return
+        val w = bitmap.width
+        val h = bitmap.height
+        val pix = IntArray(w * h)
+        bitmap.getPixels(pix, 0, w, 0, 0, w, h)
+
+        val wm = w - 1
+        val hm = h - 1
+        val wh = w * h
+        val div = radius + radius + 1
+
+        val r = IntArray(wh)
+        val g = IntArray(wh)
+        val b = IntArray(wh)
+        var rsum: Int
+        var gsum: Int
+        var bsum: Int
+        var x: Int
+        var y: Int
+        var i: Int
+        var p: Int
+        var yp: Int
+        var yi: Int
+        var yw: Int
+        val vmin = IntArray(max(w, h))
+
+        var divsum = (div + 1) shr 1
+        divsum *= divsum
+        val dv = IntArray(256 * divsum)
+        i = 0
+        while (i < 256 * divsum) {
+            dv[i] = i / divsum
+            i++
+        }
+
+        yi = 0
+        yw = 0
+
+        val stack = Array(div) { IntArray(3) }
+        var stackpointer: Int
+        var stackstart: Int
+        var sir: IntArray
+        var rbs: Int
+        val r1 = radius + 1
+        var routsum: Int
+        var goutsum: Int
+        var boutsum: Int
+        var rinsum: Int
+        var ginsum: Int
+        var binsum: Int
+
+        y = 0
+        while (y < h) {
+            bsum = 0
+            gsum = 0
+            rsum = 0
+            boutsum = 0
+            goutsum = 0
+            routsum = 0
+            binsum = 0
+            ginsum = 0
+            rinsum = 0
+            i = -radius
+            while (i <= radius) {
+                p = pix[yi + min(wm, max(i, 0))]
+                sir = stack[i + radius]
+                sir[0] = (p and 0xff0000) shr 16
+                sir[1] = (p and 0x00ff00) shr 8
+                sir[2] = p and 0x0000ff
+                rbs = r1 - abs(i)
+                rsum += sir[0] * rbs
+                gsum += sir[1] * rbs
+                bsum += sir[2] * rbs
+                if (i > 0) {
+                    rinsum += sir[0]
+                    ginsum += sir[1]
+                    binsum += sir[2]
+                } else {
+                    routsum += sir[0]
+                    goutsum += sir[1]
+                    boutsum += sir[2]
+                }
+                i++
+            }
+            stackpointer = radius
+            x = 0
+            while (x < w) {
+                r[yi] = dv[rsum]
+                g[yi] = dv[gsum]
+                b[yi] = dv[bsum]
+                rsum -= routsum
+                gsum -= goutsum
+                bsum -= boutsum
+                stackstart = stackpointer - radius + div
+                sir = stack[stackstart % div]
+                routsum -= sir[0]
+                goutsum -= sir[1]
+                boutsum -= sir[2]
+                if (y == 0) {
+                    vmin[x] = min(x + radius + 1, wm)
+                }
+                p = pix[yw + vmin[x]]
+                sir[0] = (p and 0xff0000) shr 16
+                sir[1] = (p and 0x00ff00) shr 8
+                sir[2] = p and 0x0000ff
+                rinsum += sir[0]
+                ginsum += sir[1]
+                binsum += sir[2]
+                rsum += rinsum
+                gsum += ginsum
+                bsum += binsum
+                stackpointer = (stackpointer + 1) % div
+                sir = stack[stackpointer % div]
+                routsum += sir[0]
+                goutsum += sir[1]
+                boutsum += sir[2]
+                rinsum -= sir[0]
+                ginsum -= sir[1]
+                binsum -= sir[2]
+                yi++
+                x++
+            }
+            yw += w
+            y++
+        }
+
+        x = 0
+        while (x < w) {
+            bsum = 0
+            gsum = 0
+            rsum = 0
+            boutsum = 0
+            goutsum = 0
+            routsum = 0
+            binsum = 0
+            ginsum = 0
+            rinsum = 0
+            yp = -radius * w
+            i = -radius
+            while (i <= radius) {
+                yi = max(0, yp) + x
+                sir = stack[i + radius]
+                sir[0] = r[yi]
+                sir[1] = g[yi]
+                sir[2] = b[yi]
+                rbs = r1 - abs(i)
+                rsum += r[yi] * rbs
+                gsum += g[yi] * rbs
+                bsum += b[yi] * rbs
+                if (i > 0) {
+                    rinsum += sir[0]
+                    ginsum += sir[1]
+                    binsum += sir[2]
+                } else {
+                    routsum += sir[0]
+                    goutsum += sir[1]
+                    boutsum += sir[2]
+                }
+                if (i < hm) {
+                    yp += w
+                }
+                i++
+            }
+            yi = x
+            stackpointer = radius
+            y = 0
+            while (y < h) {
+                pix[yi] =
+                    (0xff000000.toInt() and pix[yi]) or
+                        (dv[rsum] shl 16) or
+                        (dv[gsum] shl 8) or
+                        dv[bsum]
+                rsum -= routsum
+                gsum -= goutsum
+                bsum -= boutsum
+                stackstart = stackpointer - radius + div
+                sir = stack[stackstart % div]
+                routsum -= sir[0]
+                goutsum -= sir[1]
+                boutsum -= sir[2]
+                if (x == 0) {
+                    vmin[y] = min(y + r1, hm) * w
+                }
+                p = x + vmin[y]
+                sir[0] = r[p]
+                sir[1] = g[p]
+                sir[2] = b[p]
+                rinsum += sir[0]
+                ginsum += sir[1]
+                binsum += sir[2]
+                rsum += rinsum
+                gsum += ginsum
+                bsum += binsum
+                stackpointer = (stackpointer + 1) % div
+                sir = stack[stackpointer]
+                routsum += sir[0]
+                goutsum += sir[1]
+                boutsum += sir[2]
+                rinsum -= sir[0]
+                ginsum -= sir[1]
+                binsum -= sir[2]
+                yi += w
+                y++
+            }
+            x++
+        }
+        bitmap.setPixels(pix, 0, w, 0, 0, w, h)
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/utils/WallpaperFileStore.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/utils/WallpaperFileStore.kt
@@ -1,0 +1,345 @@
+package com.aliothmoon.maameow.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.net.Uri
+import java.io.File
+import java.util.Properties
+
+/**
+ * Persistent wallpaper file locations under filesDir, plus helpers for
+ * save/clear, crop-transform restore, seed-color cache, and legacy migration.
+ */
+class WallpaperFileStore(context: Context) {
+    private val appContext = context.applicationContext
+
+    val dir: File = File(appContext.filesDir, DIR_NAME).also { it.mkdirs() }
+    val sourceFile: File = File(dir, SOURCE_NAME)
+    val croppedFile: File = File(dir, CROPPED_NAME)
+    private val cropParamsFile: File = File(dir, CROP_PARAMS_NAME)
+    private val seedCacheFile: File = File(dir, SEED_CACHE_NAME)
+
+    fun croppedUriString(): String = Uri.fromFile(croppedFile).toString()
+
+    fun saveBitmap(file: File, bitmap: Bitmap): String? = saveBitmapToFile(file, bitmap)
+
+    /**
+     * Copy a content/file Uri into [target] using a single open of the source stream.
+     * This is the reliable way to import picker URIs that only have a temporary grant.
+     */
+    fun copyFromUri(uri: Uri, target: File = sourceFile): Boolean {
+        return try {
+            target.parentFile?.mkdirs()
+            val temp = File(target.parentFile, target.name + ".tmp")
+            val input = when (uri.scheme) {
+                null, "file" -> {
+                    val path = uri.path ?: return false
+                    File(path).inputStream()
+                }
+                else -> appContext.contentResolver.openInputStream(uri) ?: return false
+            }
+            input.use { src ->
+                temp.outputStream().use { dst ->
+                    // Cap copy size so a huge content URI cannot fill filesDir before decode.
+                    // Matches BitmapUtils in-memory content decode budget (25MB).
+                    val buf = ByteArray(DEFAULT_BUFFER_SIZE)
+                    var total = 0L
+                    while (true) {
+                        val read = src.read(buf)
+                        if (read < 0) break
+                        total += read
+                        if (total > MAX_COPY_BYTES) {
+                            temp.delete()
+                            return false
+                        }
+                        dst.write(buf, 0, read)
+                    }
+                }
+            }
+            if (temp.length() <= 0L) {
+                temp.delete()
+                return false
+            }
+            if (target.exists() && !target.delete()) {
+                temp.delete()
+                return false
+            }
+            if (!temp.renameTo(target)) {
+                temp.inputStream().use { a ->
+                    target.outputStream().use { b -> a.copyTo(b) }
+                }
+                temp.delete()
+            }
+            target.exists() && target.length() > 0L
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Creates a temporary backup of [source] (appended ".backup") and returns it.
+     * Returns null if source does not exist.
+     */
+    fun backupSourceFile(source: File): File? {
+        if (!source.exists()) return null
+        val backup = File(source.parentFile, source.name + ".backup")
+        source.copyTo(backup, overwrite = true)
+        return backup.takeIf { it.exists() }
+    }
+
+    /** Restores [backup] over [target].  Does nothing if backup is null or missing. */
+    fun restoreSourceFile(backup: File?, target: File) {
+        backup ?: return
+        if (!backup.exists()) return
+        backup.copyTo(target, overwrite = true)
+    }
+
+    /** Deletes a backup file.  Safe to pass null. */
+    fun deleteBackup(backup: File?) {
+        backup?.delete()
+    }
+
+    /** Path of the in-edit source backup, if any. */
+    fun sourceBackupFile(): File = File(dir, SOURCE_NAME + ".backup")
+
+    /**
+     * If a pick was interrupted (process kill), [sourceFile] may already be the new
+     * image while [croppedFile] / on-screen preview still show the previous crop.
+     * Restore source from the orphan backup so re-open crop matches the preview, then
+     * drop the backup.
+     *
+     * If crop params already match the current [sourceFile] identity, treat the pick
+     * as confirmed (cropped + params durable) and only delete the backup — do not
+     * restore, or a kill between confirm and backup-delete would resurrect the old source.
+     * No-op when no backup exists.
+     */
+    fun reconcileOrphanEditBackup() {
+        val backup = sourceBackupFile()
+        if (!backup.exists()) return
+        val identity = sourceIdentity(sourceFile)
+        if (identity.isNotEmpty() && loadCropParams(identity) != null) {
+            deleteBackup(backup)
+            return
+        }
+        restoreSourceFile(backup, sourceFile)
+        deleteBackup(backup)
+    }
+
+    fun clearFiles() {
+        if (sourceFile.exists()) sourceFile.delete()
+        if (croppedFile.exists()) croppedFile.delete()
+        if (cropParamsFile.exists()) cropParamsFile.delete()
+        if (seedCacheFile.exists()) seedCacheFile.delete()
+        // Orphan edit backups (e.g. process killed mid-pick, or clear after cancel race).
+        sourceBackupFile().delete()
+        dir.listFiles()
+            ?.filter { it.isFile && it.name.endsWith(".backup") }
+            ?.forEach { it.delete() }
+    }
+
+    fun fileExistsForUri(uriString: String): Boolean {
+        if (uriString.isEmpty()) return false
+        val path = Uri.parse(uriString).path ?: return false
+        // Only the exact preference path counts. A leftover wallpaper.jpg must not
+        // keep a stale/missing URI alive.
+        return try {
+            File(path).exists()
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    data class CropParams(
+        val scale: Float,
+        val panX: Float,
+        val panY: Float,
+        val rotationDegrees: Float,
+        val sourceIdentity: String,
+    )
+
+    fun sourceIdentity(file: File = sourceFile): String {
+        if (!file.exists()) return ""
+        return file.absolutePath + "|" + file.length() + "|" + file.lastModified()
+    }
+
+    fun saveCropParams(params: CropParams) {
+        try {
+            val props = Properties().apply {
+                setProperty("scale", params.scale.toString())
+                setProperty("panX", params.panX.toString())
+                setProperty("panY", params.panY.toString())
+                setProperty("rotationDegrees", params.rotationDegrees.toString())
+                setProperty("sourceIdentity", params.sourceIdentity)
+            }
+            cropParamsFile.outputStream().use { props.store(it, "wallpaper crop transform") }
+        } catch (_: Exception) {
+            // best-effort
+        }
+    }
+
+    fun loadCropParams(expectedSourceIdentity: String): CropParams? {
+        if (!cropParamsFile.exists() || expectedSourceIdentity.isEmpty()) return null
+        return try {
+            val props = Properties()
+            cropParamsFile.inputStream().use { props.load(it) }
+            val identity = props.getProperty("sourceIdentity").orEmpty()
+            if (identity != expectedSourceIdentity) return null
+            CropParams(
+                scale = props.getProperty("scale")?.toFloatOrNull() ?: return null,
+                panX = props.getProperty("panX")?.toFloatOrNull() ?: 0f,
+                panY = props.getProperty("panY")?.toFloatOrNull() ?: 0f,
+                rotationDegrees = props.getProperty("rotationDegrees")?.toFloatOrNull() ?: 0f,
+                sourceIdentity = identity,
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun clearCropParams() {
+        if (cropParamsFile.exists()) cropParamsFile.delete()
+    }
+
+    fun wallpaperIdentity(uriString: String): String {
+        val path = Uri.parse(uriString).path
+        val file = if (path != null) File(path) else croppedFile
+        if (!file.exists()) return uriString
+        return file.absolutePath + "|" + file.length() + "|" + file.lastModified()
+    }
+
+    fun loadCachedSeed(identity: String): Int? {
+        if (identity.isEmpty() || !seedCacheFile.exists()) return null
+        return try {
+            val props = Properties()
+            seedCacheFile.inputStream().use { props.load(it) }
+            if (props.getProperty("identity") != identity) return null
+            props.getProperty("seed")?.toIntOrNull()
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun saveCachedSeed(identity: String, seedArgb: Int) {
+        if (identity.isEmpty()) return
+        try {
+            val props = Properties().apply {
+                setProperty("identity", identity)
+                setProperty("seed", seedArgb.toString())
+            }
+            seedCacheFile.outputStream().use { props.store(it, "wallpaper seed cache") }
+        } catch (_: Exception) {
+            // best-effort
+        }
+    }
+
+    fun clearSeedCache() {
+        if (seedCacheFile.exists()) seedCacheFile.delete()
+    }
+
+    /**
+     * If preferences still point at a legacy cacheDir wallpaper that still exists,
+     * copy it into filesDir and return the new URI string; otherwise return null.
+     */
+    fun migrateLegacyUriIfNeeded(uriString: String): String? {
+        if (uriString.isEmpty()) return null
+        val uri = Uri.parse(uriString)
+        val path = uri.path ?: return null
+        val legacy = File(path)
+        if (!legacy.exists()) return null
+
+        // Already under the new filesDir location.
+        if (legacy.canonicalPath.startsWith(dir.canonicalPath)) return null
+
+        val cacheRoot = appContext.cacheDir.canonicalPath
+        val inCacheDir = legacy.canonicalPath.startsWith(cacheRoot)
+        val looksLikeOldWallpaper =
+            inCacheDir && (
+                legacy.name == CROPPED_NAME ||
+                    legacy.name == SOURCE_NAME ||
+                    legacy.parentFile?.name == DIR_NAME ||
+                    path.contains("/cache/")
+            )
+        if (!looksLikeOldWallpaper) {
+            // Unknown external path: leave as-is (may still open via content/file).
+            return null
+        }
+
+        return try {
+            dir.mkdirs()
+            legacy.inputStream().use { input ->
+                croppedFile.outputStream().use { output -> input.copyTo(output) }
+            }
+            // Best-effort source copy when the legacy file is the only copy.
+            if (!sourceFile.exists()) {
+                croppedFile.copyTo(sourceFile, overwrite = true)
+            }
+            // Clean old cache copies if they live under cacheDir.
+            if (legacy.canonicalPath.startsWith(cacheRoot)) {
+                legacy.delete()
+                legacy.parentFile
+                    ?.takeIf { it.name == DIR_NAME && it.canonicalPath.startsWith(cacheRoot) }
+                    ?.listFiles()
+                    ?.forEach { candidate ->
+                        if (candidate.name == SOURCE_NAME || candidate.name == CROPPED_NAME) {
+                            candidate.delete()
+                        }
+                    }
+            }
+            croppedUriString()
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    companion object {
+        const val DIR_NAME = "wallpaper"
+        const val SOURCE_NAME = "wallpaper_source.jpg"
+        const val CROPPED_NAME = "wallpaper.jpg"
+        private const val CROP_PARAMS_NAME = "crop_params.properties"
+        private const val SEED_CACHE_NAME = "seed_cache.properties"
+        private const val MAX_BYTES = 4L * 1024 * 1024
+        /** Max bytes accepted when copying a picker/content URI into filesDir. */
+        private const val MAX_COPY_BYTES = 25L * 1024 * 1024
+
+        fun saveBitmapToFile(file: File, bitmap: Bitmap): String? {
+            return try {
+                file.parentFile?.mkdirs()
+                val temp = File(file.parentFile, file.name + ".tmp")
+                // JPEG has no alpha; composite onto black to avoid random garbage in transparent areas.
+                val opaque = if (bitmap.hasAlpha()) {
+                    Bitmap.createBitmap(bitmap.width, bitmap.height, Bitmap.Config.ARGB_8888).also { out ->
+                        val canvas = Canvas(out)
+                        canvas.drawColor(Color.BLACK)
+                        canvas.drawBitmap(bitmap, 0f, 0f, null)
+                    }
+                } else {
+                    bitmap
+                }
+                var quality = 95
+                while (quality >= 20) {
+                    temp.outputStream().use { opaque.compress(Bitmap.CompressFormat.JPEG, quality, it) }
+                    if (temp.length() <= MAX_BYTES || quality == 20) break
+                    quality -= 15
+                }
+                if (opaque !== bitmap && !opaque.isRecycled) {
+                    opaque.recycle()
+                }
+                if (file.exists() && !file.delete()) {
+                    temp.delete()
+                    return null
+                }
+                if (!temp.renameTo(file)) {
+                    temp.inputStream().use { input ->
+                        file.outputStream().use { output -> input.copyTo(output) }
+                    }
+                    temp.delete()
+                }
+                file.absolutePath
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -48,8 +48,8 @@
     <string name="settings_startup_backend_title">Startup Mode</string>
     <string name="settings_startup_backend_desc">Choose how the app obtains system permissions</string>
     <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
-    <string name="settings_monet_color_title">Monet Theme Color</string>
-    <string name="settings_monet_color_desc">Generate colors from your wallpaper; off uses the built-in blue theme.</string>
+    <string name="settings_monet_color_title">Wallpaper Dynamic Color</string>
+    <string name="settings_monet_color_desc">Generate theme colors from your custom wallpaper; without one, follow system dynamic color. Off uses the built-in blue theme.</string>
 
     <string name="settings_achievement_title">Achievements</string>
     <string name="settings_achievement_desc">View MaaMeow milestones and hidden easter eggs</string>
@@ -1800,4 +1800,25 @@
     <string name="runlog_task_stopped">Tasks stopped, status: %1$s</string>
     <string name="runlog_service_terminated">MAA service terminated unexpectedly</string>
     <string name="runlog_game_process_gone">Game process not started or closed unexpectedly (%1$s)</string>
+    <string name="settings_wallpaper_title">Custom Wallpaper</string>
+    <string name="settings_wallpaper_desc">Choose an image as app background</string>
+    <string name="settings_wallpaper_set">Wallpaper set</string>
+    <string name="settings_wallpaper_clear">Clear Wallpaper</string>
+    <string name="settings_wallpaper_alpha">Opacity: %d%%</string>
+    <string name="settings_wallpaper_blur">Blur: %d%%</string>
+    <string name="settings_wallpaper_opacity_label">Opacity</string>
+    <string name="settings_wallpaper_blur_label">Blur</string>
+    <string name="settings_wallpaper_confirm">Confirm</string>
+    <string name="settings_wallpaper_change">Change Wallpaper</string>
+<string name="settings_wallpaper_text_contrast">Dynamic Text</string>
+    <string name="settings_wallpaper_frosted_glass">Frosted Glass</string>
+    <string name="settings_wallpaper_load_failed">Failed to load image. Try another one.</string>
+    <string name="settings_wallpaper_save_failed">Failed to save wallpaper</string>
+    <string name="settings_wallpaper_missing">Wallpaper file is missing. Please choose again.</string>
+    <string name="settings_wallpaper_edit_hint">Tap the preview to recrop</string>
+    <string name="settings_wallpaper_rotate">Rotate</string>
+    <string name="settings_wallpaper_reset_crop">Reset</string>
+    <string name="settings_wallpaper_saving">Saving…</string>
+    <string name="settings_wallpaper_loading">Loading…</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,8 +246,8 @@
     <string name="settings_startup_backend_title">启动模式</string>
     <string name="settings_startup_backend_desc">选择应用获取系统权限的方式</string>
     <!-- settings: monet theme color (system Material You toggle, Android 12+) -->
-    <string name="settings_monet_color_title">莫奈主题色</string>
-    <string name="settings_monet_color_desc">根据壁纸动态取色，关闭则使用内置蓝色主题</string>
+    <string name="settings_monet_color_title">壁纸动态取色</string>
+    <string name="settings_monet_color_desc">开启后根据自定义壁纸生成主题色；无自定义壁纸时跟随系统动态色，关闭则使用内置蓝色主题</string>
 
     <string name="settings_achievement_title">成就</string>
     <string name="settings_achievement_desc">查看 MaaMeow 使用记录与隐藏彩蛋</string>
@@ -1856,4 +1856,25 @@
     <string name="runlog_task_stopped">任务停止，状态: %1$s</string>
     <string name="runlog_service_terminated">MAA服务异常终止</string>
     <string name="runlog_game_process_gone">游戏进程未启动或被异常关闭(%1$s)</string>
+    <string name="settings_wallpaper_title">自定义壁纸</string>
+    <string name="settings_wallpaper_desc">选择一张图片作为应用背景</string>
+    <string name="settings_wallpaper_set">已设置壁纸</string>
+    <string name="settings_wallpaper_clear">清除壁纸</string>
+    <string name="settings_wallpaper_alpha">不透明度: %d%%</string>
+    <string name="settings_wallpaper_blur">模糊度: %d%%</string>
+    <string name="settings_wallpaper_opacity_label">不透明度</string>
+    <string name="settings_wallpaper_blur_label">模糊度</string>
+    <string name="settings_wallpaper_confirm">确认</string>
+    <string name="settings_wallpaper_change">更换壁纸</string>
+<string name="settings_wallpaper_text_contrast">动态色文字</string>
+    <string name="settings_wallpaper_frosted_glass">磨砂玻璃</string>
+    <string name="settings_wallpaper_load_failed">无法加载图片，请重试或换一张</string>
+    <string name="settings_wallpaper_save_failed">保存壁纸失败</string>
+    <string name="settings_wallpaper_missing">壁纸文件已丢失，请重新选择</string>
+    <string name="settings_wallpaper_edit_hint">点击预览可重新裁切</string>
+    <string name="settings_wallpaper_rotate">旋转</string>
+    <string name="settings_wallpaper_reset_crop">重置</string>
+    <string name="settings_wallpaper_saving">正在保存…</string>
+    <string name="settings_wallpaper_loading">正在加载…</string>
+
 </resources>

--- a/app/src/test/java/com/aliothmoon/maameow/data/preferences/WallpaperBackupPolicyTest.kt
+++ b/app/src/test/java/com/aliothmoon/maameow/data/preferences/WallpaperBackupPolicyTest.kt
@@ -1,0 +1,96 @@
+package com.aliothmoon.maameow.data.preferences
+
+import com.aliothmoon.maameow.domain.models.AppSettings
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Documents export/import wallpaper policy without spinning DataStore:
+ * export must strip device-local wallpaper fields; import must be able to
+ * re-apply local values over a sanitized payload.
+ *
+ * Keep this list in sync with ConfigBackupManager.AppSettings.sanitized() and
+ * AppSettingsManager.setSettingsPreservingWallpaper.
+ */
+class WallpaperBackupPolicyTest {
+
+    /** Full wallpaper-related field set that must never travel with backups. */
+    private val wallpaperFieldDefaults = mapOf(
+        "wallpaperUri" to "",
+        "wallpaperAlpha" to "100",
+        "wallpaperBlur" to "0",
+        "wallpaperTextContrast" to "false",
+        "wallpaperFrostedGlass" to "false",
+        "useWallpaperColor" to "false",
+    )
+
+    @Test
+    fun sanitizedExportShape_clearsAllWallpaperFieldsIncludingTextContrast() {
+        val local = AppSettings(
+            wallpaperUri = "file:///data/user/0/x/files/wallpaper/wallpaper.jpg",
+            wallpaperAlpha = "70",
+            wallpaperBlur = "40",
+            wallpaperTextContrast = "true",
+            wallpaperFrostedGlass = "true",
+            useWallpaperColor = "true",
+            mirrorChyanCdk = "secret",
+        )
+        // Mirrors ConfigBackupManager.AppSettings.sanitized()
+        val exported = local.copy(
+            mirrorChyanCdk = "",
+            wallpaperUri = wallpaperFieldDefaults.getValue("wallpaperUri"),
+            wallpaperAlpha = wallpaperFieldDefaults.getValue("wallpaperAlpha"),
+            wallpaperBlur = wallpaperFieldDefaults.getValue("wallpaperBlur"),
+            wallpaperTextContrast = wallpaperFieldDefaults.getValue("wallpaperTextContrast"),
+            wallpaperFrostedGlass = wallpaperFieldDefaults.getValue("wallpaperFrostedGlass"),
+            useWallpaperColor = wallpaperFieldDefaults.getValue("useWallpaperColor"),
+        )
+        assertEquals("", exported.wallpaperUri)
+        assertEquals("100", exported.wallpaperAlpha)
+        assertEquals("0", exported.wallpaperBlur)
+        assertEquals("false", exported.wallpaperTextContrast)
+        assertEquals("false", exported.wallpaperFrostedGlass)
+        assertEquals("false", exported.useWallpaperColor)
+        assertEquals("", exported.mirrorChyanCdk)
+    }
+
+    @Test
+    fun importPreservingWallpaper_keepsLocalOverBackupIncludingTextContrast() {
+        val local = AppSettings(
+            wallpaperUri = "file:///local/wallpaper.jpg",
+            wallpaperAlpha = "80",
+            wallpaperBlur = "25",
+            wallpaperTextContrast = "true",
+            wallpaperFrostedGlass = "true",
+            useWallpaperColor = "true",
+            fontSizeScale = "100",
+        )
+        val fromBackup = AppSettings(
+            wallpaperUri = "file:///other-device/wallpaper.jpg",
+            wallpaperAlpha = "10",
+            wallpaperBlur = "100",
+            wallpaperTextContrast = "false",
+            wallpaperFrostedGlass = "false",
+            useWallpaperColor = "false",
+            fontSizeScale = "90",
+        )
+        // Mirrors setSettingsPreservingWallpaper
+        val merged = fromBackup.copy(
+            wallpaperUri = local.wallpaperUri,
+            wallpaperAlpha = local.wallpaperAlpha,
+            wallpaperBlur = local.wallpaperBlur,
+            wallpaperTextContrast = local.wallpaperTextContrast,
+            wallpaperFrostedGlass = local.wallpaperFrostedGlass,
+            useWallpaperColor = local.useWallpaperColor,
+        )
+        assertEquals(local.wallpaperUri, merged.wallpaperUri)
+        assertEquals(local.wallpaperAlpha, merged.wallpaperAlpha)
+        assertEquals(local.wallpaperBlur, merged.wallpaperBlur)
+        assertEquals(local.wallpaperTextContrast, merged.wallpaperTextContrast)
+        assertEquals(local.wallpaperFrostedGlass, merged.wallpaperFrostedGlass)
+        assertEquals(local.useWallpaperColor, merged.useWallpaperColor)
+        assertEquals("90", merged.fontSizeScale)
+        assertFalse(merged.wallpaperUri.contains("other-device"))
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maameow/data/preferences/WallpaperBlurTest.kt
+++ b/app/src/test/java/com/aliothmoon/maameow/data/preferences/WallpaperBlurTest.kt
@@ -1,0 +1,30 @@
+package com.aliothmoon.maameow.data.preferences
+import org.junit.Assert.assertEquals
+import org.junit.Test
+class WallpaperBlurTest {
+    @Test
+    fun percentMapsLinearlyToRadiusDp() {
+        assertEquals(0f, WallpaperBlur.percentToRadiusDp(0), 0.001f)
+        assertEquals(6f, WallpaperBlur.percentToRadiusDp(50), 0.001f)
+        assertEquals(12f, WallpaperBlur.percentToRadiusDp(100), 0.001f)
+    }
+    @Test
+    fun legacyDpConvertsToPercent() {
+        assertEquals(0, WallpaperBlur.legacyDpToPercent(0))
+        assertEquals(50, WallpaperBlur.legacyDpToPercent(6))
+        assertEquals(100, WallpaperBlur.legacyDpToPercent(12))
+    }
+    @Test
+    fun parsePercentClamps() {
+        assertEquals(0, WallpaperBlur.parsePercent("-1"))
+        assertEquals(100, WallpaperBlur.parsePercent("200"))
+        assertEquals(33, WallpaperBlur.parsePercent("33"))
+    }
+
+    @Test
+    fun percentMapsToSoftwareRadiusPx() {
+        assertEquals(0, WallpaperBlur.percentToSoftwareRadiusPx(0))
+        assertEquals(WallpaperBlur.SOFTWARE_RADIUS_PX_MAX / 2, WallpaperBlur.percentToSoftwareRadiusPx(50))
+        assertEquals(WallpaperBlur.SOFTWARE_RADIUS_PX_MAX, WallpaperBlur.percentToSoftwareRadiusPx(100))
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperCropStateTest.kt
+++ b/app/src/test/java/com/aliothmoon/maameow/presentation/view/settings/WallpaperCropStateTest.kt
@@ -1,0 +1,102 @@
+package com.aliothmoon.maameow.presentation.view.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+class WallpaperCropStateTest {
+
+    private fun readyState(
+        screenW: Float = 1080f,
+        screenH: Float = 1920f,
+        cropW: Float = 756f,
+        cropH: Float = 1344f,
+        imageW: Float = 2000f,
+        imageH: Float = 1500f,
+    ): CropState = CropState().apply {
+        this.screenW = screenW
+        this.screenH = screenH
+        this.cropW = cropW
+        this.cropH = cropH
+        this.cropLeft = (screenW - cropW) / 2f
+        this.cropTop = (screenH - cropH) / 2f
+        this.imageW = imageW
+        this.imageH = imageH
+    }
+
+    @Test
+    fun ensureCoverScale_boostsScaleToCoverCropWindow() {
+        val s = readyState()
+        s.scale = 0.1f
+        s.ensureCoverScale()
+        assertTrue("scale should cover crop: ${s.scale}", s.scale >= 0.1f)
+        // After cover, pan must stay within bounds for the boosted scale.
+        val panX = s.panX
+        val panY = s.panY
+        s.clampPan()
+        assertEquals(panX, s.panX, 0.01f)
+        assertEquals(panY, s.panY, 0.01f)
+    }
+
+    @Test
+    fun clampPan_limitsOverPan() {
+        val s = readyState()
+        s.scale = 1f
+        s.ensureCoverScale()
+        s.panX = 99999f
+        s.panY = -99999f
+        s.clampPan()
+        assertTrue(abs(s.panX) < 99999f)
+        assertTrue(abs(s.panY) < 99999f)
+    }
+
+    @Test
+    fun rotateBy_snapsNinetyDegreeSteps() {
+        val s = readyState()
+        s.scale = 1f
+        s.ensureCoverScale()
+        s.rotateBy(90f)
+        assertEquals(90f, s.rotationDegrees, 0.01f)
+        s.rotateBy(90f)
+        assertEquals(180f, s.rotationDegrees, 0.01f)
+    }
+
+    @Test
+    fun applyTransform_oneToOneRotationAroundPivotDoesNotNaN() {
+        val s = readyState()
+        s.scale = 1.2f
+        s.ensureCoverScale()
+        s.applyTransform(
+            zoom = 1f,
+            panDeltaX = 0f,
+            panDeltaY = 0f,
+            rotationDegreesDelta = 15f,
+            pivotX = s.screenW / 2f,
+            pivotY = s.screenH / 2f,
+        )
+        assertTrue(s.scale.isFinite())
+        assertTrue(s.panX.isFinite())
+        assertTrue(s.panY.isFinite())
+        assertTrue(s.rotationDegrees.isFinite())
+        assertEquals(15f, s.rotationDegrees, 0.5f)
+    }
+
+    @Test
+    fun restore_rejectsNonFiniteAndCovers() {
+        val s = readyState()
+        s.restore(
+            restoredScale = Float.NaN,
+            restoredPanX = Float.POSITIVE_INFINITY,
+            restoredPanY = 3f,
+            restoredRotation = 45f,
+            fallbackScale = 1.5f,
+        )
+        // NaN scale falls back, then ensureCoverScale may boost further to cover.
+        assertTrue(s.scale >= 1.5f)
+        assertTrue(s.scale.isFinite())
+        assertEquals(0f, s.panX, 0.01f) // non-finite panX -> 0
+        assertTrue(s.panY.isFinite())
+        assertEquals(45f, s.rotationDegrees, 0.01f)
+    }
+}

--- a/app/src/test/java/com/aliothmoon/maameow/theme/WallpaperContentContrastTest.kt
+++ b/app/src/test/java/com/aliothmoon/maameow/theme/WallpaperContentContrastTest.kt
@@ -1,0 +1,73 @@
+package com.aliothmoon.maameow.theme
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WallpaperContentContrastTest {
+    private val colorfulSeed = 0xFF3D7CF0.toInt()
+
+    @Test
+    fun pureDarkForcesBlackSurfaces() {
+        val gray = darkColorScheme(
+            background = Color(0xFF121212),
+            surface = Color(0xFF1C1C1E),
+            surfaceContainer = Color(0xFF2C2C2E),
+            surfaceContainerHighest = Color(0xFF3A3A3C),
+        )
+        val pure = gray.withPureDarkSurfaces()
+        assertTrue(pure.background.luminance() < 0.01f)
+        assertTrue(pure.surface.luminance() < 0.01f)
+        assertTrue(pure.surfaceContainer.luminance() < 0.02f)
+        assertTrue(pure.surfaceContainerHighest.luminance() < 0.05f)
+    }
+
+    @Test
+    fun darkThemeUsesLightDynamicInk() {
+        val base = darkColorScheme()
+        val adapted = with(WallpaperColorScheme) {
+            base.adaptContentForWallpaper(colorfulSeed, isDark = true)
+        }
+        // tone ~90 → high luminance (readable on dark UI)
+        assertTrue(adapted.onSurface.luminance() > 0.50f)
+        assertTrue(adapted.onSurface.luminance() < 0.98f)
+        val spread = colorSpread(adapted.onSurface)
+        assertTrue(spread > 0.03f)
+        // hints stay system-owned
+        assertTrue(adapted.onSurfaceVariant == base.onSurfaceVariant)
+    }
+
+    @Test
+    fun lightThemeUsesDarkDynamicInk() {
+        val base = lightColorScheme()
+        val adapted = with(WallpaperColorScheme) {
+            base.adaptContentForWallpaper(colorfulSeed, isDark = false)
+        }
+        // tone ~18 → deep ink on light UI
+        assertTrue(adapted.onSurface.luminance() < 0.18f)
+        val spread = colorSpread(adapted.onSurface)
+        assertTrue(spread > 0.03f)
+        assertTrue(adapted.onSurfaceVariant == base.onSurfaceVariant)
+    }
+
+    @Test
+    fun lightAndDarkInkLuminanceDiffer() {
+        val seed = colorfulSeed
+        val darkInk = with(WallpaperColorScheme) {
+            darkColorScheme().adaptContentForWallpaper(seed, isDark = true).onSurface
+        }
+        val lightInk = with(WallpaperColorScheme) {
+            lightColorScheme().adaptContentForWallpaper(seed, isDark = false).onSurface
+        }
+        assertTrue(
+            "dark theme ink should be lighter than light theme ink",
+            darkInk.luminance() > lightInk.luminance() + 0.08f,
+        )
+    }
+
+    private fun colorSpread(c: Color): Float =
+        maxOf(c.red, c.green, c.blue) - minOf(c.red, c.green, c.blue)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ ksp = "2.3.9"
 # AndroidX Core
 coreKtx = "1.19.0"
 coreSplashscreen = "1.2.0"
+exifinterface = "1.4.1"
+materialColorUtilities = "4.1.1"
 activityCompose = "1.13.0"
 appcompat = "1.7.1"
 kotlinpoet = "2.3.0"
@@ -59,6 +61,8 @@ espressoCore = "3.7.0"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
+androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
+material-color-utilities = { group = "com.materialkolor", name = "material-color-utilities-jvm", version.ref = "materialColorUtilities" }
 bom = { module = "io.github.Rosemoe.sora-editor:bom", version.ref = "bom" }
 editor = { module = "io.github.Rosemoe.sora-editor:editor" }
 editor-language-textmate = { module = "io.github.Rosemoe.sora-editor:language-textmate" }


### PR DESCRIPTION
## Summary
Re-opens wallpaper work previously tracked in closed PR #172 (not merged), based on current `feat/wallpaper` tip.

Adds a dedicated wallpaper settings flow and runtime theming hooks:

- **Pick / crop / pan / rotate** with confirm vs cancel paths (confirm keeps new source; cancel restores backup)
- **Alpha + blur%** (0–100% → 0–12dp), frosted-glass surface option
- **Dynamic wallpaper color (MCU)** and independent **动态色文字 / Dynamic Text** (light ink ~30 / dark ~80; does not rewrite `onSurfaceVariant`)
- **PURE_DARK**: pure black surfaces, no wallpaper draw, no dynamic text
- **Backup policy**: export strips wallpaper preference group (incl. textContrast/frosted/useWallpaperColor); import preserves device-local fields; image files never enter backup
- **File hygiene**: orphan edit-backup reconcile after kill; clear deletes `*.backup`
- **Structure**: settings page split into session / crop editor / body / preview card

## Notes vs parallel work
- Upstream open **#174** (`WhiteMoon319:feat/wallpaper`) covers related wallpaper UI; this branch is a separate implementation with independent settings page, blur%, dynamic text toggle, and stricter backup stripping.
- Branch is based on earlier main; may need a rebase/merge with latest `main` during review (`behind` small).

## Test plan
- [x] CI Build Dev green on fork tip
- [x] Pick image → crop confirm → preview + re-open crop show **new** image
- [x] Pick image → cancel/back → preview + re-open crop show **old** image
- [x] Kill app mid-crop → reopen → preview/crop consistent (orphan backup)
- [x] Clear wallpaper → no leftover `.backup` under filesDir
- [x] Toggle only「动态色文字」→ seed loads; settings page + main text recolor
- [x] Light/dark themes: darker vs brighter dynamic ink; PURE_DARK: no wallpaper / no dynamic text
- [x] Export/import backup: wallpaper prefs stripped on export, preserved locally on import
- [x] α/blur sliders debounce + flush on leave

## Security
Please do not reuse any historical tokens from local tooling; rotate if exposed.
