### PR TITLE
i18n: EN IS6 DLC2 squad names

### DIFF
--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1150,9 +1150,9 @@
     <string name="panel_roguelike_squad_splendid_blossoms">Blooming Flowers Squad</string>
     <string name="panel_roguelike_squad_risky_gambit">Perilous Game Squad</string>
     <string name="panel_roguelike_squad_echo_of_ages">Sui\'s Shadow Squad</string>
-    <string name="panel_roguelike_squad_agent">Agent Squad (Not Supported)</string>
-    <string name="panel_roguelike_squad_scholarly">Knowledge Squad (知学分队)</string>
-    <string name="panel_roguelike_squad_merchant">Merchant Squad (商贾分队)</string>
+    <string name="panel_roguelike_squad_agent">Proxy Squad (Not Supported)</string>
+    <string name="panel_roguelike_squad_scholarly">Knowledge Squad</string>
+    <string name="panel_roguelike_squad_merchant">Merchant Squad</string>
     <!-- i18n: shared helpers -->
     <string name="common_enumeration_separator">, </string>
 


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)。

## 关联 Issue

<!-- Closes #123 / Fixes #123 / Related #123；没有 Issue 时请说明需求来源。 -->

## 变更摘要

<!-- 用 2～5 条 bullet 说明改了什么。 -->

## 验证

<!-- 请写清楚设备、系统版本、权限方案、执行命令或操作路径。不要只写“已测试”。 -->

## 截图 / 日志 / 说明

<!-- 涉及 UI、权限、后台服务、任务执行或 Bug 修复时，请提供截图、Logcat、Actions 链接或复现步骤。 -->

## Checklist

- [x] 我已阅读并遵守 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)

## Summary by Sourcery

更新 IS6 DLC2 中的英文类 Rogue 队伍名称，以反映最终确定的术语，并从标签中移除内嵌的中文提示。

改进内容：
- 将 Agent 队伍的英文名称调整为 `Proxy Squad`，同时标记为不受支持。
- 清理 Knowledge 和 Merchant 队伍标签，从英文字符串中移除嵌入的中文文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update English roguelike squad names for IS6 DLC2 to reflect finalized terminology and remove inline Chinese hints from labels.

Enhancements:
- Adjust English naming of the Agent squad to 'Proxy Squad' while marking it as unsupported.
- Clean up Knowledge and Merchant squad labels by dropping embedded Chinese text from the English strings.

</details>