### PR TITLE
Zz213119 patch 1

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -9,15 +9,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      maa_repo:
-        description: 'MAA Core GitHub repo (owner/repo)'
-        required: false
-        default: 'MaaAssistantArknights/MaaAssistantArknights'
-      maa_tag:
-        description: 'MAA Core release tag'
-        required: false
-        default: 'latest'
 
 jobs:
   build:
@@ -57,27 +48,14 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install OCR conversion deps
-        run: python -m pip install -r scripts/requirements.txt
-
-      - name: Download and deploy MAA Core
+      - name: Download and deploy Star Rail Core
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG_ARG=""
-          MAA_TAG="${{ github.event.inputs.maa_tag }}"
-          if [ -n "$MAA_TAG" ] && [ "$MAA_TAG" != "latest" ]; then
-            TAG_ARG="--tag $MAA_TAG"
-          fi
-          MAA_REPO="${{ github.event.inputs.maa_repo }}"
-          REPO_ARG=""
-          if [ -n "$MAA_REPO" ]; then
-            REPO_ARG="--repo $MAA_REPO"
-          fi
-          python scripts/setup_maa_core.py --clean $TAG_ARG $REPO_ARG
+          python scripts/setup_maa_core.py
 
-      - name: Print MAA Resource version
-        run: cat app/src/main/assets/MaaSync/MaaResource/version.json
+      - name: Print engine version
+        run: cat .starrailengineversion
 
       - name: Build Debug APK
         run: |

--- a/app/src/main/java/com/aliothmoon/maameow/maa/MaaFrameworkLibrary.java
+++ b/app/src/main/java/com/aliothmoon/maameow/maa/MaaFrameworkLibrary.java
@@ -1,0 +1,66 @@
+package com.aliothmoon.maameow.maa;
+
+import com.sun.jna.Library;
+import com.sun.jna.Pointer;
+import com.sun.jna.Callback;
+
+/**
+ * JNA 接口，对应 MaaFramework 的 C API（替代原 MaaCoreLibrary 里绑定的老 MAA AsstCaller 接口）。
+ * 加载的 native 库名应为 "MaaFramework"（对应 libMaaFramework.so），
+ * 需要额外把 MaaFramework Android release 里的其它依赖 .so（如 libMaaUtils.so 等，
+ * 具体以 release 包内实际文件为准）一并放进 jniLibs。
+ */
+public interface MaaFrameworkLibrary extends Library {
+
+    // ------------------- Resource -------------------
+    Pointer MaaResourceCreate();
+
+    void MaaResourceDestroy(Pointer res);
+
+    long MaaResourcePostBundle(Pointer res, String path);
+
+    int MaaResourceStatus(Pointer res, long resId);
+
+    int MaaResourceWait(Pointer res, long resId);
+
+    byte MaaResourceLoaded(Pointer res);
+
+    // ------------------- Controller -------------------
+    Pointer MaaAndroidNativeControllerCreate(String configJson);
+
+    void MaaControllerDestroy(Pointer ctrl);
+
+    long MaaControllerPostConnection(Pointer ctrl);
+
+    int MaaControllerStatus(Pointer ctrl, long ctrlId);
+
+    int MaaControllerWait(Pointer ctrl, long ctrlId);
+
+    byte MaaControllerConnected(Pointer ctrl);
+
+    // ------------------- Tasker -------------------
+    Pointer MaaTaskerCreate();
+
+    void MaaTaskerDestroy(Pointer tasker);
+
+    byte MaaTaskerBindResource(Pointer tasker, Pointer res);
+
+    byte MaaTaskerBindController(Pointer tasker, Pointer ctrl);
+
+    byte MaaTaskerInited(Pointer tasker);
+
+    long MaaTaskerPostTask(Pointer tasker, String entry, String pipelineOverride);
+
+    int MaaTaskerStatus(Pointer tasker, long taskId);
+
+    int MaaTaskerWait(Pointer tasker, long taskId);
+
+    byte MaaTaskerRunning(Pointer tasker);
+
+    long MaaTaskerPostStop(Pointer tasker);
+
+    byte MaaTaskerClearCache(Pointer tasker);
+
+    // ------------------- Version -------------------
+    String MaaVersion();
+}

