### PR TITLE
feat: 库存保持新增预设

### DIFF
--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/depot/DepotMaintainConfigPanel.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/depot/DepotMaintainConfigPanel.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -18,12 +19,15 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.UnfoldLess
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -33,7 +37,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -89,6 +95,7 @@ fun DepotMaintainConfigPanel(
 
     // 展开态是纯 UI 局部状态，不持久化；删除时重映射下标，避免落到相邻计划。
     val expandedIndices = remember { mutableStateListOf<Int>() }
+    var presetMenuExpanded by remember { mutableStateOf(false) }
 
     val notSelectedLabel = stringResource(R.string.panel_depot_not_selected)
 
@@ -190,6 +197,40 @@ fun DepotMaintainConfigPanel(
                 )
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(stringResource(R.string.panel_depot_collapse_all))
+            }
+        }
+
+        Box(modifier = Modifier.fillMaxWidth()) {
+            OutlinedButton(
+                onClick = { presetMenuExpanded = true },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(8.dp),
+            ) {
+                Text(stringResource(R.string.panel_depot_preset))
+                Spacer(modifier = Modifier.width(6.dp))
+                Icon(
+                    Icons.Default.ArrowDropDown,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+            DropdownMenu(
+                expanded = presetMenuExpanded,
+                onDismissRequest = { presetMenuExpanded = false },
+            ) {
+                DepotMaintainPreset.entries.forEach { preset ->
+                    DropdownMenuItem(
+                        text = { Text(stringResource(preset.labelRes)) },
+                        onClick = {
+                            presetMenuExpanded = false
+                            onConfigChange(
+                                config.copy(
+                                    plans = appendDepotMaintainPreset(config.plans, preset),
+                                )
+                            )
+                        },
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/depot/DepotMaintainPresets.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/presentation/view/panel/depot/DepotMaintainPresets.kt
@@ -1,0 +1,75 @@
+package com.aliothmoon.maameow.presentation.view.panel.depot
+
+import androidx.annotation.StringRes
+import com.aliothmoon.maameow.R
+import com.aliothmoon.maameow.data.model.DepotMaintainPlan
+
+/**
+ * 库存保持的 UI 内置预设。
+ *
+ * 数据与 MAA WPF DepotMaintainTaskUserControlModel.PresetData 保持一致。
+ */
+internal enum class DepotMaintainPreset(
+    @get:StringRes val labelRes: Int,
+    val plans: List<DepotMaintainPlan>,
+) {
+    CHIP_1(
+        labelRes = R.string.panel_depot_preset_chip_1,
+        plans = buildPresetPlans(
+            defaultCount = 20,
+            "PR-A-1" to listOf("3261", "3231"),
+            "PR-B-1" to listOf("3251", "3241"),
+            "PR-C-1" to listOf("3211", "3271"),
+            "PR-D-1" to listOf("3221", "3281"),
+        ),
+    ),
+    CHIP_2(
+        labelRes = R.string.panel_depot_preset_chip_2,
+        plans = buildPresetPlans(
+            defaultCount = 20,
+            "PR-A-2" to listOf("3262", "3232"),
+            "PR-B-2" to listOf("3252", "3242"),
+            "PR-C-2" to listOf("3212", "3272"),
+            "PR-D-2" to listOf("3222", "3282"),
+        ),
+    ),
+    LMD(
+        labelRes = R.string.panel_depot_preset_lmd,
+        plans = buildPresetPlans(
+            defaultCount = 2_000_000,
+            "CE-6" to listOf("4001"),
+        ),
+    ),
+    PURCHASE_CERTIFICATE(
+        labelRes = R.string.panel_depot_preset_certificate,
+        plans = buildPresetPlans(
+            defaultCount = 5_000,
+            "AP-5" to listOf("4006"),
+        ),
+    ),
+    SKILL_SUMMARY_3(
+        labelRes = R.string.panel_depot_preset_skill_summary,
+        plans = buildPresetPlans(
+            defaultCount = 200,
+            "CA-5" to listOf("3303"),
+        ),
+    ),
+}
+
+internal fun appendDepotMaintainPreset(
+    existingPlans: List<DepotMaintainPlan>,
+    preset: DepotMaintainPreset,
+): List<DepotMaintainPlan> = existingPlans + preset.plans
+
+private fun buildPresetPlans(
+    defaultCount: Int,
+    vararg stages: Pair<String, List<String>>,
+): List<DepotMaintainPlan> = stages.flatMap { (stage, dropIds) ->
+    dropIds.map { dropId ->
+        DepotMaintainPlan(
+            stage = stage,
+            dropId = dropId,
+            dropCount = defaultCount,
+        )
+    }
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1049,6 +1049,12 @@
     <string name="panel_depot_skip_during_resource">Skip while the resource collection event is active</string>
     <string name="panel_depot_add_plan">Add</string>
     <string name="panel_depot_collapse_all">Collapse</string>
+    <string name="panel_depot_preset">Preset</string>
+    <string name="panel_depot_preset_chip_1">Chips (All Classes)</string>
+    <string name="panel_depot_preset_chip_2">Chip Packs (All Classes)</string>
+    <string name="panel_depot_preset_lmd">LMD</string>
+    <string name="panel_depot_preset_certificate">Purchase Certificates</string>
+    <string name="panel_depot_preset_skill_summary">Skill Summary - III</string>
     <string name="panel_depot_target_inventory">Target inventory</string>
     <string name="panel_depot_stone_count">Use up to N Originite Prime</string>
     <string name="panel_depot_not_selected">Not selected</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1104,6 +1104,12 @@
     <string name="panel_depot_skip_during_resource">资源收集限时全天开放期间跳过</string>
     <string name="panel_depot_add_plan">添加</string>
     <string name="panel_depot_collapse_all">折叠</string>
+    <string name="panel_depot_preset">预设</string>
+    <string name="panel_depot_preset_chip_1">低级芯片（全职业）</string>
+    <string name="panel_depot_preset_chip_2">高级芯片组（全职业）</string>
+    <string name="panel_depot_preset_lmd">龙门币</string>
+    <string name="panel_depot_preset_certificate">采购凭证（红票）</string>
+    <string name="panel_depot_preset_skill_summary">技巧概要·卷3</string>
     <string name="panel_depot_target_inventory">目标库存</string>
     <string name="panel_depot_stone_count">最多使用 N 个源石</string>
     <string name="panel_depot_not_selected">未选择</string>

--- a/app/src/test/java/com/aliothmoon/maameow/presentation/view/panel/depot/DepotMaintainPresetsTest.kt
+++ b/app/src/test/java/com/aliothmoon/maameow/presentation/view/panel/depot/DepotMaintainPresetsTest.kt
@@ -1,0 +1,99 @@
+package com.aliothmoon.maameow.presentation.view.panel.depot
+
+import com.aliothmoon.maameow.data.model.DepotMaintainPlan
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+
+class DepotMaintainPresetsTest {
+
+    @Test
+    fun chip1_matchesUpstreamOrderAndTargets() {
+        assertPreset(
+            preset = DepotMaintainPreset.CHIP_1,
+            expected = listOf(
+                Triple("PR-A-1", "3261", 20),
+                Triple("PR-A-1", "3231", 20),
+                Triple("PR-B-1", "3251", 20),
+                Triple("PR-B-1", "3241", 20),
+                Triple("PR-C-1", "3211", 20),
+                Triple("PR-C-1", "3271", 20),
+                Triple("PR-D-1", "3221", 20),
+                Triple("PR-D-1", "3281", 20),
+            ),
+        )
+    }
+
+    @Test
+    fun chip2_matchesUpstreamOrderAndTargets() {
+        assertPreset(
+            preset = DepotMaintainPreset.CHIP_2,
+            expected = listOf(
+                Triple("PR-A-2", "3262", 20),
+                Triple("PR-A-2", "3232", 20),
+                Triple("PR-B-2", "3252", 20),
+                Triple("PR-B-2", "3242", 20),
+                Triple("PR-C-2", "3212", 20),
+                Triple("PR-C-2", "3272", 20),
+                Triple("PR-D-2", "3222", 20),
+                Triple("PR-D-2", "3282", 20),
+            ),
+        )
+    }
+
+    @Test
+    fun resourcePresets_matchUpstreamTargets() {
+        assertPreset(
+            DepotMaintainPreset.LMD,
+            listOf(Triple("CE-6", "4001", 2_000_000)),
+        )
+        assertPreset(
+            DepotMaintainPreset.PURCHASE_CERTIFICATE,
+            listOf(Triple("AP-5", "4006", 5_000)),
+        )
+        assertPreset(
+            DepotMaintainPreset.SKILL_SUMMARY_3,
+            listOf(Triple("CA-5", "3303", 200)),
+        )
+    }
+
+    @Test
+    fun presetPlans_leaveConsumablesDisabled() {
+        DepotMaintainPreset.entries.flatMap { it.plans }.forEach { plan ->
+            assertFalse(plan.useMedicine)
+            assertEquals(0, plan.medicineCount)
+            assertFalse(plan.useStone)
+            assertEquals(0, plan.stoneCount)
+        }
+    }
+
+    @Test
+    fun append_keepsExistingPlansAndAddsPresetEveryTime() {
+        val existing = DepotMaintainPlan(stage = "1-7", dropId = "30011", dropCount = 100)
+
+        val once = appendDepotMaintainPreset(listOf(existing), DepotMaintainPreset.LMD)
+        val twice = appendDepotMaintainPreset(once, DepotMaintainPreset.LMD)
+
+        assertEquals(existing, once.first())
+        assertNotSame(existing, once.last())
+        assertEquals(
+            listOf(
+                Triple("1-7", "30011", 100),
+                Triple("CE-6", "4001", 2_000_000),
+                Triple("CE-6", "4001", 2_000_000),
+            ),
+            twice.map { Triple(it.stage, it.dropId, it.dropCount) },
+        )
+    }
+
+    private fun assertPreset(
+        preset: DepotMaintainPreset,
+        expected: List<Triple<String, String, Int>>,
+    ) {
+        assertEquals(
+            expected,
+            preset.plans.map { Triple(it.stage, it.dropId, it.dropCount) },
+        )
+    }
+}


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)。

## 关联 Issue

同步 MAA WPF 库存保持 UI 的预设能力（MaaAssistantArknights/MaaAssistantArknights#17512）。

## 变更摘要

- 在库存保持配置面板中新增“预设”下拉菜单。
- 移植低级芯片、高级芯片组、龙门币、采购凭证、技巧概要·卷3 共 5 个上游预设。
- 选择预设时按上游行为追加计划，不覆盖或去重现有计划；新增计划默认不使用理智药和源石。
- 补充中英文文案及单元测试，不修改 MaaCore、任务参数协议和现有配置序列化结构。

## 验证

- [x] JDK 25 环境下执行 `./gradlew testDebugUnitTest assembleDebug` 成功。
- [x] 新增 5 项预设单元测试，覆盖计划数量、顺序、关卡、物品 ID、目标库存、消耗品默认值及重复追加行为。
- [x] Xiaomi 2410DPN6CC / Android 16（SDK 36）/ Shizuku 授权环境下完成真机验证。
- [x] 真机操作路径：任务列表 → 添加“库存保持” → 打开配置 → 点击“预设” → 选择预设。
- [x] 验证预设菜单可正常打开，选择后计划会立即追加，已有计划不会被覆盖，原有编辑、删除和折叠操作正常。

## 截图 / 日志 / 说明

<img width="400" alt="Screenshot_2026-08-06-17-17-48-019_com aliothmoon maameow debug-edit" src="https://github.com/user-attachments/assets/60cbfbeb-b57f-402c-8e06-fcd480818018" />

- 本次预设数据与 MAA WPF `DepotMaintainTaskUserControlModel.PresetData` 保持一致。
- 该功能完全由 UI 层实现，不涉及 MaaCore、资源文件、权限流程或后台服务改动。
- 不改变 `DepotMaintainConfig`、`DepotMaintainPlan` 的字段和 JSON 格式，已有配置无需迁移。

## Checklist

- [x] 我已阅读并遵守 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)

## Summary by Sourcery

在仓库维护配置界面中添加内置预设，并确保它们与上游数据保持一致，同时保留现有方案。

新功能：
- 在仓库维护配置面板中引入预设下拉菜单，可快速为常见仓库目标添加预定义方案。
- 提供五种内置的仓库维护预设，分别用于芯片、芯片组、LMD、采购证书和技能摘要。

测试：
- 添加单元测试，以验证预设内容、消耗品默认值，以及应用预设时会在不更改现有方案的前提下追加新方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add built-in presets to the depot maintain configuration UI and ensure they match upstream data while preserving existing plans.

New Features:
- Introduce a preset dropdown in the depot maintain configuration panel to quickly add predefined plans for common depot targets.
- Provide five built-in depot maintain presets for chips, chip packs, LMD, purchase certificates, and skill summaries.

Tests:
- Add unit tests validating preset contents, consumable defaults, and that applying presets appends plans without altering existing ones.

</details>