### PR TITLE
fix: 修复 asst.log 不可读导致日志导出失败

### DIFF
--- a/app/asset-manifest.gradle.kts
+++ b/app/asset-manifest.gradle.kts
@@ -35,7 +35,9 @@ abstract class GenerateAssetManifestTask : DefaultTask() {
     private fun listFilesRecursively(dir: File, basePath: String): List<String> {
         val result = mutableListOf<String>()
         dir.listFiles()?.forEach { file ->
-            val relativePath = if (basePath.isEmpty()) file.name else "$basePath/${file.name}"
+            val name = file.name
+            if (shouldSkip(name)) return@forEach
+            val relativePath = if (basePath.isEmpty()) name else "$basePath/$name"
             if (file.isDirectory) {
                 result.addAll(listFilesRecursively(file, relativePath))
             } else {
@@ -43,6 +45,12 @@ abstract class GenerateAssetManifestTask : DefaultTask() {
             }
         }
         return result
+    }
+
+    private fun shouldSkip(name: String): Boolean {
+        // 与 AAPT2 默认 ignoreAssetsPattern 对齐：跳过 macOS 元数据与隐藏文件，
+        // 避免清单列出但 APK 实际不含的文件导致设备端解压失败
+        return name == ".DS_Store" || name.startsWith("._") || name.startsWith(".")
     }
 }
 

--- a/app/src/main/java/com/aliothmoon/maameow/data/datasource/AssetExtractor.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/data/datasource/AssetExtractor.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.io.OutputStream
@@ -113,6 +114,9 @@ class AssetExtractor(private val context: Context) {
                                     }
                                     val count = extractedCount.incrementAndGet()
                                     onProgress(ExtractProgress(count, totalFiles, relativePath))
+                                } catch (e: FileNotFoundException) {
+                                    // 清单里有但 APK 中缺失（如被 AAPT2 过滤的 .DS_Store），跳过而非整体失败
+                                    Timber.w("跳过清单中存在但 APK 缺失的资源: $assetPath")
                                 } catch (e: Exception) {
                                     Timber.e(e, "文件复制最终失败: $assetPath")
                                     throw ExtractFailedException(assetPath, 3, e)

--- a/app/src/main/java/com/aliothmoon/maameow/domain/service/LogExportService.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/domain/service/LogExportService.kt
@@ -112,16 +112,38 @@ class LogExportService(
                 }
             }
 
+            val unreadableFiles = mutableListOf<Pair<String, String>>()
             for (file in logFiles) {
                 val relativePath = file.relativeTo(baseDir).path
                 val entry = ZipEntry(relativePath)
                 entry.time = file.lastModified()
                 zos.putNextEntry(entry)
 
-                FileInputStream(file).use { fis ->
-                    fis.copyTo(zos, bufferSize = 8192)
+                try {
+                    FileInputStream(file).use { fis ->
+                        fis.copyTo(zos, bufferSize = 8192)
+                    }
+                } catch (e: Exception) {
+                    // 提权进程写入的文件可能对 App 不可读（EACCES），跳过而不是让整个导出失败
+                    Timber.w(e, "Skipping unreadable log file during export: ${file.absolutePath}")
+                    unreadableFiles += relativePath to (e.message ?: e.javaClass.simpleName)
                 }
                 zos.closeEntry()
+            }
+
+            if (unreadableFiles.isNotEmpty()) {
+                zos.putNextEntry(ZipEntry("unreadable.txt"))
+                val content = buildString {
+                    appendLine("以下文件因权限问题未能导出（多为提权进程写入的日志）：")
+                    appendLine()
+                    unreadableFiles.forEach { (path, reason) ->
+                        appendLine(path)
+                        appendLine("  reason: $reason")
+                    }
+                }
+                zos.write(content.toByteArray(Charsets.UTF_8))
+                zos.closeEntry()
+                Timber.w("Exported ${unreadableFiles.size} unreadable log file(s), see unreadable.txt in the zip")
             }
         }
     }