--- a/app/src/main/java/com/aliothmoon/maameow/remote/MaaFrameworkServiceImpl.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/remote/MaaFrameworkServiceImpl.kt
@@ -1,0 +1,76 @@
+package com.aliothmoon.maameow.remote
+
+import com.aliothmoon.maameow.maa.MaaFrameworkLibrary
+import com.aliothmoon.maameow.third.Ln
+import com.sun.jna.Pointer
+import java.util.concurrent.atomic.AtomicReference
+
+class MaaFrameworkServiceImpl(private val lib: MaaFrameworkLibrary?) {
+
+    companion object {
+        private const val TAG = "MaaFrameworkService"
+        private const val STATUS_SUCCEEDED = 3000
+    }
+
+    private val resourceHandle = AtomicReference<Pointer>()
+    private val controllerHandle = AtomicReference<Pointer>()
+    private val taskerHandle = AtomicReference<Pointer>()
+
+    private fun requireLib(): MaaFrameworkLibrary? {
+        if (lib == null) Ln.e("$TAG: MaaFrameworkLibrary not loaded")
+        return lib
+    }
+
+    fun loadResource(resourcePath: String): Boolean {
+        val core = requireLib() ?: return false
+        val res = core.MaaResourceCreate() ?: return false
+        resourceHandle.set(res)
+        val resId = core.MaaResourcePostBundle(res, resourcePath)
+        if (resId <= 0) return false
+        val status = core.MaaResourceWait(res, resId)
+        return status == STATUS_SUCCEEDED
+    }
+
+    fun createController(configJson: String = "{}"): Boolean {
+        val core = requireLib() ?: return false
+        val ctrl = core.MaaAndroidNativeControllerCreate(configJson) ?: return false
+        controllerHandle.set(ctrl)
+        val connId = core.MaaControllerPostConnection(ctrl)
+        val status = core.MaaControllerWait(ctrl, connId)
+        return status == STATUS_SUCCEEDED
+    }
+
+    fun createTasker(): Boolean {
+        val core = requireLib() ?: return false
+        val res = resourceHandle.get() ?: return false
+        val ctrl = controllerHandle.get() ?: return false
+        val tasker = core.MaaTaskerCreate() ?: return false
+        val boundRes = core.MaaTaskerBindResource(tasker, res)
+        val boundCtrl = core.MaaTaskerBindController(tasker, ctrl)
+        if (boundRes.toInt() == 0 || boundCtrl.toInt() == 0) return false
+        taskerHandle.set(tasker)
+        return core.MaaTaskerInited(tasker).toInt() != 0
+    }
+
+    fun runTask(entry: String): Boolean {
+        val core = requireLib() ?: return false
+        val tasker = taskerHandle.get() ?: return false
+        val taskId = core.MaaTaskerPostTask(tasker, entry, null)
+        if (taskId <= 0) return false
+        val status = core.MaaTaskerWait(tasker, taskId)
+        return status == STATUS_SUCCEEDED
+    }
+
+    fun stopAll() {
+        val core = requireLib() ?: return
+        val tasker = taskerHandle.get() ?: return
+        core.MaaTaskerPostStop(tasker)
+    }
+
+    fun destroy() {
+        val core = requireLib()
+        taskerHandle.getAndSet(null)?.let { core?.MaaTaskerDestroy(it) }
+        controllerHandle.getAndSet(null)?.let { core?.MaaControllerDestroy(it) }
+        resourceHandle.getAndSet(null)?.let { core?.MaaResourceDestroy(it) }
+    }
+}