--- a/app/src/main/java/com/aliothmoon/maameow/remote/DebugLogPermissionFixer.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/remote/DebugLogPermissionFixer.kt
@@ -1,0 +1,35 @@
+package com.aliothmoon.maameow.remote
+
+import com.aliothmoon.maameow.third.Ln
+import java.io.File
+
+/**
+ * 提权进程（Shizuku=shell / Root=uid0）与 App 进程 uid 不同。
+ * MaaCore 的 asst.log / logcat 等以提权身份落盘的 debug 日志可能因受限 umask（如 077）
+ * 变成对 App uid 不可读，导致 App 侧导出日志时 EACCES。
+ * 递归放开读权限，保证双进程都能读取这些日志。
+ */
+object DebugLogPermissionFixer {
+
+    private const val TAG = "DebugLogPermissionFixer"
+
+    /**
+     * 递归将 [dir] 下所有目录设为可读可执行、所有文件设为可读（ownerOnly=false，对全体放开）。
+     */
+    fun makeReadableForApp(dir: File) {
+        if (!dir.exists()) return
+        try {
+            var fixed = 0
+            dir.walkTopDown().forEach { f ->
+                f.setReadable(true, false)
+                if (f.isDirectory) {
+                    f.setExecutable(true, false)
+                }
+                fixed++
+            }
+            Ln.i("$TAG: fixed $fixed entries under ${dir.absolutePath}")
+        } catch (e: Exception) {
+            Ln.e("$TAG: makeReadableForApp error: ${e.message}")
+        }
+    }
+}

--- a/app/src/main/java/com/aliothmoon/maameow/remote/LogcatCaptureServiceImpl.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/remote/LogcatCaptureServiceImpl.kt
@@ -54,6 +54,8 @@ class LogcatCaptureServiceImpl : ILogcatService.Stub() {
             Ln.i("$TAG: Capturing app PID $appPid -> ${appLog.absolutePath}")
             watchTargets[appPid] = pipeLogcat(appPid, appLog)
         }
+        // 提权进程创建的目录/文件要对 App 进程可读，否则导出日志时 EACCES
+        DebugLogPermissionFixer.makeReadableForApp(debugDir)
     }
 
     private fun pipeLogcat(pid: Int, outFile: File): Process {
@@ -65,6 +67,7 @@ class LogcatCaptureServiceImpl : ILogcatService.Stub() {
             try {
                 process.inputStream.use { input ->
                     FileOutputStream(outFile, true).use { output ->
+                        outFile.setReadable(true, false)
                         input.copyTo(output)
                     }
                 }

--- a/app/src/main/java/com/aliothmoon/maameow/remote/MaaCoreManager.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/remote/MaaCoreManager.kt
@@ -25,6 +25,12 @@ object MaaCoreManager {
 
     val maaService: MaaCoreServiceImpl = MaaCoreServiceImpl(MaaContext)
 
+    /**
+     * setup() 记录的 userDir，用于 CreateInstance 后修复 debug 日志权限。
+     */
+    @Volatile
+    var userDir: String? = null
+
     fun destroy() {
         Ln.i("$TAG: destroy()")
         maaService.DestroyInstance()

--- a/app/src/main/java/com/aliothmoon/maameow/remote/MaaCoreServiceImpl.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/remote/MaaCoreServiceImpl.kt
@@ -11,6 +11,7 @@ import com.aliothmoon.maameow.maa.MaaCoreLibrary
 import com.aliothmoon.maameow.third.Ln
 import com.sun.jna.Memory
 import com.sun.jna.Pointer
+import java.io.File
 import java.io.FileDescriptor
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.system.exitProcess
@@ -84,6 +85,10 @@ class MaaCoreServiceImpl(private val ctx: MaaCoreLibrary?) : MaaCoreService.Stub
 
         val success = instance.get() != null
         Ln.i("$TAG: CreateInstance() = $success")
+        if (success) {
+            // 此时 MaaCore 已初始化日志（asst.log 已落盘），放开权限避免 App 导出时 EACCES
+            MaaCoreManager.userDir?.let { DebugLogPermissionFixer.makeReadableForApp(File(it, "debug")) }
+        }
         return success
     }
 

--- a/app/src/main/java/com/aliothmoon/maameow/remote/RemoteServiceImpl.kt
+++ b/app/src/main/java/com/aliothmoon/maameow/remote/RemoteServiceImpl.kt
@@ -115,6 +115,10 @@ class RemoteServiceImpl : RemoteService.Stub() {
                 }
                 Ln.i("MaaCore ${AsstGetVersion()}")
             }
+            MaaCoreManager.userDir = userDir
+            if (userDir != null) {
+                DebugLogPermissionFixer.makeReadableForApp(File(userDir, "debug"))
+            }
             PermissionGrantHelper.disablePhantomProcessKiller()
             setup = true
         }


### PR DESCRIPTION
1.修复asst.log不可读导致日志导出失败
2.追加对mac资源解压兼容

fix #205 

## 关联 Issue

- Related #205 （用户反馈：日志导出失败 `asst.log: EACCES (Permission denied)`）

## 变更摘要

- 修复双进程权限问题：`asst.log` 等由提权进程（Shizuku=shell / Root=uid0）落盘的 debug 日志可能对 App 进程不可读（EACCES），导致日志导出整体失败；新增 `DebugLogPermissionFixer`，提权进程在 `setup` 与 `CreateInstance` 后递归放开 `debug/` 读权限，logcat 捕获文件同步放开。
- 日志导出兜底：单个文件不可读时跳过并告警，不再让整个 zip 导出失败；被跳过的文件写入 zip 内 `unreadable.txt`（含失败原因），收到日志包可一眼定位缺失项。
- 资源解压兼容 macOS 元数据：`asset-manifest.gradle.kts` 生成清单时过滤 `.DS_Store` / `._*` / 隐藏文件（与 AAPT2 默认 `ignoreAssetsPattern` 对齐），避免「清单有、APK 无」；`AssetExtractor` 对清单中存在但 APK 缺失的文件跳过而非整体失败。

## 验证

-  本地执行 `./gradlew :app:compileDebugKotlin` 通过（BUILD SUCCESSFUL）
- 测试矩阵（设备 / 系统 / 权限方案）：
  - 模拟器 Pixel 6，Android 14，Root
  - 真机 Pixel 9，Android 16，Shizuku
  - 真机 一加 Ace 6，Android 16，Root
  - 真机 小米 13，Android 16，Shizuku
-  复现验证（按以下步骤逐项确认，覆盖 Root 与 Shizuku 各至少一台）：
  1. `adb shell su -c 'chmod 600 /storage/emulated/0/Android/data/com.aliothmoon.maameow/files/Maa/debug/asst.log'`（Root 设备；Shizuku 设备用对应 shell 权限 chmod）
  2. 不重启任务直接导出 → 应成功，zip 内含 `unreadable.txt` 且列出 `asst.log + EACCES`
  3. 保持 600 权限重启一次任务再导出 → `asst.log` 应正常入包（提权侧 chmod 生效），`ls -l` 显示 `-rw-r--r--`
  4. 权限损坏后重装/解压资源 → 初始化不应再因 `.DS_Store` 失败

## 截图 / 日志 / 说明

- 修复前 App 侧报错堆栈：`LogExportService$exportZip ... FileNotFoundException: .../Maa/debug/asst.log: open failed: EACCES`
- 资源解压失败弹窗文案：`资源初始化失败: 文件 MaaSync/MaaResource/.DS_Store 在 3 次尝试后仍失败`
- 涉及双进程（提权 + App）与 Shizuku/Root 两种后端，需分别在两种方案下验证导出与资源初始化。

## Checklist

- [☑️] 我已阅读并遵守 [PR 规范](../docs/PULL_REQUEST_GUIDELINES.md) / [PR Guidelines](../docs/PULL_REQUEST_GUIDELINES_EN.md)

## Summary by Sourcery

处理导出的调试日志的权限问题，并提升跨平台资源（asset）解压的健壮性。

Bug 修复：
- 当单个调试日志文件（例如 `asst.log`）因权限问题不可读时，防止整个日志导出过程失败。
- 确保由 MaaCore 和 logcat 生成的调试日志在双进程（Shizuku/Root）环境中调整好权限，使应用进程可以读取它们。
- 避免由于 macOS 元数据或隐藏文件在清单中列出但在 APK 中不存在而导致的资源解压失败。

增强：
- 将不可读的日志文件记录到导出 zip 中的 `unreadable.txt` 条目中，并附上原因以便排查问题。
- 在生成资源清单时跳过 macOS 元数据和隐藏文件，使其与 AAPT2 的忽略模式保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle permission issues for exported debug logs and improve robustness of asset extraction across platforms.

Bug Fixes:
- Prevent log export from failing entirely when individual debug log files (e.g., asst.log) are unreadable due to permission issues.
- Ensure MaaCore- and logcat-generated debug logs have permissions adjusted so the app process can read them in dual-process (Shizuku/Root) setups.
- Avoid asset extraction failures caused by macOS metadata or hidden files listed in the manifest but absent from the APK.

Enhancements:
- Record unreadable log files into an unreadable.txt entry inside the exported zip with reasons for troubleshooting.
- Align asset manifest generation with AAPT2 ignore patterns by skipping macOS metadata and hidden files during manifest creation.

</details>