--- a/scripts/setup_maa_core.py
+++ b/scripts/setup_maa_core.py
@@ -1,66 +1,39 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-MAA Core Download & Deploy Script
-Download prebuilt MAA Core artifacts from GitHub Release,
-deploy resources to assets and shared libraries to jniLibs.
-
-usage:
-    python scripts/setup_maa_core.py                    # download latest release and deploy
-    python scripts/setup_maa_core.py --tag v6.3.0       # download specific tag
-    python scripts/setup_maa_core.py --skip-download     # deploy from cache only
-
-Note: target directories (assets/MaaSync/MaaResource and jniLibs/<abi>/<MAA *.so>)
-are always cleaned before deploy to avoid stale files from previous versions.
+Star Rail Core Download & Deploy Script
+从 MaaXYZ/MaaFramework 下载安卓引擎 .so，从 VincenttHo/MaaStarRail 拉取星铁资源包。
 """
 
 import argparse
-import io
 import json
 import os
-import re
 import shutil
+import subprocess
 import sys
-import tarfile
 import urllib.request
 import urllib.error
+import zipfile
 from pathlib import Path
 
-import convert_ocr_ncnn
+ENGINE_REPO = "MaaXYZ/MaaFramework"
+ENGINE_API_BASE = f"https://api.github.com/repos/{ENGINE_REPO}"
 
-# Fix Windows console encoding
-if sys.platform == "win32":
-    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
-    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+RESOURCE_REPO_URL = "https://github.com/VincenttHo/MaaStarRail.git"
+RESOURCE_SUBDIR = "assets/resource/base"
+INTERFACE_JSON_PATH = "assets/interface.json"
 
-# ── Config ──────────────────────────────────────────────
-DEFAULT_GITHUB_REPO = "MaaAssistantArknights/MaaAssistantArknights"
-API_BASE = f"https://api.github.com/repos/{DEFAULT_GITHUB_REPO}"
-
-# ABI mapping: release asset keyword -> jniLibs subdirectory
 ABI_MAP = {
-    "android-arm64": "arm64-v8a",
-    "android-x64": "x86_64",
+    "android-aarch64": "arm64-v8a",
+    "android-x86_64": "x86_64",
 }
 
-# Excluded from jniLibs copy.
-# - libc++_shared.so: provided by the NDK toolchain, never ship MAA's copy.
-# - libfastdeploy_ppocr.so: desktop OCR backend; Android uses OcrPackNcnn driven
-#   by the ncnn weights generated in convert_ocr_ncnn.py, so this ~tens-of-MB
-#   so is dead weight in the APK.
-EXCLUDE_SO = {"libc++_shared.so", "libfastdeploy_ppocr.so"}
+EXCLUDE_SO = {"libc++_shared.so"}
 
-# Ignored file extensions
-IGNORE_EXTENSIONS = {".h"}
-
-# Target paths (relative to project root)
-ASSETS_RESOURCE_DIR = "app/src/main/assets/MaaSync/MaaResource"
+ASSETS_RESOURCE_DIR = "app/src/main/assets/StarRailResource"
 JNILIBS_DIR = "app/src/main/jniLibs"
-CACHE_DIR = ".maa-cache"
-VERSION_FILE = ".maaversion"
-
-# Extract version from tarball name, e.g. MAAComponent-v6.12.0-beta.2-android-arm64.tar.gz
-TARBALL_VERSION_RE = re.compile(r"-(v\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?)-android-")
+CACHE_DIR = ".starrail-cache"
+VERSION_FILE = ".starrailengineversion"
 
 
 def get_project_root() -> Path:
@@ -68,284 +41,158 @@ def get_project_root() -> Path:
 
 
 def fetch_json(url: str) -> dict:
-    def _do_request(with_auth: bool) -> dict:
-        req = urllib.request.Request(url)
-        req.add_header("Accept", "application/vnd.github.v3+json")
-        req.add_header("User-Agent", "MaaMeow-Setup")
-        if with_auth:
-            req.add_header("Authorization", f"token {token}")
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return json.loads(resp.read().decode("utf-8"))
-
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/vnd.github.v3+json")
+    req.add_header("User-Agent", "StarRailMeow-Setup")
     token = os.environ.get("GITHUB_TOKEN")
-    if not token:
-        return _do_request(with_auth=False)
-    try:
-        return _do_request(with_auth=True)
-    except urllib.error.HTTPError as e:
-        # GITHUB_TOKEN is scoped to the current repo and may be rejected (401)
-        # when accessing a different public repository. Retry without auth.
-        if e.code == 401:
-            print(f"[WARN] Auth failed ({e.code}), retrying without token...")
-            return _do_request(with_auth=False)
-        raise
+    if token:
+        req.add_header("Authorization", f"token {token}")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
 
 
 def download_file(url: str, dest: Path):
     print(f"  [DOWNLOAD] {dest.name}")
-    token = os.environ.get("GITHUB_TOKEN")
-
-    def _make_req(with_auth: bool):
-        r = urllib.request.Request(url)
-        r.add_header("Accept", "application/octet-stream")
-        r.add_header("User-Agent", "MaaMeow-Setup")
-        if with_auth and token:
-            r.add_header("Authorization", f"token {token}")
-        return r
-
     dest.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        req = _make_req(with_auth=bool(token))
-        resp_ctx = urllib.request.urlopen(req, timeout=600)
-    except urllib.error.HTTPError as e:
-        if e.code == 401 and token:
-            print(f"[WARN] Auth failed ({e.code}), retrying without token...")
-            req = _make_req(with_auth=False)
-            resp_ctx = urllib.request.urlopen(req, timeout=600)
-        else:
-            raise
-    with resp_ctx as resp:
-        total = int(resp.headers.get("Content-Length", 0))
-        downloaded = 0
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/octet-stream")
+    req.add_header("User-Agent", "StarRailMeow-Setup")
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        req.add_header("Authorization", f"token {token}")
+    with urllib.request.urlopen(req, timeout=600) as resp:
         with open(dest, "wb") as f:
-            while True:
-                chunk = resp.read(1024 * 1024)  # 1MB chunks
-                if not chunk:
-                    break
-                f.write(chunk)
-                downloaded += len(chunk)
-                if total > 0:
-                    pct = downloaded * 100 // total
-                    mb = downloaded / (1024 * 1024)
-                    total_mb = total / (1024 * 1024)
-                    print(f"\r    {mb:.1f}/{total_mb:.1f} MB ({pct}%)", end="", flush=True)
-        print()
+            shutil.copyfileobj(resp, f)
 
 
-def get_release_assets(tag: str = None) -> list:
-    if tag:
-        url = f"{API_BASE}/releases/tags/{tag}"
-    else:
-        url = f"{API_BASE}/releases/latest"
-    print(f"[FETCH] Fetching release info: {url}")
+def get_release_assets(tag: str = None):
+    url = f"{ENGINE_API_BASE}/releases/tags/{tag}" if tag else f"{ENGINE_API_BASE}/releases/latest"
+    print(f"[FETCH] {url}")
     try:
         data = fetch_json(url)
     except urllib.error.HTTPError as e:
-        print(f"[ERROR] Request failed: {e.code} {e.reason}")
+        print(f"[ERROR] {e.code} {e.reason}")
         sys.exit(1)
-    tag_name = data.get("tag_name", "unknown")
-    print(f"  Tag: {tag_name}")
-    return tag_name, data.get("assets", [])
+    return data.get("tag_name", "unknown"), data.get("assets", [])
 
 
 def find_android_assets(assets: list) -> dict:
-    """Find android-arm64 and android-x64 tar.gz assets."""
     result = {}
     for asset in assets:
         name = asset["name"]
-        if not name.endswith(".tar.gz"):
+        if not name.endswith(".zip"):
             continue
         for keyword, abi in ABI_MAP.items():
             if keyword in name:
-                result[abi] = {
-                    "name": name,
-                    "url": asset["browser_download_url"],
-                    "size": asset["size"],
-                }
+                result[abi] = {"name": name, "url": asset["browser_download_url"], "size": asset["size"]}
     return result
 
 
-def extract_and_deploy(tarball: Path, abi: str, project_root: Path):
-    assets_dir = project_root / ASSETS_RESOURCE_DIR
+def deploy_engine(zip_path: Path, abi: str, project_root: Path):
     jnilib_dir = project_root / JNILIBS_DIR / abi
-
     if jnilib_dir.exists():
-        # Only delete MAA-related .so files, keep libjnidispatch.so etc.
         for f in jnilib_dir.iterdir():
             if f.suffix == ".so" and f.name != "libjnidispatch.so":
                 f.unlink()
-                print(f"    [DELETE] {abi}/{f.name}")
-
     jnilib_dir.mkdir(parents=True, exist_ok=True)
 
-    stats = {"resource": 0, "so": 0, "skipped": 0}
-
-    print(f"  [EXTRACT] {tarball.name} -> {abi}")
-    with tarfile.open(tarball, "r:gz") as tar:
-        for member in tar.getmembers():
-            if not member.isfile():
+    count = 0
+    with zipfile.ZipFile(zip_path) as z:
+        for info in z.infolist():
+            name = Path(info.filename).name
+            if not name.endswith(".so") or name in EXCLUDE_SO:
                 continue
+            with z.open(info) as src, open(jnilib_dir / name, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            count += 1
+    print(f"    [{abi}] 部署 {count} 个 .so 文件")
+    return count
 
-            name = Path(member.name).name
-            parts = Path(member.name).parts
 
-            # Skip header files
-            if Path(name).suffix in IGNORE_EXTENSIONS:
-                stats["skipped"] += 1
-                continue
+def deploy_resource(project_root: Path, ref: str = None):
+    assets_dir = project_root / ASSETS_RESOURCE_DIR
+    if assets_dir.exists():
+        shutil.rmtree(assets_dir)
+    assets_dir.parent.mkdir(parents=True, exist_ok=True)
 
-            # resource dir -> assets
-            if "resource" in parts:
-                res_idx = list(parts).index("resource")
-                rel_parts = parts[res_idx + 1:]
-                if not rel_parts:
-                    continue
-                dest = assets_dir / Path(*rel_parts)
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                with tar.extractfile(member) as src:
-                    dest.write_bytes(src.read())
-                stats["resource"] += 1
-                continue
+    tmp_clone = project_root / CACHE_DIR / "MaaStarRail_src"
+    if tmp_clone.exists():
+        shutil.rmtree(tmp_clone)
+    tmp_clone.parent.mkdir(parents=True, exist_ok=True)
 
-            # .so files -> jniLibs
-            if name.endswith(".so"):
-                if name in EXCLUDE_SO:
-                    stats["skipped"] += 1
-                    continue
-                dest = jnilib_dir / name
-                with tar.extractfile(member) as src:
-                    dest.write_bytes(src.read())
-                stats["so"] += 1
-                continue
+    print(f"[CLONE] {RESOURCE_REPO_URL}")
+    cmd = ["git", "clone", "--depth", "1", "--recursive"]
+    if ref:
+        cmd += ["--branch", ref]
+    cmd += [RESOURCE_REPO_URL, str(tmp_clone)]
+    subprocess.run(cmd, check=True)
 
-            stats["skipped"] += 1
+    configure_script = tmp_clone / "configure.py"
+    if configure_script.exists():
+        print("[CONFIGURE] 运行 configure.py 填充 OCR 模型...")
+        subprocess.run([sys.executable, str(configure_script)], cwd=tmp_clone, check=True)
 
-    print(f"    resource: {stats['resource']} files, so: {stats['so']} files, skipped: {stats['skipped']}")
-    return stats
+    src_resource = tmp_clone / RESOURCE_SUBDIR
+    if not src_resource.exists():
+        print(f"[ERROR] 没找到 {RESOURCE_SUBDIR}/")
+        sys.exit(1)
+
+    shutil.copytree(src_resource, assets_dir)
+    file_count = sum(1 for _ in assets_dir.rglob("*") if _.is_file())
+    print(f"    资源文件: {file_count} 个")
+
+    iface = tmp_clone / INTERFACE_JSON_PATH
+    if iface.exists():
+        shutil.copy(iface, assets_dir.parent / "interface.json")
 
 
 def write_version_file(version: str, project_root: Path):
-    version_file = project_root / VERSION_FILE
-    version_file.write_text(version + "\n", encoding="utf-8")
-    print(f"  [VERSION] {VERSION_FILE}: {version}")
+    (project_root / VERSION_FILE).write_text(version + "\n", encoding="utf-8")
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Download and deploy prebuilt MAA Core artifacts")
-    parser.add_argument("--repo", "-r", default=DEFAULT_GITHUB_REPO,
-                        help=f"GitHub repository (owner/repo, default: {DEFAULT_GITHUB_REPO})")
-    parser.add_argument("--tag", "-t", help="Specify release tag (default: latest)")
-    parser.add_argument("--clean", "-c", action="store_true",
-                        help="Deprecated: target dirs are always cleaned before deploy (kept for compatibility)")
-    parser.add_argument("--skip-download", "-s", action="store_true", help="Skip download, use cache")
-    parser.add_argument("--abi", choices=["arm64-v8a", "x86_64", "all"], default="all",
-                        help="Process only specified ABI (default: all)")
-    parser.add_argument("--skip-ncnn", action="store_true",
-                        help="Skip OCR onnx->ncnn conversion (Android OCR needs ncnn; debug only)")
-    parser.add_argument("--keep-onnx", action="store_true",
-                        help="Keep OCR inference.onnx after conversion (default: delete, ~72MB unused on Android)")
-    parser.add_argument("--rec-fp16", action="store_true",
-                        help="Store rec ncnn weights as fp16 (smaller APK; det always stays fp32)")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", "-t")
+    parser.add_argument("--resource-ref")
+    parser.add_argument("--skip-engine", action="store_true")
+    parser.add_argument("--skip-resource", action="store_true")
+    parser.add_argument("--abi", choices=["arm64-v8a", "x86_64", "all"], default="all")
     args = parser.parse_args()
-
-    global API_BASE
-    API_BASE = f"https://api.github.com/repos/{args.repo}"
 
     project_root = get_project_root()
     cache_dir = project_root / CACHE_DIR
-
-    print("=" * 55)
-    print("==> MAA Core Download & Deploy")
-    print("=" * 55)
-
-    # Always clean assets resource dir to avoid stale files from previous versions
-    assets_dir = project_root / ASSETS_RESOURCE_DIR
-    if assets_dir.exists():
-        print(f"[DELETE] Cleaning resource dir: {assets_dir}")
-        shutil.rmtree(assets_dir)
-
     target_abis = list(ABI_MAP.values()) if args.abi == "all" else [args.abi]
 
-    if not args.skip_download:
-        tag_name, assets = get_release_assets(args.tag)
-        android_assets = find_android_assets(assets)
+    print("=" * 55)
+    print("==> Star Rail Engine + Resource Setup")
+    print("=" * 55)
 
+    if not args.skip_engine:
+        tag_name, assets = get_release_assets(args.tag)
+        print(f"  引擎版本: {tag_name}")
+        android_assets = find_android_assets(assets)
         if not android_assets:
-            print("[ERROR] No Android artifacts found. Check if the release contains android-arm64/android-x64 tar.gz files.")
+            print("[ERROR] release 里没找到 android zip")
             sys.exit(1)
 
-        print(f"\n[INFO] Found {len(android_assets)} Android artifact(s):")
-        for abi, info in android_assets.items():
-            size_mb = info["size"] / (1024 * 1024)
-            print(f"  {abi}: {info['name']} ({size_mb:.1f} MB)")
-
-        # Download
-        print(f"\n[DOWNLOAD] Downloading to cache: {cache_dir}")
         for abi, info in android_assets.items():
             if abi not in target_abis:
                 continue
             dest = cache_dir / info["name"]
-            if dest.exists() and dest.stat().st_size == info["size"]:
-                print(f"  [CACHE] {info['name']} already exists, skipping download")
-            else:
+            if not (dest.exists() and dest.stat().st_size == info["size"]):
                 download_file(info["url"], dest)
+            deploy_engine(dest, abi, project_root)
+
+        write_version_file(tag_name, project_root)
     else:
-        print("[SKIP] Skipping download, using cache")
+        print("[SKIP] 跳过引擎下载")
 
-    # Deploy
-    print(f"\n[DEPLOY] Deploying artifacts...")
-    resource_deployed = False
-    deployed_version = None
-    for tarball in sorted(cache_dir.glob("*.tar.gz")):
-        for keyword, abi in ABI_MAP.items():
-            if keyword in tarball.name and abi in target_abis:
-                extract_and_deploy(tarball, abi, project_root)
-                resource_deployed = True
-                m = TARBALL_VERSION_RE.search(tarball.name)
-                if m:
-                    deployed_version = m.group(1)
-
-    if not resource_deployed:
-        print("[ERROR] No tar.gz files found in cache. Run without --skip-download first.")
-        sys.exit(1)
-
-    # Record deployed MAA Core version for the Gradle build (BuildConfig.MAA_CORE_VERSION)
-    if deployed_version:
-        write_version_file(deployed_version, project_root)
+    if not args.skip_resource:
+        deploy_resource(project_root, args.resource_ref)
     else:
-        print(f"[WARN] Could not parse version from tarball name, {VERSION_FILE} not updated")
+        print("[SKIP] 跳过资源下载")
 
-    # Convert OCR onnx -> ncnn in place. Android (OcrPackNcnn) needs ncnn; doing it here,
-    # from the just-deployed onnx, keeps ncnn always in lockstep with the onnx/keys it
-    # ships with, so the Android-only ncnn never has to live in MAA's shared resource.
-    if not args.skip_ncnn:
-        print("\n[NCNN] Converting OCR onnx -> ncnn (Android-only)...")
-        ncnn_cache = cache_dir / "ncnn"
-        stats = convert_ocr_ncnn.convert_tree(
-            resource_dir=assets_dir,
-            cache_dir=ncnn_cache,
-            keep_onnx=args.keep_onnx,
-            rec_fp16=args.rec_fp16,
-        )
-        print(f"[NCNN] converted={stats['converted']} cached={stats['cached']} "
-              f"onnx_removed={stats['onnx_removed']} skipped={stats['skipped']}")
-    else:
-        print("\n[SKIP] Skipping OCR ncnn conversion (--skip-ncnn)")
-
-    # Summary
-    print("\n" + "=" * 55)
-    print("[DONE] Deploy complete!")
-    print("=" * 55)
-    for abi in target_abis:
-        jnilib_dir = project_root / JNILIBS_DIR / abi
-        if jnilib_dir.exists():
-            so_files = [f.name for f in jnilib_dir.iterdir() if f.suffix == ".so"]
-            print(f"  {abi}/: {', '.join(sorted(so_files))}")
-    assets_dir = project_root / ASSETS_RESOURCE_DIR
-    if assets_dir.exists():
-        file_count = sum(1 for f in assets_dir.rglob("*") if f.is_file())
-        total_size = sum(f.stat().st_size for f in assets_dir.rglob("*") if f.is_file())
-        print(f"  resource: {file_count} files, {total_size / (1024 * 1024):.1f} MB")
+    print("[DONE] 完成")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)。

## 关联 Issue

<!-- Closes #123 / Fixes #123 / Related #123；没有 Issue 时请说明需求来源。 -->

## 变更摘要

<!-- 用 2～5 条 bullet 说明改了什么。 -->

## 验证

<!-- 请写清楚设备、系统版本、权限方案、执行命令或操作路径。不要只写“已测试”。 -->

## 截图 / 日志 / 说明

<!-- 涉及 UI、权限、后台服务、任务执行或 Bug 修复时，请提供截图、Logcat、Actions 链接或复现步骤。 -->

## Checklist

- [x] 我已阅读并遵守 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)

## Summary by Sourcery

将 Android 构建和设置脚本从旧版 MAA Core 切换到基于 MaaFramework 的崩坏：星穹铁道（Star Rail）引擎和资源。

新增功能：
- 引入基于 JNA 的 `MaaFrameworkLibrary` 绑定，用于连接 MaaFramework C API，支持资源、控制器、任务器以及版本相关操作。
- 添加 `MaaFrameworkServiceImpl`，用于管理资源加载、连接 Android 控制器、创建任务器、运行任务以及生命周期清理。

改进内容：
- 将原有的 MAA Core 设置脚本替换为 Star Rail 引擎/资源设置脚本，用于下载 MaaFramework Android 制品和 Star Rail 资源包，并记录已部署的引擎版本。
- 简化 GitHub Actions 的开发构建工作流，使其使用新的 Star Rail 设置脚本，不再需要可配置的 MAA 仓库/标签参数，并改为输出 Star Rail 引擎版本文件，而不是旧的 MAA 资源版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch Android build and setup scripts from the legacy MAA Core to the new MaaFramework-based Star Rail engine and resources.

New Features:
- Introduce a JNA-based MaaFrameworkLibrary binding to the MaaFramework C API for resource, controller, tasker, and version operations.
- Add MaaFrameworkServiceImpl to manage loading resources, connecting the Android controller, creating taskers, running tasks, and lifecycle cleanup.

Enhancements:
- Replace the MAA Core setup script with a Star Rail engine/resource setup script that downloads MaaFramework Android artifacts and Star Rail resource bundles, and records the deployed engine version.
- Simplify GitHub Actions dev build workflow to use the new Star Rail setup script without configurable MAA repo/tag inputs, and print the Star Rail engine version file instead of the old MAA resource version.

</details>